### PR TITLE
[mariadb] Default randomized password

### DIFF
--- a/charts/mariadb/CHANGELOG.md
+++ b/charts/mariadb/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.1 (2025-09-04)
 
-* [mariadb]: Default randomized password ([#35](https://github.com/CloudPirates-io/helm-charts/pull/35))
+* [mariadb] Default randomized password ([#35](https://github.com/CloudPirates-io/helm-charts/pull/35))
 
 ## 0.2.0 (2025-09-02)
 

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "12.0.2"
 keywords:
   - mariadb

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -48,6 +48,16 @@ Return the proper Docker Image Registry Secret Names
 {{- define "mariadb.imagePullSecrets" -}}
 {{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" .) }}
 {{- end -}}
+{{/*
+Get the secret name for MariaDB root password
+*/}}
+{{- define "mariadb.secretName" -}}
+{{- if .Values.auth.existingSecret }}
+{{- .Values.auth.existingSecret }}
+{{- else }}
+{{- include "mariadb.fullname" . }}
+{{- end }}
+{{- end }}
 
 {{/*
 Return the MariaDB Secret Name
@@ -70,16 +80,4 @@ Return the MariaDB ConfigMap Name
 {{- include "mariadb.fullname" . }}
 {{- end }}
 {{- end }}
-
-{{/*
-Validate MariaDB required passwords are not empty
-*/}}
-{{- define "mariadb.validateValues.auth" -}}
-{{- if .Values.auth.enabled }}
-{{- if not .Values.auth.existingSecret -}}
-  {{- /* No validation needed for rootPassword as it's auto-generated when empty */ -}}
-  {{- /* No validation needed for user password as it's auto-generated when empty */ -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
 

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -60,14 +60,10 @@ Get the secret name for MariaDB root password
 {{- end }}
 
 {{/*
-Return the MariaDB Secret Name
+Validate values of MariaDB - Authentication
 */}}
-{{- define "mariadb.secretName" -}}
-{{- if .Values.auth.existingSecret }}
-{{- .Values.auth.existingSecret }}
-{{- else }}
-{{- include "mariadb.fullname" . }}
-{{- end }}
+{{- define "mariadb.validateValues.auth" -}}
+{{/* No validation needed - empty rootPassword will trigger auto-generation */}}
 {{- end }}
 
 {{/*

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -77,16 +77,8 @@ Validate MariaDB required passwords are not empty
 {{- define "mariadb.validateValues.auth" -}}
 {{- if .Values.auth.enabled }}
 {{- if not .Values.auth.existingSecret -}}
-  {{- if not .Values.auth.rootPassword -}}
-mariadb: auth.rootPassword
-    You must provide a password for MariaDB root user.
-    Please set auth.rootPassword or use an existing secret.
-  {{- end -}}
-  {{- if and .Values.auth.username (not .Values.auth.password) -}}
-mariadb: auth.password
-    You must provide a password for the custom MariaDB user.
-    Please set auth.password or use an existing secret.
-  {{- end -}}
+  {{- /* No validation needed for rootPassword as it's auto-generated when empty */ -}}
+  {{- /* No validation needed for user password as it's auto-generated when empty */ -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/mariadb/templates/secret.yaml
+++ b/charts/mariadb/templates/secret.yaml
@@ -12,8 +12,17 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ .Values.auth.secretKeys.rootPasswordKey }}: {{ .Values.auth.rootPassword | b64enc | quote }}
+  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "mariadb.fullname" .)) }}
+  {{- $existingRootPassword := "" }}
+  {{- if and $existingSecret $existingSecret.data }}
+    {{- $existingRootPassword = index $existingSecret.data .Values.auth.secretKeys.rootPasswordKey }}
+  {{- end }}
+  {{ .Values.auth.secretKeys.rootPasswordKey }}: {{ $existingRootPassword | default (.Values.auth.rootPassword | default (randAlphaNum 32) | b64enc) | quote }}
   {{- if or .Values.auth.username .Values.auth.password }}
-  {{ .Values.auth.secretKeys.userPasswordKey }}: {{ .Values.auth.password | b64enc | quote }}
+  {{- $existingUserPassword := "" }}
+  {{- if and $existingSecret $existingSecret.data }}
+    {{- $existingUserPassword = index $existingSecret.data .Values.auth.secretKeys.userPasswordKey }}
+  {{- end }}
+  {{ .Values.auth.secretKeys.userPasswordKey }}: {{ $existingUserPassword | default (.Values.auth.password | default (randAlphaNum 32) | b64enc) | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Use a default randomized password, at initial mariadb installation / initialization

### Benefits

Easier initial setup

### Possible drawbacks

/ 

### Applicable issues

#34 

### Additional information

/

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
