### PR TITLE
[rabbitmq]: Fix erlang cookie copy / access rights

### DIFF
--- a/charts/rabbitmq/CHANGELOG.md
+++ b/charts/rabbitmq/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.1.2 (2025-09-08)
+## 0.1.3 (2025-09-09)
 
-* [rabbitmq] Update RabbitMQ to 4.1.4 ([#45](https://github.com/CloudPirates-io/helm-charts/pull/45))
+* [rabbitmq]: Fix erlang cookie copy / access rights ([#48](https://github.com/CloudPirates-io/helm-charts/pull/48))
 
 ## <small>0.1.1 (2025-09-08)</small>
 

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "4.1.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -39,6 +39,7 @@ spec:
             - |
               echo "$RABBITMQ_ERLANG_COOKIE" > /var/lib/rabbitmq/.erlang.cookie
               chmod 400 /var/lib/rabbitmq/.erlang.cookie
+              chown {{ .Values.securityContext.runAsUser | default 999 }}:{{ .Values.securityContext.runAsGroup | default 999 }} /var/lib/rabbitmq/.erlang.cookie
           env:
             - name: RABBITMQ_ERLANG_COOKIE
               valueFrom:

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -39,7 +39,6 @@ spec:
             - |
               echo "$RABBITMQ_ERLANG_COOKIE" > /var/lib/rabbitmq/.erlang.cookie
               chmod 400 /var/lib/rabbitmq/.erlang.cookie
-              chown 999:999 /var/lib/rabbitmq/.erlang.cookie
           env:
             - name: RABBITMQ_ERLANG_COOKIE
               valueFrom:

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/rabbitmq
-      {{- end }}‚
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.securityContext }}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -25,8 +25,10 @@ spec:
       {{ . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "rabbitmq.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- if .Values.auth.enabled }}
       initContainers:
         - name: init-erlang-cookie
@@ -50,8 +52,10 @@ spec:
       {{- end }}‚
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 10 }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           image: {{ include "rabbitmq.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
           ports:

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -21,40 +21,37 @@ spec:
       labels:
         {{- include "rabbitmq.selectorLabels" . | nindent 8 }}
     spec:
-{{- with (include "rabbitmq.imagePullSecrets" .) }}
-{{ . | nindent 6 }}
-{{- end }}
+      {{- with (include "rabbitmq.imagePullSecrets" .) }}
+      {{ . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "rabbitmq.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.auth.enabled }}
       initContainers:
-        - name: {{ .Chart.Name }}-init
+        - name: init-erlang-cookie
           image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              echo "$RABBITMQ_ERLANG_COOKIE" > /var/lib/rabbitmq/.erlang.cookie
+              chmod 400 /var/lib/rabbitmq/.erlang.cookie
+              chown 999:999 /var/lib/rabbitmq/.erlang.cookie
           env:
             - name: RABBITMQ_ERLANG_COOKIE
               valueFrom:
                 secretKeyRef:
                   name: {{ include "rabbitmq.secretName" . }}
                   key: {{ include "rabbitmq.secretErlangCookieKey" . }}
-          command:
-            - sh
-            - -c
-            - |
-              if [ ! -f /var/lib/rabbitmq/.erlang.cookie ]; then
-                echo "Copy erlang cookie"
-                echo $RABBITMQ_ERLANG_COOKIE > /var/lib/rabbitmq/.erlang.cookie
-              else
-                echo "Erlang cookie already exists."
-              fi
-              chmod 600 /var/lib/rabbitmq/.erlang.cookie
           volumeMounts:
             - name: data
               mountPath: /var/lib/rabbitmq
-      {{- end }}
+      {{- end }}‚
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 10 }}
           image: {{ include "rabbitmq.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
           ports:

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -25,9 +25,9 @@ spec:
       {{ . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "rabbitmq.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }}
+      {{- if .Values.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
         {{- end }}
       {{- if .Values.auth.enabled }}
       initContainers:
@@ -52,9 +52,9 @@ spec:
       {{- end }}‚
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.securityContext }}
+          {{- if .Values.securityContext }}
           securityContext:
-            {{- toYaml . | nindent 10 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           {{- end }}
           image: {{ include "rabbitmq.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}


### PR DESCRIPTION
### Description of the change

Always copy the erlang cookie, giving it the right permissions

### Benefits

Running RabbitMQ after restart

### Possible drawbacks


### Applicable issues

- fixes #31 

### Additional information


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
