### PR TITLE
[postgres] chore: add support for persistentVolumeClaimRetentionPolicy

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "17.6"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -177,6 +177,14 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `persistence.accessModes`   | Persistent Volume access modes                     | `["ReadWriteOnce"]` |
 | `persistence.existingClaim` | The name of an existing PVC to use for persistence | `""`                |
 
+### Persistent Volume Claim Retention Policy
+
+| Parameter                                          | Description                                                                    | Default    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | -----------|
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for the Statefulset                  | `false`    |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `"Retain"` |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `"Retain"` |
+
 ### Liveness and readiness probes
 
 | Parameter                            | Description                                    | Default |

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -164,6 +164,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   {{- if .Values.persistence.enabled }}
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -501,6 +501,28 @@
         }
       }
     },
+    "persistentVolumeClaimRetentionPolicy": {
+      "type": "object",
+      "title": "Persistent Volume Claim Retention Policy Configuration",
+      "description": "Persistent Volume Claim Retention Policy configuration parameters",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable Persistent volume retention policy",
+          "description": "Enable Persistent volume retention policy for the Statefulset"
+        },
+        "whenDeleted": {
+          "type": "string",
+          "title": "whenDeleted Volume retention behavior",
+          "description": "Volume retention behavior that applies when the StatefulSet is deleted"
+        },
+        "whenScaled": {
+          "type": "string",
+          "title": "whenScaled Volume retention behavior",
+          "description": "Volume retention behavior when the replica count of the StatefulSet is reduced"
+        }
+      }
+    },
     "livenessProbe": {
       "type": "object",
       "title": "Liveness Probe Configuration",

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -174,6 +174,15 @@ persistence:
   ## @param persistence.existingClaim The name of an existing PVC to use for persistence
   existingClaim: ""
 
+## @section Persistent Volume Claim Retention Policy
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for the Statefulset
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  whenDeleted: Retain
+
 ## @section Liveness and readiness probes
 livenessProbe:
   ## @param livenessProbe.enabled Enable livenessProbe on PostgreSQL containers


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add support for persistentVolumeClaimRetentionPolicy

### Benefits

Enable changing Persistent Volume Claim Retention Policy for the Statefulset
(We used this feature in the old Bitnami chart)

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
