### PR TITLE
[all] add extraObjects to allow deploying additional manifests

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL
 type: application
-version: 0.1.6
+version: 0.2.0
 appVersion: "12.0.2"
 keywords:
   - mariadb

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -174,6 +174,43 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | `extraSecrets` | A list of additional existing secrets that will be mounted into the container    | `[]`    |
 | `extraConfigs` | A list of additional existing configMaps that will be mounted into the container | `[]`    |
 | `extraVolumes` | A list of additional existing volumes that will be mounted into the container    | `[]`    |
+| `extraObjects` | A list of additional Kubernetes objects to deploy alongside the release          | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
 
 ### Health Check Parameters
 

--- a/charts/mariadb/templates/extraobjects.yaml
+++ b/charts/mariadb/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -717,6 +717,15 @@
       "type": "object",
       "title": "Affinity Configuration",
       "description": "Affinity settings for pod assignment"
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -223,3 +223,6 @@ podLabels: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -3,7 +3,7 @@ name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
 
-version: 0.0.2
+version: 0.1.0
 appVersion: "1.6.32"
 
 keywords:

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -166,6 +166,43 @@ The following table lists the configurable parameters of the Memcached chart and
 | `extraEnv`          | A list of additional environment variables                                          | `[]`    |
 | `extraVolumes`      | A list of additional existing volumes that will be mounted into the container       | `[]`    |
 | `extraVolumeMounts` | A list of additional existing volume mounts that will be mounted into the container | `[]`    |
+| `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release             | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
 
 ### Pod Configuration Parameters
 

--- a/charts/memcached/templates/extraobjects.yaml
+++ b/charts/memcached/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -134,6 +134,15 @@
       "type": "object",
       "title": "Resource configuration",
       "description": "Pod resource configuration"
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -82,7 +82,8 @@ config:
   verbosity: 0
 
 ## @param resources Resource limits and requests for Memcached pod
-resources: {}
+resources:
+  {}
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -153,3 +154,6 @@ extraVolumes: []
 
 ## @param extraVolumeMounts Additional volume mounts to add to the Memcached container
 extraVolumeMounts: []
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.1.8
+version: 0.2.0
 appVersion: "2024.8.17"
 keywords:
   - minio

--- a/charts/minio/README.md
+++ b/charts/minio/README.md
@@ -133,12 +133,12 @@ The following table lists the configurable parameters of the MinIO chart and the
 
 ### Service configuration
 
-| Parameter                   | Description                  | Default     |
-| --------------------------- | ---------------------------- | ----------- |
-| `service.type`              | MinIO service type           | `ClusterIP` |
-| `service.port`              | MinIO service port           | `9000`      |
-| `service.consolePort`       | MinIO console service port   | `9090`      |
-| `service.annotations`       | Service annotations          | `{}`        |
+| Parameter             | Description                | Default     |
+| --------------------- | -------------------------- | ----------- |
+| `service.type`        | MinIO service type         | `ClusterIP` |
+| `service.port`        | MinIO service port         | `9000`      |
+| `service.consolePort` | MinIO console service port | `9090`      |
+| `service.annotations` | Service annotations        | `{}`        |
 
 ### Ingress configuration
 
@@ -211,6 +211,48 @@ The following table lists the configurable parameters of the MinIO chart and the
 | `nodeSelector` | Node labels for pod assignment       | `{}`    |
 | `tolerations`  | Toleration labels for pod assignment | `[]`    |
 | `affinity`     | Affinity settings for pod assignment | `{}`    |
+
+### Extra Configuration Parameters
+
+| Parameter           | Description                                                                         | Default |
+| ------------------- | ----------------------------------------------------------------------------------- | ------- |
+| `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release             | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
 
 ## Examples
 

