### PR TITLE
[minio] Improve overall configuration

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "2024.8.17"
 keywords:
   - minio

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -96,8 +96,8 @@ Return MinIO server URL args
 */}}
 {{- define "minio.serverUrl" -}}
 {{- if .Values.config.serverUrl -}}
-{{- printf "--console-address :%d --address :%d" (int .Values.service.consoleTargetPort) (int .Values.service.targetPort) -}}
+{{- printf "--console-address :%d --address :%d" (int .Values.service.consolePort) (int .Values.service.port) -}}
 {{- else -}}
-{{- printf "--console-address :%d --address :%d" (int .Values.service.consoleTargetPort) (int .Values.service.targetPort) -}}
+{{- printf "--console-address :%d --address :%d" (int .Values.service.consolePort) (int .Values.service.port) -}}
 {{- end -}}
 {{- end }}

--- a/charts/minio/templates/configmap.yaml
+++ b/charts/minio/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -76,10 +76,10 @@ spec:
             {{- end }}
           ports:
             - name: minio
-              containerPort: {{ .Values.service.targetPort }}
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
             - name: console
-              containerPort: {{ .Values.service.consoleTargetPort }}
+              containerPort: {{ .Values.service.consolePort }}
               protocol: TCP
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
@@ -117,8 +117,10 @@ spec:
             successThreshold: {{ .Values.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}

--- a/charts/minio/templates/ingress-console.yaml
+++ b/charts/minio/templates/ingress-console.yaml
@@ -1,24 +1,25 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.consoleIngress.enabled -}}
 {{- $fullName := include "minio.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-console
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
-  {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
+    app.kubernetes.io/component: console
+  {{- $annotations := merge .Values.consoleIngress.annotations .Values.commonAnnotations }}
   {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.consoleIngress.className }}
+  ingressClassName: {{ .Values.consoleIngress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.consoleIngress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    {{- range .Values.consoleIngress.tls }}
     - hosts:
         {{- range .hosts }}
         - {{ . }}
@@ -27,7 +28,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
+    {{- range .Values.consoleIngress.hosts }}
     - host: {{ .host }}
       http:
         paths:
@@ -40,7 +41,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: minio
+                  name: console
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/minio/templates/pvc.yaml
+++ b/charts/minio/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}

--- a/charts/minio/templates/secret.yaml
+++ b/charts/minio/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
@@ -14,30 +14,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: minio
-  selector:
-    {{- include "minio.selectorLabels" . | nindent 4 }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "minio.fullname" . }}-console
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-    {{- include "minio.labels" . | nindent 4 }}
-    app.kubernetes.io/component: console
-  {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
-  {{- with $annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  type: {{ .Values.service.type }}
-  ports:
     - port: {{ .Values.service.consolePort }}
-      targetPort: {{ .Values.service.consoleTargetPort }}
       protocol: TCP
       name: console
   selector:

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -268,24 +268,10 @@
           "minimum": 1,
           "maximum": 65535
         },
-        "targetPort": {
-          "type": "integer",
-          "title": "Target Port",
-          "description": "MinIO container port",
-          "minimum": 1,
-          "maximum": 65535
-        },
         "consolePort": {
           "type": "integer",
           "title": "Console Service Port",
           "description": "MinIO console service port",
-          "minimum": 1,
-          "maximum": 65535
-        },
-        "consoleTargetPort": {
-          "type": "integer",
-          "title": "Console Target Port",
-          "description": "MinIO console container port",
           "minimum": 1,
           "maximum": 65535
         },

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -86,12 +86,8 @@ service:
   type: ClusterIP
   ## @param service.port MinIO service port
   port: 9000
-  ## @param service.targetPort MinIO container port
-  targetPort: 9000
   ## @param service.consolePort MinIO console service port
   consolePort: 9090
-  ## @param service.consoleTargetPort MinIO console container port
-  consoleTargetPort: 9090
   ## @param service.annotations Service annotations
   annotations: {}
 
@@ -127,6 +123,7 @@ consoleIngress:
   className: ""
   ## @param consoleIngress.annotations Additional annotations for the Console Ingress resource
   annotations: {}
+    # nginx.ingress.kubernetes.io/proxy-body-size: 1000m
   ## @param consoleIngress.hosts[0].host Hostname for MinIO Console ingress
   ## @param consoleIngress.hosts[0].paths[0].path Path for MinIO Console ingress
   ## @param consoleIngress.hosts[0].paths[0].pathType Path type for MinIO Console ingress
@@ -200,7 +197,7 @@ readinessProbe:
 
 startupProbe:
   ## @param startupProbe.enabled Enable startupProbe on MinIO containers
-  enabled: true
+  enabled: false
   ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
   initialDelaySeconds: 10
   ## @param startupProbe.periodSeconds Period seconds for startupProbe


### PR DESCRIPTION
### Description of the change

Streamline the ingress configuration and remove deprecated Kubernetes 1.19 settings. Additionally this pull request has some minor changes to the general chart layout and fixes some port mappings.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
