### PR TITLE
Fix GitHub Actions: Checkout external merge request repositories

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -21,8 +21,9 @@ jobs:
       - name: Checkout pull request branch
         uses: actions/checkout@v5.0.0
         with:
-          fetch-depth: 0
           ref: ${{ github.head_ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
@@ -68,8 +69,9 @@ jobs:
       - name: Checkout pull request branch
         uses: actions/checkout@v5.0.0
         with:
-          fetch-depth: 0
           ref: ${{ github.head_ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
### Description of the change
External Merge requests belongs to a different repository, so the checkout actions needs to checkout the remote Repo.