### PR TITLE
[postgres] added support for service account configuration

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "17.6"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -208,6 +208,15 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `tolerations`  | Toleration labels for pod assignment | `[]`    |
 | `affinity`     | Affinity settings for pod assignment | `{}`    |
 
+### Service Account
+
+| Parameter                                     | Description                                                                                                               | Default |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a service account should be created                                                                     | `false` |
+| `serviceAccount.annotations`                  | Annotations to add to the service account                                                                                 | `{}`    |
+| `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Whether to automount the SA token inside the pod                                                                          | `false` |
+
 ## Examples
 
 ### Basic Deployment

--- a/charts/postgres/templates/_helpers.tpl
+++ b/charts/postgres/templates/_helpers.tpl
@@ -155,3 +155,14 @@ Return the proper Docker Image Registry Secret Names
 {{- define "postgres.imagePullSecrets" -}}
 {{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" .) }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "postgres.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "postgres.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/postgres/templates/serviceaccount.yaml
+++ b/charts/postgres/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "postgres.serviceAccountName" . }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -29,6 +29,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "postgres.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- with (include "postgres.imagePullSecrets" .) }}
 {{ . | nindent 6 }}
 {{- end }}

--- a/charts/postgres/tests/service-account_test.yaml
+++ b/charts/postgres/tests/service-account_test.yaml
@@ -1,0 +1,41 @@
+suite: test postgres service account parameters
+templates:
+  - serviceaccount.yaml
+set:
+  serviceAccount:
+    create: true
+tests:
+  - it: should use default labels for the manifest
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-postgres
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: postgres
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should respect serviceAccount.name override
+    set:
+      serviceAccount:
+        name: "my-service-account"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-service-account
+
+  - it: should respect serviceAccount.annotations override
+    set:
+      serviceAccount:
+        annotations:
+          key1: "value1"
+          key2: "value2"
+    asserts:
+      - equal:
+          path: metadata.annotations.key1
+          value: value1
+      - equal:
+          path: metadata.annotations.key2
+          value: value2

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -647,6 +647,33 @@
       "type": "object",
       "title": "Affinity Configuration",
       "description": "Affinity settings for pod assignment"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "title": "Service Account Configuration",
+      "description": "Service account configuration",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "title": "Create Service Account",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "title": "Service Account Annotations",
+          "description": "Annotations to add to the service account"
+        },
+        "name": {
+          "type": "string",
+          "title": "Service Account Name",
+          "description": "The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template."
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "title": "Automount Service Account Token",
+          "description": "Whether to automount the service account token inside the pod"
+        }
+      }
     }
   }
 }

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -224,3 +224,15 @@ tolerations: []
 
 ## @param affinity Affinity settings for pod assignment
 affinity: {}
+
+
+## @section Service Account
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  create: false
+  ## @param serviceAccount.annotations Annotations to add to the service account
+  annotations: {}
+  ## @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template.
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken whether to automount the SA token inside the pod
+  automountServiceAccountToken: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Allow configuring a custom service account for the postgres pod.

### Benefits

<!-- What benefits will be realized by the code change? -->

integration with service meshes & ability to not mount the SA entirely.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None, should be backwards-compatible

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
