### PR TITLE
[postgres] chore: add support for passing extra environment variables

### DIFF
--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -232,6 +232,12 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. | `""`    |
 | `serviceAccount.automountServiceAccountToken` | Whether to automount the SA token inside the pod                                                                          | `false` |
 
+### Extra Environment
+
+| Parameter  | Description                                           | Default |
+| ---------- | ----------------------------------------------------- | ------- |
+| `extraEnv` | Additional environment variables from key-value pairs | `{}`    |
+
 ### Extra Configuration Parameters
 
 | Parameter      | Description                                                             | Default |

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -77,6 +77,10 @@ spec:
             - name: POSTGRES_EFFECTIVE_CACHE_SIZE
               value: {{ .Values.config.postgresqlEffectiveCacheSize | quote }}
             {{- end }}
+            {{- range $key, $value := .Values.extraEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           ports:
             - name: postgresql
               containerPort: {{ .Values.service.targetPort }}

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -719,6 +719,14 @@
         }
       }
     },
+    "extraEnv": {
+      "type": "object",
+      "title": "Extra Environment",
+      "description": "Additional environment variables from key-value pairs",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "extraObjects": {
       "type": "array",
       "title": "Extra Objects",

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -254,5 +254,10 @@ serviceAccount:
   ## @param serviceAccount.automountServiceAccountToken whether to automount the SA token inside the pod
   automountServiceAccountToken: false
 
+## @param extraEnv Additional environment variables from key-value pairs
+extraEnv: {}
+# VARNAME1: value1
+# VARNAME2: value2
+
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add support for passing additional environment variables from key-value pairs

### Benefits

Useful to pass some extra environment variables to the container, a lot of Helm charts have it.
In particular, I would need it to pass the "PGHOST" environment variable.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