--- a/charts/minio/templates/extraobjects.yaml
+++ b/charts/minio/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -661,6 +661,15 @@
       "type": "object",
       "title": "Affinity Configuration",
       "description": "Affinity settings for pod assignment"
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -98,7 +98,8 @@ ingress:
   ## @param ingress.className IngressClass that will be used to implement the Ingress
   className: ""
   ## @param ingress.annotations Additional annotations for the Ingress resource
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   ## @param ingress.hosts[0].host Hostname for MinIO ingress
@@ -122,7 +123,8 @@ consoleIngress:
   ## @param consoleIngress.className IngressClass that will be used to implement the Ingress
   className: ""
   ## @param consoleIngress.annotations Additional annotations for the Console Ingress resource
-  annotations: {}
+  annotations:
+    {}
     # nginx.ingress.kubernetes.io/proxy-body-size: 1000m
   ## @param consoleIngress.hosts[0].host Hostname for MinIO Console ingress
   ## @param consoleIngress.hosts[0].paths[0].path Path for MinIO Console ingress
@@ -136,7 +138,8 @@ consoleIngress:
   tls: []
 
 ## @section Resources
-resources: {}
+resources:
+  {}
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -215,3 +218,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -154,6 +154,43 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `extraEnv`          | Additional environment variables to set                  | `[]`    |
 | `extraVolumes`      | Additional volumes to add to the pod                     | `[]`    |
 | `extraVolumeMounts` | Additional volume mounts to add to the MongoDB container | `[]`    |
+| `extraObjects`      | Additional Kubernetes objects to deploy                  | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
 
 ## Example Values
 

--- a/charts/mongodb/templates/extraobjects.yaml
+++ b/charts/mongodb/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -412,6 +412,15 @@
       "items": {
         "type": "object"
       }
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -63,7 +63,6 @@ config:
   ## param config.existingConfigmapKey Name of the key in the Configmap that should be used
   existingConfigmapKey: ""
 
-
 persistence:
   ## @param persistence.enabled Enable persistent storage
   enabled: true
@@ -146,3 +145,6 @@ extraVolumes: []
 
 ## @param extraVolumeMounts Additional volume mounts to add to the MongoDB container
 extraVolumeMounts: []
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -217,6 +217,48 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. | `""`    |
 | `serviceAccount.automountServiceAccountToken` | Whether to automount the SA token inside the pod                                                                          | `false` |
 
+### Extra Configuration Parameters
+
+| Parameter      | Description                                                             | Default |
+| -------------- | ----------------------------------------------------------------------- | ------- |
+| `extraObjects` | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
 ## Examples
 
 ### Basic Deployment

--- a/charts/postgres/templates/extraobjects.yaml
+++ b/charts/postgres/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -674,6 +674,15 @@
           "description": "Whether to automount the service account token inside the pod"
         }
       }
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -126,7 +126,8 @@ ingress:
   ## @param ingress.className IngressClass that will be used to implement the Ingress
   className: ""
   ## @param ingress.annotations Additional annotations for the Ingress resource
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   ## @param ingress.hosts[0].host Hostname for PostgreSQL ingress
@@ -144,7 +145,8 @@ ingress:
   #      - postgres.local
 
 ## @section Resources
-resources: {}
+resources:
+  {}
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -225,7 +227,6 @@ tolerations: []
 ## @param affinity Affinity settings for pod assignment
 affinity: {}
 
-
 ## @section Service Account
 serviceAccount:
   ## @param serviceAccount.create Specifies whether a service account should be created
