### PR TITLE
[valkey] Add support for serviceAccount

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.1.7
+version: 0.2.0
 appVersion: "8.1.3"
 home: https://www.cloudpirates.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -141,6 +141,15 @@ The following table lists the configurable parameters of the Valkey chart and th
 | `service.targetPort`  | Valkey container port | `6379`      |
 | `service.annotations` | Service annotations   | `{}`        |
 
+### ServiceAccount configuration
+
+| Parameter                       | Description                                      | Default |
+| ------------------------------- | ------------------------------------------------ | ------- |
+| `serviceAccount.create`         | Enable creation of a Service Account             | `true`  |
+| `serviceAccount.name`           | Name of the Service Account                      | `""`    |
+| `serviceAccount.annotations`    | Annotations to add to the Service Account        | `{}`    |
+| `serviceAccount.automountToken` | Enable automounting of the Service Account token | `false` |
+
 ### Ingress configuration
 
 | Parameter                            | Description                                             | Default        |

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -85,6 +85,17 @@ Return Valkey configuration ConfigMap name
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "valkey.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "valkey.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Return Valkey data directory
 */}}
 {{- define "valkey.dataDir" -}}

--- a/charts/valkey/templates/serviceaccount.yaml
+++ b/charts/valkey/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "valkey.serviceAccountName" . }}
+  labels:
+      {{- include "valkey.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountToken | default false }}
+{{- end }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -33,6 +33,7 @@ spec:
 {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "valkey.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -627,6 +627,36 @@
         }
       }
     },
+    "serviceAccount": {
+      "type": "object",
+      "title": "Service Account Configuration",
+      "description": "ServiceAccount configuration for Valkey",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "title": "Create ServiceAccount",
+          "description": "Enable creation of a Service Account"
+        },
+        "name": {
+          "type": "string",
+          "title": "ServiceAccount Name",
+          "description": "Name of the Service Account"
+        },
+        "annotations": {
+          "type": "object",
+          "title": "ServiceAccount Annotations",
+          "description": "Annotations to add to the Service Account",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "automountToken": {
+          "type": "boolean",
+          "title": "Automount ServiceAccount Token",
+          "description": "Enable automounting of the Service Account token"
+        }
+      }
+    },
     "affinity": {
       "type": "object",
       "title": "Affinity Configuration",

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -92,6 +92,17 @@ service:
   ## @param service.annotations Service annotations
   annotations: {}
 
+## @section Service Account configuration
+## @param serviceAccount.create Enable creation of a Service Account
+serviceAccount:
+  create: true
+  ## @param serviceAccount.name Name of the Service Account
+  name: ""
+  ## @param serviceAccount.annotations Annotations to add to the Service Account
+  annotations: {}
+  ## @param serviceAccount.automountToken Enable automounting of the Service Account token
+  automountToken: false
+
 ## @section Ingress configuration
 ingress:
   ## @param ingress.enabled Enable ingress record generation for Valkey


### PR DESCRIPTION
### Description of the change

Adds serviceAccount creation by default with option to disable. 
This is standard with `helm create` as well.

### Benefits

Allow configuring serviceAccount instead of using default sa. 
Also lets users set automountServiceAccountToken (false, by default)

### Possible drawbacks

serviceAccount generation is enabled by default, which would lead to restart for existing deployments. 
We could instead disable by default, but that would lead to worse security on new default installs, as using the default sa with token mounted is discouraged.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #29

### Additional information

i'd be happy to do the other charts as well, i just figured i'd start with one and clear up any issues/questions first.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
