### PR TITLE
[rabbitmq] Fix copy rabbitmq plugins

### DIFF
--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -68,20 +68,40 @@ spec:
             - sh
             - -c
             - |
-              mkdir -p /var/lib/rabbitmq/plugins /opt/rabbitmq/plugins
+              mkdir -p /var/lib/rabbitmq/plugins
               {{- range .Values.installPlugins }}
               echo "Downloading plugin from {{ . }}"
               wget -O /var/lib/rabbitmq/plugins/$(basename {{ . }}) {{ . }}
               {{- end }}
-              echo "Copying plugins to RabbitMQ plugin directory"
-              cp /var/lib/rabbitmq/plugins/*.ez /opt/rabbitmq/plugins/
-              chown -R {{ .Values.securityContext.runAsUser | default 999 }}:{{ .Values.securityContext.runAsGroup | default 999 }} /var/lib/rabbitmq/plugins /opt/rabbitmq/plugins
-              chmod -R 755 /var/lib/rabbitmq/plugins /opt/rabbitmq/plugins
+              echo "Moving downloaded plugins to shared directory"
+              if ls /var/lib/rabbitmq/plugins/*.ez 1> /dev/null 2>&1; then
+                mv /var/lib/rabbitmq/plugins/*.ez /tmp/plugins/
+                echo "Successfully moved plugins"
+              else
+                echo "No plugins to move"
+              fi
           volumeMounts:
             - name: data
               mountPath: /var/lib/rabbitmq
             - name: plugins
-              mountPath: /opt/rabbitmq/plugins
+              mountPath: /tmp/plugins
+        - name: copy-plugins
+          image: {{ include "rabbitmq.image" . | quote }}
+          imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
+          {{- if .Values.initContainer.securityContext }}
+          securityContext:
+            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -c
+            - |
+              echo "Copying built-in RabbitMQ plugins to shared directory"
+              cp -r /opt/rabbitmq/plugins/* /tmp/plugins/
+              echo "Built-in plugins copied successfully"
+          volumeMounts:
+            - name: plugins
+              mountPath: /tmp/plugins
         {{- end }}
       {{- end }}
       containers:

--- a/test-values.yaml
+++ b/test-values.yaml
@@ -1,0 +1,2 @@
+installPlugins:
+  - "https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v3.13.0/rabbitmq_delayed_message_exchange-3.13.0.ez"


### PR DESCRIPTION
### Description of the change

Properly copy / chmod the downloaded plugins

### Benefits

Working rabbitmq plugins

### Possible drawbacks



### Applicable issues

- fixes #115 

### Additional information


### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