@@ -236,3 +237,6 @@ serviceAccount:
   name: ""
   ## @param serviceAccount.automountServiceAccountToken whether to automount the SA token inside the pod
   automountServiceAccountToken: false
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.0.3
+version: 0.1.0
 appVersion: "4.1.3"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -62,165 +62,203 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 
 ### Global parameters
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `global.imageRegistry` | Global Docker image registry | `""` |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]` |
+| Parameter                 | Description                                     | Default |
+| ------------------------- | ----------------------------------------------- | ------- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`    |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`    |
 
 ### Common parameters
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `nameOverride` | String to partially override rabbitmq.fullname | `""` |
-| `fullnameOverride` | String to fully override rabbitmq.fullname | `""` |
-| `commonLabels` | Labels to add to all deployed objects | `{}` |
-| `commonAnnotations` | Annotations to add to all deployed objects | `{}` |
+| Parameter           | Description                                    | Default |
+| ------------------- | ---------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override rabbitmq.fullname | `""`    |
+| `fullnameOverride`  | String to fully override rabbitmq.fullname     | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects          | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects     | `{}`    |
 
 ### RabbitMQ image parameters
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `image.registry` | RabbitMQ image registry | `docker.io` |
-| `image.repository` | RabbitMQ image repository | `rabbitmq` |
-| `image.tag` | RabbitMQ image tag | `"4.1.3-managemen@sha256:4c521003d812dd7b33793e2b7e45fbcc323d764b8c3309dfcb0e4c5db30c56ab"` |
-| `image.imagePullPolicy` | RabbitMQ image pull policy | `Always` |
+| Parameter               | Description                | Default                                                                                     |
+| ----------------------- | -------------------------- | ------------------------------------------------------------------------------------------- |
+| `image.registry`        | RabbitMQ image registry    | `docker.io`                                                                                 |
+| `image.repository`      | RabbitMQ image repository  | `rabbitmq`                                                                                  |
+| `image.tag`             | RabbitMQ image tag         | `"4.1.3-managemen@sha256:4c521003d812dd7b33793e2b7e45fbcc323d764b8c3309dfcb0e4c5db30c56ab"` |
+| `image.imagePullPolicy` | RabbitMQ image pull policy | `Always`                                                                                    |
 
 ### Deployment configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `replicaCount` | Number of RabbitMQ replicas to deploy (clustering needs to be enabled to set more than 1 replicas) | `1` |
+| Parameter      | Description                                                                                        | Default |
+| -------------- | -------------------------------------------------------------------------------------------------- | ------- |
+| `replicaCount` | Number of RabbitMQ replicas to deploy (clustering needs to be enabled to set more than 1 replicas) | `1`     |
 
 ### Service configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `service.type` | Kubernetes service type | `ClusterIP` |
-| `service.amqpPort` | RabbitMQ AMQP service port | `5672` |
-| `service.managementPort` | RabbitMQ management UI port | `15672` |
-| `service.epmdPort` | RabbitMQ EPMD port | `4369` |
-| `service.distPort` | RabbitMQ distribution port | `25672` |
+| Parameter                | Description                 | Default     |
+| ------------------------ | --------------------------- | ----------- |
+| `service.type`           | Kubernetes service type     | `ClusterIP` |
+| `service.amqpPort`       | RabbitMQ AMQP service port  | `5672`      |
+| `service.managementPort` | RabbitMQ management UI port | `15672`     |
+| `service.epmdPort`       | RabbitMQ EPMD port          | `4369`      |
+| `service.distPort`       | RabbitMQ distribution port  | `25672`     |
 
 ### RabbitMQ Authentication
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `auth.enabled` | Enable RabbitMQ authentication | `true` |
-| `auth.username` | RabbitMQ default username | `admin` |
-| `auth.password` | RabbitMQ password (if empty, random password will be generated) | `""` |
-| `auth.erlangCookie` | Erlang cookie for clustering (if empty, random cookie will be generated) | `""` |
-| `auth.existingSecret` | Name of existing secret containing RabbitMQ credentials | `""` |
-| `auth.existingPasswordKey` | Key in existing secret containing RabbitMQ password | `"password"` |
-| `auth.existingErlangCookieKey` | Key in existing secret containing Erlang cookie | `"erlang-cookie"` |
+| Parameter                      | Description                                                              | Default           |
+| ------------------------------ | ------------------------------------------------------------------------ | ----------------- |
+| `auth.enabled`                 | Enable RabbitMQ authentication                                           | `true`            |
+| `auth.username`                | RabbitMQ default username                                                | `admin`           |
+| `auth.password`                | RabbitMQ password (if empty, random password will be generated)          | `""`              |
+| `auth.erlangCookie`            | Erlang cookie for clustering (if empty, random cookie will be generated) | `""`              |
+| `auth.existingSecret`          | Name of existing secret containing RabbitMQ credentials                  | `""`              |
+| `auth.existingPasswordKey`     | Key in existing secret containing RabbitMQ password                      | `"password"`      |
+| `auth.existingErlangCookieKey` | Key in existing secret containing Erlang cookie                          | `"erlang-cookie"` |
 
 ### RabbitMQ configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `config.memoryHighWatermark.enabled` | Enable configuring Memory high watermark on RabbitMQ | `false` |
-| `config.memoryHighWatermark.type` | Memory high watermark type. Either `absolute` or `relative` | `"relative"` |
-| `config.memoryHighWatermark.value` | Memory high watermark value | `0.4` |
-| `config.extraConfiguration` | Additional RabbitMQ configuration | `""` |
-| `config.advancedConfiguration` | Advanced RabbitMQ configuration | `""` |
+| Parameter                            | Description                                                 | Default      |
+| ------------------------------------ | ----------------------------------------------------------- | ------------ |
+| `config.memoryHighWatermark.enabled` | Enable configuring Memory high watermark on RabbitMQ        | `false`      |
+| `config.memoryHighWatermark.type`    | Memory high watermark type. Either `absolute` or `relative` | `"relative"` |
+| `config.memoryHighWatermark.value`   | Memory high watermark value                                 | `0.4`        |
+| `config.extraConfiguration`          | Additional RabbitMQ configuration                           | `""`         |
+| `config.advancedConfiguration`       | Advanced RabbitMQ configuration                             | `""`         |
 
 ### PeerDiscoveryK8sPlugin configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `peerDiscoveryK8sPlugin.enabled` | Enable K8s peer discovery plugin for a RabbitMQ HA-cluster | `false` |
-| `peerDiscoveryK8sPlugin.useLongname` | Uses the FQDN as connection string (RABBITMQ_USE_LONGNAME) | `true` |
-| `peerDiscoveryK8sPlugin.addressType` | Peer discovery plugin address type | `hostname` |
+| Parameter                            | Description                                                | Default    |
+| ------------------------------------ | ---------------------------------------------------------- | ---------- |
+| `peerDiscoveryK8sPlugin.enabled`     | Enable K8s peer discovery plugin for a RabbitMQ HA-cluster | `false`    |
+| `peerDiscoveryK8sPlugin.useLongname` | Uses the FQDN as connection string (RABBITMQ_USE_LONGNAME) | `true`     |
+| `peerDiscoveryK8sPlugin.addressType` | Peer discovery plugin address type                         | `hostname` |
 
 ### ManagementPlugin configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `managementPlugin.enabled` | Enable RabbitMQ management plugin | `true` |
+| Parameter                  | Description                       | Default |
+| -------------------------- | --------------------------------- | ------- |
+| `managementPlugin.enabled` | Enable RabbitMQ management plugin | `true`  |
 
 ### Metrics configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `metrics.enabled` | Enable RabbitMQ metrics (via prometheus plugin) | `false` |
-| `metrics.port` | RabbitMQ metrics port | `15692` |
-| `metrics.serviceMonitor.enabled` | Create ServiceMonitor for Prometheus monitoring | `false` |
-| `metrics.serviceMonitor.namespace` | Namespace for ServiceMonitor | `""` |
-| `metrics.serviceMonitor.labels` | Labels for ServiceMonitor | `{}` |
-| `metrics.serviceMonitor.annotations` | Annotations for ServiceMonitor | `{}` |
-| `metrics.serviceMonitor.interval` | Scrape interval | `30s` |
-| `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout | `10s` |
-| `additionalPlugins` | Additional RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added) | `[]` |
+| Parameter                              | Description                                                                                                                 | Default |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `metrics.enabled`                      | Enable RabbitMQ metrics (via prometheus plugin)                                                                             | `false` |
+| `metrics.port`                         | RabbitMQ metrics port                                                                                                       | `15692` |
+| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor for Prometheus monitoring                                                                             | `false` |
+| `metrics.serviceMonitor.namespace`     | Namespace for ServiceMonitor                                                                                                | `""`    |
+| `metrics.serviceMonitor.labels`        | Labels for ServiceMonitor                                                                                                   | `{}`    |
+| `metrics.serviceMonitor.annotations`   | Annotations for ServiceMonitor                                                                                              | `{}`    |
+| `metrics.serviceMonitor.interval`      | Scrape interval                                                                                                             | `30s`   |
+| `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout                                                                                                              | `10s`   |
+| `additionalPlugins`                    | Additional RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added) | `[]`    |
 
 ### Persistence
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `persistence.enabled` | Enable persistent storage | `true` |
-| `persistence.storageClass` | Storage class to use for persistent volume | `""` |
-| `persistence.accessModes` | Persistent Volume access modes | `["ReadWriteOnce"]` |
-| `persistence.size` | Size of persistent volume | `8Gi` |
-| `persistence.annotations` | Annotations for persistent volume claims | `{}` |
+| Parameter                  | Description                                | Default             |
+| -------------------------- | ------------------------------------------ | ------------------- |
+| `persistence.enabled`      | Enable persistent storage                  | `true`              |
+| `persistence.storageClass` | Storage class to use for persistent volume | `""`                |
+| `persistence.accessModes`  | Persistent Volume access modes             | `["ReadWriteOnce"]` |
+| `persistence.size`         | Size of persistent volume                  | `8Gi`               |
+| `persistence.annotations`  | Annotations for persistent volume claims   | `{}`                |
 
 ### Ingress configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `ingress.enabled` | Enable ingress for RabbitMQ management | `false` |
-| `ingress.className` | Ingress class name | `""` |
-| `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.hosts` | Ingress hosts configuration | `[{"host": "rabbitmq.local", "paths": [{"path": "/", "pathType": "Prefix"}]}]` |
-| `ingress.tls` | Ingress TLS configuration | `[]` |
+| Parameter             | Description                            | Default                                                                        |
+| --------------------- | -------------------------------------- | ------------------------------------------------------------------------------ |
+| `ingress.enabled`     | Enable ingress for RabbitMQ management | `false`                                                                        |
+| `ingress.className`   | Ingress class name                     | `""`                                                                           |
+| `ingress.annotations` | Ingress annotations                    | `{}`                                                                           |
+| `ingress.hosts`       | Ingress hosts configuration            | `[{"host": "rabbitmq.local", "paths": [{"path": "/", "pathType": "Prefix"}]}]` |
+| `ingress.tls`         | Ingress TLS configuration              | `[]`                                                                           |
 
 ### Resources
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `resources` | Resource limits and requests for RabbitMQ pods | `{}` |
+| Parameter   | Description                                    | Default |
+| ----------- | ---------------------------------------------- | ------- |
+| `resources` | Resource limits and requests for RabbitMQ pods | `{}`    |
 
 ### Node Selection
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `nodeSelector` | Node labels for pod assignment | `{}` |
-| `tolerations` | Toleration labels for pod assignment | `[]` |
-| `affinity` | Affinity settings for pod assignment | `{}` |
+| Parameter      | Description                          | Default |
+| -------------- | ------------------------------------ | ------- |
+| `nodeSelector` | Node labels for pod assignment       | `{}`    |
+| `tolerations`  | Toleration labels for pod assignment | `[]`    |
+| `affinity`     | Affinity settings for pod assignment | `{}`    |
 
 ### Security Context
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `podSecurityContext.fsGroup` | Group ID for the volumes of the pod | `999` |
-| `securityContext.allowPrivilegeEscalation` | Enable container privilege escalation | `false` |
-| `securityContext.runAsNonRoot` | Configure the container to run as a non-root user | `true` |
-| `securityContext.runAsUser` | User ID for the RabbitMQ container | `999` |
-| `securityContext.runAsGroup` | Group ID for the RabbitMQ container | `999` |
-| `securityContext.readOnlyRootFilesystem` | Mount container root filesystem as read-only | `true` |
-| `securityContext.capabilities.drop` | Linux capabilities to be dropped | `["ALL"]` |
+| Parameter                                  | Description                                       | Default   |
+| ------------------------------------------ | ------------------------------------------------- | --------- |
+| `podSecurityContext.fsGroup`               | Group ID for the volumes of the pod               | `999`     |
+| `securityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
+| `securityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
+| `securityContext.runAsUser`                | User ID for the RabbitMQ container                | `999`     |
+| `securityContext.runAsGroup`               | Group ID for the RabbitMQ container               | `999`     |
+| `securityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `true`    |
+| `securityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
 
 ### Liveness and readiness probes
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `livenessProbe.enabled` | Enable livenessProbe on RabbitMQ containers | `true` |
-| `livenessProbe.initialDelaySeconds` | Initial delay seconds for livenessProbe | `120` |
-| `livenessProbe.periodSeconds` | Period seconds for livenessProbe | `30` |
-| `livenessProbe.timeoutSeconds` | Timeout seconds for livenessProbe | `20` |
-| `livenessProbe.failureThreshold` | Failure threshold for livenessProbe | `3` |
-| `livenessProbe.successThreshold` | Success threshold for livenessProbe | `1` |
-| `readinessProbe.enabled` | Enable readinessProbe on RabbitMQ containers | `true` |
-| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe | `0` |
-| `readinessProbe.periodSeconds` | Period seconds for readinessProbe | `10` |
-| `readinessProbe.timeoutSeconds` | Timeout seconds for readinessProbe | `5` |
-| `readinessProbe.failureThreshold` | Failure threshold for readinessProbe | `1` |
-| `readinessProbe.successThreshold` | Success threshold for readinessProbe | `1` |
+| Parameter                            | Description                                  | Default |
+| ------------------------------------ | -------------------------------------------- | ------- |
+| `livenessProbe.enabled`              | Enable livenessProbe on RabbitMQ containers  | `true`  |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe      | `120`   |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe             | `30`    |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe            | `20`    |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe          | `3`     |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe          | `1`     |
+| `readinessProbe.enabled`             | Enable readinessProbe on RabbitMQ containers | `true`  |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe     | `0`     |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe            | `10`    |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe           | `5`     |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe         | `1`     |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe         | `1`     |
 
 ### Additional Configuration
 
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `extraEnv` | Additional environment variables to set | `[]` |
-| `extraVolumes` | Additional volumes to add to the pod | `[]` |
-| `extraVolumeMounts` | Additional volume mounts to add to the RabbitMQ container | `[]` |
+| Parameter           | Description                                                             | Default |
+| ------------------- | ----------------------------------------------------------------------- | ------- |
+| `extraEnv`          | Additional environment variables to set                                 | `[]`    |
+| `extraVolumes`      | Additional volumes to add to the pod                                    | `[]`    |
+| `extraVolumeMounts` | Additional volume mounts to add to the RabbitMQ container               | `[]`    |
+| `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
 
 ## Examples
 

