### PR TITLE
[postgres] chore: add support for db initialization scripts

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "17.6"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -139,6 +139,13 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `config.extraConfig`                          | Additional PostgreSQL configuration parameters                                          | `[]`    |
 | `config.existingConfigmap`                    | Name of existing ConfigMap with PostgreSQL configuration                                | `""`    |
 
+### PostgreSQL Initdb Configuration
+
+| Parameter                 | Description                                    | Default |
+| ------------------------- | ---------------------------------------------- | ------- |
+| `initdb.scripts`          | Dictionary of scripts to be run at first boot  | `{}`    |
+| `initdb.scriptsConfigMap` | ConfigMap with scripts to be run at first boot | `""`    |
+
 ### Service configuration
 
 | Parameter             | Description               | Default     |

--- a/charts/postgres/templates/_helpers.tpl
+++ b/charts/postgres/templates/_helpers.tpl
@@ -96,6 +96,17 @@ Return PostgreSQL configuration ConfigMap name
 {{- end }}
 
 {{/*
+Return PostgreSQL initialization scripts ConfigMap name
+*/}}
+{{- define "postgres.initdb.scriptsCM" -}}
+{{- if .Values.initdb.scriptsConfigMap -}}
+    {{- printf "%s" (tpl .Values.initdb.scriptsConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-init-scripts" (include "postgres.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return PostgreSQL data directory
 */}}
 {{- define "postgres.dataDir" -}}

--- a/charts/postgres/templates/initialization-configmap.yaml
+++ b/charts/postgres/templates/initialization-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.initdb.scripts (not .Values.initdb.scriptsConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-init-scripts" (include "postgres.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "postgres.annotations" . | nindent 4 }}
+  {{- end }}
+data: {{- include "common.tplvalues.render" (dict "value" .Values.initdb.scripts "context" .) | nindent 2 }}
+{{- end }}

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -136,6 +136,10 @@ spec:
               mountPath: {{ include "postgres.runDir" . }}
             - name: tmp
               mountPath: /tmp
+            {{- if or .Values.initdb.scriptsConfigMap .Values.initdb.scripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/
+            {{- end }}
       volumes:
         {{- if not .Values.persistence.enabled }}
         - name: data
@@ -151,6 +155,11 @@ spec:
           emptyDir: {}
         - name: tmp
           emptyDir: {}
+        {{- if or .Values.initdb.scriptsConfigMap .Values.initdb.scripts }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ include "postgres.initdb.scriptsCM" . }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -305,6 +305,26 @@
         }
       }
     },
+    "initdb": {
+      "type": "object",
+      "title": "PostgreSQL Initdb Configuration",
+      "description": "PostgreSQL Initdb Configuration parameters",
+      "properties": {
+        "scripts": {
+          "type": "object",
+          "title": "Initdb Scripts",
+          "description": "Dictionary of scripts to be run at first boot",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "scriptsConfigMap": {
+          "type": "string",
+          "title": "Initdb Scripts ConfigMap",
+          "description": "ConfigMap with scripts to be run at first boot"
+        }
+      }
+    },
     "service": {
       "type": "object",
       "title": "Service Configuration",
@@ -514,12 +534,14 @@
         "whenDeleted": {
           "type": "string",
           "title": "whenDeleted Volume retention behavior",
-          "description": "Volume retention behavior that applies when the StatefulSet is deleted"
+          "description": "Volume retention behavior that applies when the StatefulSet is deleted",
+          "enum": ["Delete", "Retain"]
         },
         "whenScaled": {
           "type": "string",
           "title": "whenScaled Volume retention behavior",
-          "description": "Volume retention behavior when the replica count of the StatefulSet is reduced"
+          "description": "Volume retention behavior when the replica count of the StatefulSet is reduced",
+          "enum": ["Delete", "Retain"]
         }
       }
     },

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -108,6 +108,13 @@ config:
   ## @param config.existingConfigmap Name of existing ConfigMap with PostgreSQL configuration
   existingConfigmap: ""
 
+## @section PostgreSQL Initdb configuration
+initdb:
+  ## @param initdb.scripts Dictionary of initdb scripts
+  scripts: {}
+  ## @param initdb.scriptsConfigMap ConfigMap with scripts to be run at first boot
+  scriptsConfigMap: ""
+
 ## @section Service configuration
 service:
   ## @param service.type PostgreSQL service type


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add support for custom PostgreSQL db initialization scripts

### Benefits

Support for custom PostgreSQL initialization scripts.
The docker.io/library/postgres container image already supports this mechanism in its entrypoint.
(This is the last missing feature we used with the old Bitnami chart)

This commit also includes a small fix for my previous PR.
 
### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
