### PR TITLE
[rabbitmq]  allow setting a clusterdomain different than the default cluster.local

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "4.1.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -69,12 +69,13 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 
 ### Common parameters
 
-| Parameter           | Description                                    | Default |
-| ------------------- | ---------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override rabbitmq.fullname | `""`    |
-| `fullnameOverride`  | String to fully override rabbitmq.fullname     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects          | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects     | `{}`    |
+| Parameter           | Description                                    | Default         |
+| ------------------- | ---------------------------------------------- | --------------- |
+| `nameOverride`      | String to partially override rabbitmq.fullname | `""`            |
+| `fullnameOverride`  | String to fully override rabbitmq.fullname     | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects          | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects     | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain                      | `cluster.local` |
 
 ### RabbitMQ image parameters
 

--- a/charts/rabbitmq/templates/configmap.yaml
+++ b/charts/rabbitmq/templates/configmap.yaml
@@ -37,10 +37,10 @@ data:
     # Clustering with K8s peer discovery plugin
     cluster_name = {{ include "rabbitmq.fullname" . }}-cluster
     cluster_formation.peer_discovery_backend = rabbit_peer_discovery_k8s
-    cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+    cluster_formation.k8s.host = kubernetes.default.svc.{{ .Values.clusterDomain }}
     cluster_formation.k8s.address_type = {{ .Values.peerDiscoveryK8sPlugin.addressType }}
     cluster_formation.k8s.service_name = {{ include "rabbitmq.fullname" . }}-headless
-    cluster_formation.k8s.hostname_suffix = .{{ include "rabbitmq.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local
+    cluster_formation.k8s.hostname_suffix = .{{ include "rabbitmq.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
     {{- end }}
 
 

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
                   fieldPath: metadata.name
             {{- if .Values.peerDiscoveryK8sPlugin.useLongname }}
             - name: RABBITMQ_NODENAME
-              value: rabbit@$(NODE_NAME).{{ include "rabbitmq.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local
+              value: rabbit@$(NODE_NAME).{{ include "rabbitmq.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- else }}
             - name: RABBITMQ_NODENAME
               value: rabbit@$(NODE_NAME)

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -86,6 +86,11 @@
         }
       }
     },
+    "clusterDomain": {
+      "type": "string",
+      "title": "Cluster Domain",
+      "description": "Kubernetes cluster domain"
+    },
     "replicaCount": {
       "type": "integer",
       "title": "Replica Count",

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -26,6 +26,9 @@ image:
   ## @param image.imagePullPolicy RabbitMQ image pull policy
   imagePullPolicy: Always
 
+## @param clusterDomain Kubernetes cluster domain
+clusterDomain: cluster.local
+
 ## @section Deployment configuration
 ## @param replicaCount Number of RabbitMQ replicas to deploy (clustering needs to be enabled to set more than 1 replicas)
 replicaCount: 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Adding the ability to overwrite the default kubernetes cluster domain

### Benefits

This chart can be used even if your kubernetes cluster domain is different than the default

### Possible drawbacks

None that i could think of

### Applicable issues

- none at the moment

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
