### PR TITLE
[rabbitmq] Custom init containers / post start scripts

### DIFF
--- a/charts/rabbitmq/CHANGELOG.md
+++ b/charts/rabbitmq/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.2.7 (2025-09-16)
+## 0.2.8 (2025-09-17)
 
-* [busybox] chore(deps): update docker.io/busybox:1.37.0 Docker digest to d82f458 ([#104](https://github.com/CloudPirates-io/helm-charts/pull/104))
+* [rabbitmq] Custom init containers / post start scripts ([#111](https://github.com/CloudPirates-io/helm-charts/pull/111))
 
 ## <small>0.1.1 (2025-09-08)</small>
 

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "4.1.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
-      {{- if or .Values.auth.enabled .Values.installPlugins }}
+      {{- if or .Values.auth.enabled .Values.installPlugins .Values.customScripts.initContainers }}
       initContainers:
         {{- if .Values.auth.enabled }}
         - name: init-erlang-cookie
@@ -83,6 +83,9 @@ spec:
             - name: plugins
               mountPath: /opt/rabbitmq/plugins
         {{- end }}
+        {{- if .Values.customScripts.initContainers }}
+        {{- toYaml .Values.customScripts.initContainers | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -92,6 +95,13 @@ spec:
           {{- end }}
           image: {{ include "rabbitmq.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
+          {{- if .Values.customScripts.postStart.enabled }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  {{- toYaml .Values.customScripts.postStart.command | nindent 18 }}
+          {{- end }}
           ports:
             - name: amqp
               containerPort: 5672

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -276,3 +276,32 @@ extraVolumeMounts: []
 
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []
+
+## @section Custom Scripts and Hooks
+customScripts:
+  ## @param customScripts.postStart PostStart lifecycle hook configuration
+  postStart:
+    ## @param customScripts.postStart.enabled Enable postStart lifecycle hook
+    enabled: false
+    ## @param customScripts.postStart.command Command to execute in postStart hook
+    command: []
+    # Example:
+    # - /bin/bash
+    # - -c
+    # - |
+    #   sleep 10
+    #   rabbitmq-queues rebalance all
+  ## @param customScripts.initContainers Custom init containers to run before RabbitMQ starts
+  initContainers: []
+  # Example:
+  # - name: custom-setup
+  #   image: alpine:3.18
+  #   command:
+  #     - sh
+  #     - -c
+  #     - |
+  #       echo "Setting up custom configuration"
+  #       # Add your custom setup logic here
+  #   volumeMounts:
+  #     - name: data
+  #       mountPath: /var/lib/rabbitmq


### PR DESCRIPTION
### Description of the change

Add the ability for custom init containers / postStart scripts

### Benefits

Custom initContainers and postStart scripts

### Possible drawbacks

None that I know of

### Applicable issues

- fixes #105 

### Additional information



### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
