### PR TITLE
[rabbitmq] Fix ingress port and added test

### DIFF
--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: management
+                  number: {{ $svcPort }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/rabbitmq/tests/rabbitmq-functionality_test.yaml
+++ b/charts/rabbitmq/tests/rabbitmq-functionality_test.yaml
@@ -167,8 +167,10 @@ tests:
           path: spec.volumeClaimTemplates[0].spec.storageClassName
           value: "fast-ssd"
 
-  - it: should create ingress when enabled
+  - it: should create and configure ingress correctly when enabled
     set:
+      service:
+        managementPort: 15672
       ingress:
         enabled: true
         hosts:
@@ -183,6 +185,9 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: rabbitmq.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 15672
 
   - it: should configure security contexts correctly
     set:


### PR DESCRIPTION

Previously, the RabbitMQ chart's Ingress template referenced the service backend port by **name** (`management`), while the Service declared the port with the name `mgmt`. 

This PR updates `charts/rabbitmq/templates/ingress.yaml` to reference the management port **by number** (using `.Values.service.managementPort`) instead of a hard-coded port name. It also updates a unit test to ensure the Ingress uses the right port **number**.

### Changes
- `charts/rabbitmq/templates/ingress.yaml`
  - Use `backend.service.port.number: {{ $svcPort }}` instead of `backend.service.port.name`.
- `charts/rabbitmq/tests/rabbitmq-functionality_test.yaml`
  - Updated helm-unittest that asserts `spec.rules[0].http.paths[0].backend.service.port.number` equals the configured `service.managementPort`.

Reesolves https://github.com/CloudPirates-io/helm-charts/issues/4