### PR TITLE
[rabbitmq]: add support to automatically download and enable 3rd party plugins

### DIFF
--- a/charts/rabbitmq/CHANGELOG.md
+++ b/charts/rabbitmq/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.1.7 (2025-09-10)
+## 0.2.0 (2025-09-10)
 
-* [rabbitmq]: add missing @ for sha image reference ([#73](https://github.com/CloudPirates-io/helm-charts/pull/73))
+* [rabbitmq]: add support to automatically download and enable 3rd party plugins ([#75](https://github.com/CloudPirates-io/helm-charts/pull/75))

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.1.7
+version: 0.2.0
 appVersion: "4.1.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -139,6 +139,12 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | -------------------------- | --------------------------------- | ------- |
 | `managementPlugin.enabled` | Enable RabbitMQ management plugin | `true`  |
 
+## Plugin configuration
+
+| Parameter        | Description                                                                                                                                       | Default |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `installPlugins` | Additional 3rd party RabbitMQ plugins to download and enable | `[]`    |
+
 ### Metrics configuration
 
 | Parameter                              | Description                                                                                                                 | Default |

--- a/charts/rabbitmq/templates/_helpers.tpl
+++ b/charts/rabbitmq/templates/_helpers.tpl
@@ -92,3 +92,13 @@ Return the proper Docker Image Registry Secret Names
         {{- default "default" -}}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Extract plugin name from plugin URL
+*/}}
+{{- define "rabbitmq.pluginName" -}}
+{{- $url := . -}}
+{{- $filename := (regexReplaceAll ".*/" $url "") -}}
+{{- $filename = (regexReplaceAll "-[0-9]+\\.[0-9]+\\.[0-9]+.*" $filename "") -}}
+{{- $filename -}}
+{{- end -}}

--- a/charts/rabbitmq/templates/configmap.yaml
+++ b/charts/rabbitmq/templates/configmap.yaml
@@ -11,6 +11,11 @@
 {{- if .Values.additionalPlugins }}
 {{ $plugins = concat $plugins .Values.additionalPlugins }}
 {{- end }}
+{{- if .Values.installPlugins }}
+{{- range .Values.installPlugins }}
+{{ $plugins = append $plugins (include "rabbitmq.pluginName" .) }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,7 +37,7 @@ data:
     # Management plugin options
     management.tcp.port = {{ .Values.service.managementPort }}
     {{- end }}
-    
+
     {{- if .Values.peerDiscoveryK8sPlugin.enabled }}
     # Clustering with K8s peer discovery plugin
     cluster_name = {{ include "rabbitmq.fullname" . }}-cluster
@@ -53,12 +58,12 @@ data:
     # Prometheus metrics
     prometheus.tcp.port = {{ .Values.metrics.port }}
     {{- end }}
-    
+
     {{- if and .Values.config.extraConfiguration (ne .Values.config.extraConfiguration "") }}
     # Extra configuration
 {{ .Values.config.extraConfiguration | indent 4 }}
     {{- end }}
-    
+
   {{- if and .Values.config.advancedConfiguration (ne .Values.config.advancedConfiguration "") }}
   advanced.config: |
 {{ .Values.config.advancedConfiguration | indent 4 }}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -29,8 +29,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
-      {{- if .Values.auth.enabled }}
+      {{- if or .Values.auth.enabled .Values.installPlugins }}
       initContainers:
+        {{- if .Values.auth.enabled }}
         - name: init-erlang-cookie
           image: "{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}/{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
@@ -54,6 +55,34 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/rabbitmq
+        {{- end }}
+        {{- if .Values.installPlugins }}
+        - name: download-plugins
+          image: "{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}/{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
+          {{- if .Values.initContainer.securityContext }}
+          securityContext:
+            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /var/lib/rabbitmq/plugins /opt/rabbitmq/plugins
+              {{- range .Values.installPlugins }}
+              echo "Downloading plugin from {{ . }}"
+              wget -O /var/lib/rabbitmq/plugins/$(basename {{ . }}) {{ . }}
+              {{- end }}
+              echo "Copying plugins to RabbitMQ plugin directory"
+              cp /var/lib/rabbitmq/plugins/*.ez /opt/rabbitmq/plugins/
+              chown -R {{ .Values.securityContext.runAsUser | default 999 }}:{{ .Values.securityContext.runAsGroup | default 999 }} /var/lib/rabbitmq/plugins /opt/rabbitmq/plugins
+              chmod -R 755 /var/lib/rabbitmq/plugins /opt/rabbitmq/plugins
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/rabbitmq
+            - name: plugins
+              mountPath: /opt/rabbitmq/plugins
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -145,6 +174,10 @@ spec:
               mountPath: /etc/rabbitmq
             - name: logs
               mountPath: /var/log/rabbitmq
+            {{- if .Values.installPlugins }}
+            - name: plugins
+              mountPath: /opt/rabbitmq/plugins
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -153,6 +186,10 @@ spec:
           emptyDir: {}
         {{- if not .Values.persistence.enabled }}
         - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.installPlugins }}
+        - name: plugins
           emptyDir: {}
         {{- end }}
         - name: config

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -328,6 +328,14 @@
         "type": "string"
       }
     },
+    "installPlugins": {
+      "type": "array",
+      "title": "Install Plugins",
+      "description": "Additional 3rd party RabbitMQ plugins to download and enable",
+      "items": {
+        "type": "string"
+      }
+    },
     "persistence": {
       "type": "object",
       "title": "Persistence Configuration",

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -149,8 +149,11 @@ metrics:
     ## @param metrics.serviceMonitor.scrapeTimeout Scrape timeout
     scrapeTimeout: 10s
 
-## @param additionalPlugins Additional RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added)
+## @param additionalPlugins Additional default RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added)
 additionalPlugins: []
+
+## @param installPlugins Additional 3rd party RabbitMQ plugins to download and enable
+installPlugins: []
 
 ## @section Persistence
 persistence:


### PR DESCRIPTION
### Description of the change

Add support for installing 3rd party plugins from URLs via a new `installPlugins` value. This will automatically add another init container (Still based on busybox) that downloads plugins and automatically enables them in the RabbitMQ config.

### Benefits

- Easy installation of 3rd-party plugins by providing download URLs
- Automatic plugin name extraction and configuration
- No manual intervention required

### Possible drawbacks

- Plugin download failures will prevent pod startup
- Users must ensure plugin compatibility with RabbitMQ version

### Applicable issues

- (Please inform me if I should create a matching issue for such ideas/changes beforehand)

### Additional information

Example usage:
```yaml
installPlugins:
  - https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v4.1.0/rabbitmq_delayed_message_exchange-4.1.0.ez
```

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title