--- a/charts/rabbitmq/templates/extraobjects.yaml
+++ b/charts/rabbitmq/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -719,6 +719,15 @@
       "items": {
         "type": "object"
       }
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -143,7 +143,8 @@ ingress:
   ## @param ingress.className Ingress class name
   className: ""
   ## @param ingress.annotations Ingress annotations
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   ## @param ingress.hosts Ingress hosts configuration
@@ -157,7 +158,8 @@ ingress:
 
 ## @section Resources
 ## @param resources Resource limits and requests for RabbitMQ pods
-resources: {}
+resources:
+  {}
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -238,3 +240,6 @@ extraVolumes: []
 
 ## @param extraVolumeMounts Additional volume mounts to add to the RabbitMQ container
 extraVolumeMounts: []
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.1.8
+version: 0.2.0
 appVersion: "8.2.1"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -165,11 +165,48 @@ redis-cli -h my-redis -a $REDIS_PASSWORD
 
 ### Additional Configuration
 
-| Parameter           | Description                                  | Default |
-| ------------------- | -------------------------------------------- | ------- |
-| `extraEnv`          | Additional environment variables             | `[]`    |
-| `extraVolumes`      | Additional volumes to add to the pod         | `[]`    |
-| `extraVolumeMounts` | Additional volume mounts for Redis container | `[]`    |
+| Parameter           | Description                                                             | Default |
+| ------------------- | ----------------------------------------------------------------------- | ------- |
+| `extraEnv`          | Additional environment variables                                        | `[]`    |
+| `extraVolumes`      | Additional volumes to add to the pod                                    | `[]`    |
+| `extraVolumeMounts` | Additional volume mounts for Redis container                            | `[]`    |
+| `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
 
 ## Examples
 

--- a/charts/redis/templates/extraobjects.yaml
+++ b/charts/redis/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -474,6 +474,15 @@
       "items": {
         "type": "object"
       }
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -144,3 +144,13 @@ extraVolumes: []
 
 ## @param extraVolumeMounts Additional volume mounts to add to the Redis container
 extraVolumeMounts: []
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: extra-config
+#     namespace: "{{ .Release.Namespace }}"
+#   data:
+#     key: value

--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "2.21.3-pg17"
 keywords:
   - timescaledb

--- a/charts/timescaledb/README.md
+++ b/charts/timescaledb/README.md
@@ -196,6 +196,48 @@ The following table lists the configurable parameters of the TimescaleDB chart a
 | `tolerations`  | Toleration labels for pod assignment | `[]`    |
 | `affinity`     | Affinity settings for pod assignment | `{}`    |
 
+### Additional Configuration
+
+| Parameter           | Description                                                             | Default |
+| ------------------- | ----------------------------------------------------------------------- | ------- |
+| `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
 ## Examples
 
 ### Basic Deployment

