### PR TITLE
[mariadb] respect full container security context

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "12.0.2"
 keywords:
   - mariadb

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -154,7 +154,6 @@ The following table lists the configurable parameters of the MariaDB chart and t
 | --------------------------------------------------- | ----------------------------------------------------- | ------- |
 | `podSecurityContext.enabled`                        | Enabled MariaDB pod Security Context                  | `true`  |
 | `podSecurityContext.fsGroup`                        | Set MariaDB pod's Security Context fsGroup            | `999`   |
-| `containerSecurityContext.enabled`                  | Enabled MariaDB container's Security Context          | `true`  |
 | `containerSecurityContext.runAsUser`                | Set MariaDB container's Security Context runAsUser    | `999`   |
 | `containerSecurityContext.runAsNonRoot`             | Set MariaDB container's Security Context runAsNonRoot | `true`  |
 | `containerSecurityContext.allowPrivilegeEscalation` | Set MariaDB container's privilege escalation          | `false` |

--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -39,12 +39,7 @@ spec:
         - name: mariadb
           image: {{ include "mariadb.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
-          {{- if .Values.containerSecurityContext.enabled }}
-          securityContext:
-            runAsUser: {{ .Values.containerSecurityContext.runAsUser }}
-            runAsNonRoot: {{ .Values.containerSecurityContext.runAsNonRoot }}
-            allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-          {{- end }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- if or .Values.auth.enabled .Values.auth.database .Values.auth.username .Values.auth.allowEmptyRootPassword .Values.env }}
           env:
             {{- if and .Values.auth.enabled }}

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -93,8 +93,6 @@ podSecurityContext:
 
 ## @section MariaDB Container Security Context
 containerSecurityContext:
-  ## @param containerSecurityContext.enabled Enabled MariaDB container's Security Context
-  enabled: true
   ## @param containerSecurityContext.runAsUser Set MariaDB container's Security Context runAsUser
   runAsUser: 999
   ## @param containerSecurityContext.runAsNonRoot Set MariaDB container's Security Context runAsNonRoot

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -104,7 +104,6 @@ The following table lists the configurable parameters of the Memcached chart and
 | --------------------------------------------------- | ------------------------------------------------------- | ------- |
 | `podSecurityContext.enabled`                        | Enabled Memcached pod Security Context                  | `true`  |
 | `podSecurityContext.fsGroup`                        | Set Memcached pod's Security Context fsGroup            | `11211` |
-| `containerSecurityContext.enabled`                  | Enabled Memcached container's Security Context          | `true`  |
 | `containerSecurityContext.runAsUser`                | Set Memcached container's Security Context runAsUser    | `11211` |
 | `containerSecurityContext.runAsNonRoot`             | Set Memcached container's Security Context runAsNonRoot | `true`  |
 | `containerSecurityContext.allowPrivilegeEscalation` | Set Memcached container's privilege escalation          | `false` |


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

- mariadb should respect full custom container security context settings
- memcached readme fixed, this option was not available


### Benefits

no fixed security context anymore. Now allows also capabilities

### Possible drawbacks


### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
