### PR TITLE
[postgres] add support for extra env vars from secret

### DIFF
--- a/charts/postgres/CHANGELOG.md
+++ b/charts/postgres/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.4.0 (2025-09-16)
+
+* [postgres] add support for extra env vars from a secret
 
 ## 0.3.0 (2025-09-16)
 

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "17.6"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -236,9 +236,10 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 
 ### Extra Configuration Parameters
 
-| Parameter      | Description                                                 | Default |
-| -------------- | ----------------------------------------------------------- | ------- |
-| `extraObjects` | Array of extra objects to deploy with the release          | `[]`    |
+| Parameter            | Description                                                            | Default   |
+|----------------------|------------------------------------------------------------------------|-----------|
+| `extraObjects`       | Array of extra objects to deploy with the release                      | `[]`      |
+| `extraEnvVarsSecret` | Name of an existing Secret containing additional environment variables | ``        |
 
 #### Extra Objects
 

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -78,6 +78,11 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.extraEnvVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+          {{- end }}
           ports:
             - name: postgresql
               containerPort: {{ .Values.service.targetPort }}

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -730,6 +730,11 @@
         "type": "string"
       }
     },
+    "extraEnvVarsSecret": {
+      "type": "string",
+      "title": "Extra Environment Secret",
+      "description": "Name of an existing Secret containing additional environment variables"
+    },
     "extraObjects": {
       "type": "array",
       "title": "Extra Objects",

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -253,5 +253,8 @@ extraEnv: {}
 # VARNAME1: value1
 # VARNAME2: value2
 
+## @param extraEnvVarsSecret Name of a secret containing additional environment variables
+extraEnvVarsSecret: ""
+
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Support for adding extra environment variables from an existing secret to the Postgres container.

### Benefits

<!-- What benefits will be realized by the code change? -->
For example, it can be used for providing credentials in an init script. We use it to create different users and schemas
while in the init phase.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
