### PR TITLE
Add zookeeper label to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -67,5 +67,6 @@ body:
         - redis
         - timescaledb
         - valkey
+        - zookeeper
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -56,3 +56,4 @@ body:
         - redis
         - timescaledb
         - valkey
+        - zookeeper


### PR DESCRIPTION
### Description of the change

Adds the option to select the `zookeeper` label in the issue templates.