--- a/charts/timescaledb/templates/extraobjects.yaml
+++ b/charts/timescaledb/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/timescaledb/values.schema.json
+++ b/charts/timescaledb/values.schema.json
@@ -544,6 +544,15 @@
       "type": "object",
       "title": "Affinity Configuration",
       "description": "Affinity settings for pod assignment"
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/timescaledb/values.yaml
+++ b/charts/timescaledb/values.yaml
@@ -106,7 +106,8 @@ service:
   annotations: {}
 
 ## @section Resources
-resources: {}
+resources:
+  {}
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -186,3 +187,13 @@ tolerations: []
 
 ## @param affinity Affinity settings for pod assignment
 affinity: {}
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: extra-config
+#     namespace: "{{ .Release.Namespace }}"
+#   data:
+#     key: value

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "8.1.3"
 home: https://www.cloudpirates.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -210,6 +210,49 @@ The following table lists the configurable parameters of the Valkey chart and th
 | `tolerations`  | Toleration labels for pod assignment | `[]`    |
 | `affinity`     | Affinity settings for pod assignment | `{}`    |
 
+### Additional Configuration
+
+| Parameter      | Description                                                             | Default |
+| -------------- | ----------------------------------------------------------------------- | ------- |
+| `extraObjects` | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
+
 ## Examples
 
 ### Basic Deployment

--- a/charts/valkey/templates/extraobjects.yaml
+++ b/charts/valkey/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -678,6 +678,15 @@
           "description": "Pod anti-affinity configuration"
         }
       }
+    },
+    "extraObjects": {
+      "type": "array",
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     }
   }
 }

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -202,3 +202,13 @@ tolerations: []
 
 ## @param affinity Affinity settings for pod assignment
 affinity: {}
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []
+# - apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: extra-config
+#     namespace: "{{ .Release.Namespace }}"
+#   data:
+#     key: value


### PR DESCRIPTION
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

- adds extraObjects array to all charts to allow deploying additional manifests with the chart
	- e.g. networkPolicy, externalSecrets, etc. 	

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #32

### Additional information

I didn't really have the time to do individual PRs for each chart. I hope this is alright, since it's just the same change for all of them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
