### PR TITLE
[nginx] fix artifacthub-repo id

### DIFF
--- a/charts/nginx/CHANGELOG.md
+++ b/charts/nginx/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
-## 0.1.3 (2025-09-08)
+## 0.1.4 (2025-09-10)
 
-* [nginx] Update nginx to 1.29.1 (alpine) ([#44](https://github.com/CloudPirates-io/helm-charts/pull/44))
+* [nginx] fix artifacthub-repo id ([#72](https://github.com/CloudPirates-io/helm-charts/pull/72))
+
+## <small>0.1.3 (2025-09-08)</small>
+
+* add artifacthub-repo id ([ee4f192](https://github.com/CloudPirates-io/helm-charts/commit/ee4f192))
+* bump version to 0.1.2 ([f75a781](https://github.com/CloudPirates-io/helm-charts/commit/f75a781))
+* fix containerport and change ingress host-pathtype ([60e3223](https://github.com/CloudPirates-io/helm-charts/commit/60e3223))
+* Update appVersion ([933ba01](https://github.com/CloudPirates-io/helm-charts/commit/933ba01))
+* update chart-icon ([7ed7c8e](https://github.com/CloudPirates-io/helm-charts/commit/7ed7c8e))
+* add hpa feature ([e5eab56](https://github.com/CloudPirates-io/helm-charts/commit/e5eab56))
+* Bump nginx to latest version + alpine ([8b0fc57](https://github.com/CloudPirates-io/helm-charts/commit/8b0fc57))
+* fix linting ([11d72e9](https://github.com/CloudPirates-io/helm-charts/commit/11d72e9))
+* Initial commit to add Nginx ([1579cc4](https://github.com/CloudPirates-io/helm-charts/commit/1579cc4))
+* make nginx work ([097d204](https://github.com/CloudPirates-io/helm-charts/commit/097d204))
+* Update CHANGELOG.md ([d0f0153](https://github.com/CloudPirates-io/helm-charts/commit/d0f0153))
+* Update CHANGELOG.md ([4ff2bbc](https://github.com/CloudPirates-io/helm-charts/commit/4ff2bbc))
+* Update CHANGELOG.md ([a13f40d](https://github.com/CloudPirates-io/helm-charts/commit/a13f40d))
+* Update CHANGELOG.md ([19e5317](https://github.com/CloudPirates-io/helm-charts/commit/19e5317))
+* Update readme ([e09a5a3](https://github.com/CloudPirates-io/helm-charts/commit/e09a5a3))

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -3,7 +3,7 @@ name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
 
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.29.1"
 
 keywords:

--- a/charts/nginx/artifacthub-repo.yml
+++ b/charts/nginx/artifacthub-repo.yml
@@ -1,1 +1,1 @@
-repositoryID: "7e7ab434-cbc6-4e1b-aa32-5ad4145a9fa2"
+repositoryID: 7e7ab434-cbc6-4e1b-aa32-5ad4145a9fa2


### PR DESCRIPTION
### Description of the change

Fix the repositoryID in the file "artifacthub-repo.yml", so that in Artifacthub the Repository is viewed as Verified Publisher

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
