### PR TITLE
[ghost] add ghost helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository provides secure, well-documented, and configurable Helm charts f
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | [ClusterPirate](charts/clusterpirate/) | Client agent for the CloudPirates Managed Observability Platform to connect your Kubernetes cluster to our infrastructure |
 | [Common](charts/common/)               | A library chart for common templates and helper functions                                                                 |
+| [Ghost](charts/ghost/)                 | A simple, powerful publishing platform that allows you to share your stories with the world.                              |
 | [Keycloak](charts/keycloak/)           | Open Source Identity and Access Management solution                                                                       |
 | [MariaDB](charts/mariadb/)             | High-performance, open-source relational database server that is a drop-in replacement for MySQL                          |
 | [Memcached](charts/memcached/)         | High-performance, distributed memory object caching system                                                                |

--- a/charts/ghost/CHANGELOG.md
+++ b/charts/ghost/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/charts/ghost/Chart.lock
+++ b/charts/ghost/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: common
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 1.0.0
+- name: mariadb
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 0.2.7
+digest: sha256:49f8b34756b9430a575ee1bd1d1d40b9489e36af7a1dcaf579ad3970f3949560
+generated: "2025-09-18T16:46:21.188225+02:00"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: ghost
+description: A simple, powerful publishing platform that allows you to share your stories with the world.
+type: application
+version: 0.1.0
+appVersion: "609"
+keywords:
+  - ghost
+  - blogging
+  - content management
+home: https://www.cloudpirates.io
+sources:
+  - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/ghost
+maintainers:
+  - name: CloudPirates GmbH & Co. KG
+    url: https://www.cloudpirates.io
+dependencies:
+  - name: common
+    version: "1.x.x"
+    repository: oci://registry-1.docker.io/cloudpirates
+  - name: mariadb
+    version: "0.2.x"
+    repository: oci://registry-1.docker.io/cloudpirates
+    condition: mariadb.enabled
+icon: https://a.storyblok.com/f/143071/512x512/9fcd98c061/ghost-logo.svg

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -3,7 +3,7 @@ name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
 version: 0.1.0
-appVersion: "609"
+appVersion: "6.0.9"
 keywords:
   - ghost
   - blogging

--- a/charts/ghost/LICENSE
+++ b/charts/ghost/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -22,6 +22,13 @@ To install with custom values:
 helm install my-ghost oci://registry-1.docker.io/cloudpirates/ghost -f my-values.yaml
 ```
 
+The output should show you the URL's for your Ghost instance and Admin interface accoriding to your settings in my-values.yaml
+
+```
+URLS:
+ 1) Website: https://ghost.localhost
+ 2) Admin: https://admin.ghost.localhost/ghost
+```
 
 ## Uninstalling
 
@@ -53,6 +60,29 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/ghost:<version>
 
 
 ## Configuration
+
+### External database support
+
+If you want to use an external database (e.g., AWS RDS, DigitalOcean Managed Databases), you need to set the following values in your `my-values.yaml`:
+
+```yaml
+mariadb:
+  enabled: false
+config:
+  database:
+    client: "mysql"
+    externalConnection:
+      host: "ghost-mariadb"
+      port: 3306
+      user: "ghost"
+      password: "changeme"
+      database: "ghost"
+    pool:
+      min: 2
+      max: 10
+  ...
+```
+
 
 The following tables list the configurable parameters of the Ghost chart organized by category:
 
@@ -166,16 +196,13 @@ The following tables list the configurable parameters of the Ghost chart organiz
 
 
 ## Example: Custom Ghost Configuration
-
-Create a `my-values.yaml` file to override default settings:
-
 https://docs.ghost.org/config 
 
 ```yaml
 config:
   database:
     client: "mysql"
-    connection:
+    externalConnection:
       host: "ghost-mariadb"
       port: 3306
       user: "ghost"

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -54,21 +54,109 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/ghost:<version>
 
 ## Configuration
 
-The following table lists the configurable parameters of the Ghost chart and their default values (see `values.yaml` for full details):
+The following tables list the configurable parameters of the Ghost chart organized by category:
 
-| Parameter                | Description                                 | Default         |
-|--------------------------|---------------------------------------------|-----------------|
-| `image.repository`       | Ghost image repository                      | `ghost`         |
-| `image.tag`              | Ghost image tag                             | `6.0.9`         |
-| `containerPorts`         | List of container ports                     | `[{name: http, containerPort: 2368}]` |
-| `service.type`           | Kubernetes service type                     | `ClusterIP`     |
-| `service.ports`          | List of service ports                       | `[{port: 80, targetPort: http}]` |
-| `ingress.enabled`        | Enable ingress                              | `true`          |
-| `ingress.hosts`          | List of ingress hosts                       | `ghost.localhost`|
-| `persistence.enabled`    | Enable persistence (PVC)                    | `true`          |
-| `resources`              | Pod resource requests/limits                | `{}`            |
-| `mariadb.enabled`        | Deploy MariaDB as dependency                | `true`          |
-| `config`                 | Ghost configuration (database, mail, etc.)  | See values.yaml |
+### Global & Common Parameters
+
+| Parameter                | Description                                   | Default         |
+|--------------------------|-----------------------------------------------|-----------------|
+| `global.imageRegistry`   | Global Docker image registry                  | `""`            |
+| `global.imagePullSecrets`| Global Docker registry secret names as array  | `[]`            |
+| `nameOverride`           | String to partially override ghost.fullname   | `""`            |
+| `fullnameOverride`       | String to fully override ghost.fullname       | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects         | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects    | `{}`            |
+
+### Image Parameters
+
+| Parameter                | Description                                   | Default         |
+|--------------------------|-----------------------------------------------|-----------------|
+| `image.registry`         | Ghost image registry                          | `docker.io`     |
+| `image.repository`       | Ghost image repository                        | `ghost`         |
+| `image.tag`              | Ghost image tag                               | `6.0.9`         |
+| `image.pullPolicy`       | Ghost image pull policy                       | `Always`        |
+| `replicaCount`           | Number of Ghost replicas to deploy            | `1`             |
+
+### Network Parameters
+
+| Parameter                | Description                                   | Default         |
+|--------------------------|-----------------------------------------------|-----------------|
+| `containerPorts`         | List of container ports                       | `[{name: http, containerPort: 2368}]` |
+| `service.type`           | Kubernetes service type                       | `ClusterIP`     |
+| `service.ports`          | List of service ports                         | `[{port: 80, targetPort: http}]` |
+| `ingress.enabled`        | Enable ingress record generation              | `true`          |
+| `ingress.className`      | IngressClass for the ingress record           | `""`            |
+| `ingress.annotations`    | Additional ingress annotations                | `{}`            |
+| `ingress.hosts`          | List of ingress hosts                         | `[{host: ghost.localhost, paths:[{path: /, pathType: Prefix}]}, {host: admin.ghost.localhost, paths:[{path: /ghost, pathType: Prefix}]}]` |
+| `ingress.tls`            | TLS configuration for ingress                 | `[]`            |
+
+### Persistence Parameters
+
+| Parameter                   | Description                                | Default         |
+|-----------------------------|--------------------------------------------|-----------------|
+| `persistence.enabled`       | Enable persistence using PVC               | `true`          |
+| `persistence.annotations`   | Annotations for PVC                        | `{}`            |
+| `persistence.existingClaim` | Use an existing PVC                        | `""`            |
+| `persistence.storageClass`  | Storage class of backing PVC               | `""`            |
+| `persistence.accessModes`   | PVC access modes                           | `[ReadWriteOnce]` |
+| `persistence.size`          | Size of persistent volume claim            | `8Gi`           |
+
+### Database Parameters
+
+| Parameter                    | Description                               | Default         |
+|------------------------------|-------------------------------------------|-----------------|
+| `mariadb.enabled`            | Deploy MariaDB as dependency              | `true`          |
+| `mariadb.auth.database`      | MariaDB database name                     | `ghost`         |
+| `mariadb.auth.username`      | MariaDB username                          | `ghost`         |
+| `mariadb.auth.password`      | MariaDB password                          | `changeme`      |
+| `mariadb.auth.existingSecret`| Existing secret with MariaDB credentials  | `""`            |
+| `mariadb.auth.allowEmptyRootPassword` | Allow empty root password        | `false`         |
+
+### Pod Parameters
+
+| Parameter                    | Description                               | Default         |
+|------------------------------|-------------------------------------------|-----------------|
+| `resources`                  | Resource limits and requests for pod      | `{}`            |
+| `nodeSelector`               | Node selector for pod assignment          | `{}`            |
+| `tolerations`                | Tolerations for pod assignment            | `[]`            |
+| `affinity`                   | Affinity for pod assignment               | `{}`            |
+| `podSecurityContext.fsGroup` | Set pod's Security Context fsGroup        | `1000`          |
+| `containerSecurityContext.runAsUser` | Set container's Security Context runAsUser | `1000` |
+| `containerSecurityContext.runAsNonRoot` | Run as non-root user           | `true`          |
+| `containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation | `false` |
+
+### Health Check Parameters
+
+| Parameter                            | Description                         | Default         |
+|--------------------------------------|-------------------------------------|-----------------|
+| `livenessProbe.enabled`              | Enable liveness probe               | `true`          |
+| `livenessProbe.type`                 | Probe type (tcpSocket or httpGet)   | `tcpSocket`     |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds               | `30`            |
+| `livenessProbe.periodSeconds`        | Period seconds                      | `10`            |
+| `readinessProbe.enabled`             | Enable readiness probe              | `true`          |
+| `readinessProbe.type`                | Probe type (tcpSocket or httpGet)   | `tcpSocket`     |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds               | `5`             |
+| `readinessProbe.periodSeconds`       | Period seconds                      | `12`            |
+
+### Autoscaling Parameters
+
+| Parameter                               | Description                      | Default         |
+|-----------------------------------------|----------------------------------|-----------------|
+| `autoscaling.enabled`                   | Enable autoscaling               | `false`         |
+| `autoscaling.minReplicas`               | Minimum number of replicas       | `""`            |
+| `autoscaling.maxReplicas`               | Maximum number of replicas       | `""`            |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization      | `""`            |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization| `""`            |
+
+### Additional Configuration
+
+| Parameter           | Description                                       | Default         |
+|---------------------|---------------------------------------------------|-----------------|
+| `extraEnv`          | Additional environment variables                  | `[]`            |
+| `extraVolumes`      | Additional volumes                                | `[]`            |
+| `extraVolumeMounts` | Additional volume mounts                          | `[]`            |
+| `extraObjects`      | Extra Kubernetes objects to deploy                | `[]`            |
+| `config`            | Ghost configuration (database, mail, etc.)        | See values.yaml |
 
 
 ## Example: Custom Ghost Configuration
@@ -165,11 +253,6 @@ config:
   comments:
     url: "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/comments-ui.min.js"
     styles: "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/main.css"
-```
-
-Install with:
-```bash
-helm install my-ghost oci://registry-1.docker.io/cloudpirates/ghost -f my-values.yaml
 ```
 
 

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -138,6 +138,12 @@ The following tables list the configurable parameters of the Ghost chart organiz
 | `readinessProbe.initialDelaySeconds` | Initial delay seconds               | `5`             |
 | `readinessProbe.periodSeconds`       | Period seconds                      | `12`            |
 
+### Init Container Parameters
+
+| Parameter                              | Description                         | Default         |
+|----------------------------------------|-------------------------------------|-----------------|
+| `initContainers.waitForMariadb.image`  | MariaDB init container image        | `mariadb:12.0.2`|
+
 ### Autoscaling Parameters
 
 | Parameter                               | Description                      | Default         |

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -1,0 +1,457 @@
+<p align="center">
+    <a href="https://artifacthub.io/packages/search?repo=cloudpirates-ghost"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudpirates-ghost" /></a>
+</p>
+
+# Ghost
+
+Ghost is a powerful publishing platform that allows you to share your stories with the world.
+
+## Installing the Chart
+
+To install the chart with the release name `my-ghost`:
+
+```bash
+helm install my-ghost oci://registry-1.docker.io/cloudpirates/ghost
+```
+
+```bash
+helm install my-ghost oci://registry-1.docker.io/cloudpirates/ghost
+```
+
+To install with custom values:
+
+```bash
+helm install my-ghost oci://registry-1.docker.io/cloudpirates/ghost -f my-values.yaml
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-ghost` deployment:
+
+```bash
+helm uninstall my-ghost
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Security & Signature Verification
+
+This Helm chart is cryptographically signed with Cosign to ensure authenticity and prevent tampering.
+
+**Public Key:**
+
+```
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7BgqFgKdPtHdXz6OfYBklYwJgGWQ
+mZzYz8qJ9r6QhF3NxK8rD2oG7Bk6nHJz7qWXhQoU2JvJdI3Zx9HGpLfKvw==
+-----END PUBLIC KEY-----
+```
+
+To verify the helm chart before installation, copy the public key to the file `cosign.pub` and run cosign:
+
+```bash
+cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/nginx:<version>
+```
+
+## Common Use Cases
+
+### Custom Container Port (e.g., 8080)
+
+To run Nginx on port 8080 with matching health checks:
+
+```yaml
+# my-values.yaml
+containerPort: 8080
+serverConfig: |
+  server {
+    listen 0.0.0.0:8080;
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    
+    location / {
+      try_files $uri $uri/ /index.html;
+    }
+  }
+livenessProbe:
+  type: httpGet
+  path: /
+readinessProbe:
+  type: httpGet
+  path: /
+```
+
+Then install with:
+```bash
+helm install my-nginx oci://registry-1.docker.io/cloudpirates/nginx -f my-values.yaml
+```
+
+### Multiple Ports Configuration
+
+For advanced setups with multiple ports:
+
+```yaml
+# advanced-values.yaml
+containerPorts:
+  - name: http
+    containerPort: 80
+    protocol: TCP
+  - name: https
+    containerPort: 443
+    protocol: TCP
+service:
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Nginx chart and their default values.
+
+### Global Parameters
+
+| Parameter                 | Description                                     | Default |
+| ------------------------- | ----------------------------------------------- | ------- |
+| `global.imageRegistry`    | Global Docker Image registry                    | `""`    |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`    |
+
+### Common Parameters
+
+| Parameter           | Description                                     | Default |
+| ------------------- | ----------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override nginx.fullname     | `""`    |
+| `fullnameOverride`  | String to fully override nginx.fullname         | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects           | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects      | `{}`    |
+
+
+### Nginx Image Parameters
+
+| Parameter           | Description                                          | Default                                                                            |
+| ------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `image.registry`    | Nginx image registry                                 | `docker.io`                                                                        |
+| `image.repository`  | Nginx image repository                               | `nginx`                                                                            |
+| `image.tag`         | Nginx image tag                                      | `"1.28.0@sha256:24ccf9a6192d2c6c5c4a6e9d2fdfa2a8e382b15f8dd7d0e05a1579f6a46f7776"` |
+| `image.pullPolicy`  | Nginx image pull policy                              | `Always`                                                                           |
+
+
+### Nginx Configuration Parameters
+
+| Parameter             | Description                                               | Default |
+| --------------------- | --------------------------------------------------------- | ------- |
+| `config`              | Custom NGINX configuration file (nginx.conf)              | `""`    |
+| `serverConfig`        | Custom server block to be added to NGINX configuration    | `""`    |
+| `streamServerConfig`  | Custom stream server block to be added to NGINX config    | `""`    |
+
+
+### Container Port Parameters
+
+| Parameter         | Description                                                       | Default |
+| ----------------- | ----------------------------------------------------------------- | ------- |
+| `containerPort`   | Nginx container port                                              | `80`    |
+| `containerPorts`  | Array of container ports (advanced configuration) - see examples | `[]`    |
+
+#### Container Ports Examples
+
+**Single custom port:**
+```yaml
+containerPort: 8080
+```
+
+**Multiple ports (advanced):**
+```yaml
+containerPorts:
+  - name: http
+    containerPort: 80
+    protocol: TCP
+  - name: https
+    containerPort: 443
+    protocol: TCP
+```
+
+
+### Service Parameters
+
+| Parameter        | Description                                                | Default     |
+| ---------------- | ---------------------------------------------------------- | ----------- |
+| `service.type`   | Nginx service type                                         | `ClusterIP` |
+| `service.port`   | Nginx service port                                         | `80`        |
+| `service.ports`  | Array of service ports (advanced configuration) - see examples | `[]`    |
+
+#### Service Ports Examples
+
+**Multiple service ports (advanced):**
+```yaml
+service:
+  ports:
+    - port: 80
+      targetPort: nginx
+      protocol: TCP
+      name: http
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+```
+
+
+### Security Context Parameters
+
+| Parameter                                           | Description                                             | Default |
+| --------------------------------------------------- | ------------------------------------------------------- | ------- |
+| `podSecurityContext.fsGroup`                        | Set Nginx pod's Security Context fsGroup                | `101`   |
+| `containerSecurityContext.runAsUser`                | Set Nginx container's Security Context runAsUser        | `101`   |
+| `containerSecurityContext.runAsNonRoot`             | Set Nginx container's Security Context runAsNonRoot     | `true`  |
+| `containerSecurityContext.allowPrivilegeEscalation` | Set Nginx container's privilege escalation              | `false` |
+
+
+### Resources Parameters
+
+| Parameter   | Description                              | Default |
+| ----------- | ---------------------------------------- | ------- |
+| `resources` | Resource limits and requests for Nginx pod| `{}`    |
+
+
+### Health Check Parameters
+
+| Parameter                            | Description                                   | Default     |
+| ------------------------------------ | --------------------------------------------- | ----------- |
+| `livenessProbe.enabled`              | Enable liveness probe                         | `true`      |
+| `livenessProbe.type`                 | Probe type (tcpSocket or httpGet)             | `tcpSocket` |
+| `livenessProbe.path`                 | Path for HTTP probe (only used when type is httpGet) | `/`     |
+| `livenessProbe.initialDelaySeconds`  | Initial delay before starting probes          | `30`        |
+| `livenessProbe.periodSeconds`        | How often to perform the probe                | `10`        |
+| `livenessProbe.timeoutSeconds`       | Timeout for each probe attempt                | `5`         |
+| `livenessProbe.failureThreshold`     | Number of failures before pod is restarted    | `3`         |
+| `livenessProbe.successThreshold`     | Number of successes to mark probe as successful| `1`        |
+| `readinessProbe.enabled`             | Enable readiness probe                        | `true`      |
+| `readinessProbe.type`                | Probe type (tcpSocket or httpGet)             | `tcpSocket` |
+| `readinessProbe.path`                | Path for HTTP probe (only used when type is httpGet) | `/`     |
+| `readinessProbe.initialDelaySeconds` | Initial delay before starting probes          | `5`         |
+| `readinessProbe.periodSeconds`       | How often to perform the probe                | `5`         |
+| `readinessProbe.timeoutSeconds`      | Timeout for each probe attempt                | `5`         |
+| `readinessProbe.failureThreshold`    | Number of failures before pod is marked unready| `3`        |
+| `readinessProbe.successThreshold`    | Number of successes to mark probe as successful| `1`        |
+
+#### Health Check Examples
+
+**HTTP-based probes for custom port 8080:**
+```yaml
+containerPort: 8080
+livenessProbe:
+  enabled: true
+  type: httpGet
+  path: /health
+readinessProbe:
+  enabled: true
+  type: httpGet
+  path: /ready
+```
+
+**TCP-based probes (default):**
+```yaml
+containerPort: 8080
+livenessProbe:
+  enabled: true
+  type: tcpSocket
+readinessProbe:
+  enabled: true
+  type: tcpSocket
+```
+
+
+### Service Account Parameters
+
+| Parameter                                     | Description                                           | Default |
+| --------------------------------------------- | ----------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a service account should be created | `true`  |
+| `serviceAccount.annotations`                  | Annotations to add to the service account             | `{}`    |
+| `serviceAccount.name`                         | The name of the service account to use                | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Automatically mount service account token             | `false` |
+
+
+### Ingress Parameters
+
+| Parameter             | Description                                                                   | Default                                                                                         |
+| --------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `ingress.enabled`     | Enable ingress record generation                                              | `false`                                                                                         |
+| `ingress.className`   | IngressClass that will be be used to implement the Ingress                    | `""`                                                                                            |
+| `ingress.annotations` | Additional annotations for the Ingress resource                               | `{}`                                                                                            |
+| `ingress.hosts`       | An array with hosts and paths                                                 | `[{{host: "nginx.local", paths: [{{path: "/", pathType: "ImplementationSpecific"}}]}}]`      |
+| `ingress.tls`         | TLS configuration for the Ingress                                             | `[]`                                                                                            |
+
+
+### Extra Configuration Parameters
+
+| Parameter           | Description                                                                         | Default |
+| ------------------- | ----------------------------------------------------------------------------------- | ------- |
+| `extraEnv`          | Additional environment variables to set                                             | `[]`    |
+| `extraVolumes`      | Additional volumes to add to the pod                                                | `[]`    |
+| `extraVolumeMounts` | Additional volume mounts to add to the Nginx container                             | `[]`    |
+| `extraObjects`      | Array of extra objects to deploy with the release                                   | `[]`    |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
+
+### Pod Configuration Parameters
+
+| Parameter        | Description                    | Default |
+| ---------------- | ------------------------------ | ------- |
+| `nodeSelector`   | Node selector for pod assignment| `{}`    |
+| `tolerations`    | Tolerations for pod assignment | `[]`    |
+| `affinity`       | Affinity rules for pod assignment| `{}`  |
+
+## Examples
+
+
+### Basic Installation
+
+Create a `values.yaml` file:
+
+```yaml
+replicaCount: 2
+resources:
+  limits:
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+service:
+  type: ClusterIP
+  port: 8080
+```
+
+Install the chart:
+
+```bash
+helm install my-nginx charts/nginx -f values.yaml
+```
+
+### Custom NGINX Configuration
+
+```yaml
+config: |-
+  user  nginx;
+  worker_processes  1;
+  error_log  /var/log/nginx/error.log warn;
+  pid        /run/nginx.pid;
+  events {
+      worker_connections  1024;
+  }
+  http {
+      include       /etc/nginx/mime.types;
+      default_type  application/octet-stream;
+      log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for"';
+      access_log  /var/log/nginx/access.log  main;
+      sendfile        on;
+      keepalive_timeout  65;
+      include /etc/nginx/conf.d/*.conf;
+  }
+```
+
+### With Service Account
+
+```yaml
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/nginx-role
+```
+
+### Enable Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: nginx.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+```
+
+### Enable Autoscaling
+
+```yaml
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+```
+
+## Troubleshooting
+
+
+### Connection Issues
+
+1. **Check deployment and service status**:
+
+  ```bash
+  kubectl get deployment -l app.kubernetes.io/name=nginx
+  kubectl get svc -l app.kubernetes.io/name=nginx
+  kubectl get pods -l app.kubernetes.io/name=nginx
+  ```
+2. **Check pod logs**:
+
+  ```bash
+  kubectl logs <pod-name>
+  ```
+
+### Performance Tuning
+
+For production workloads, consider:
+
+- Using a dedicated ConfigMap for Nginx configuration
+- Implementing rate limiting and connection throttling
+- Enabling gzip compression for responses
+- Monitoring performance metrics with Prometheus
+
+## Links
+
+- [Nginx Official Documentation](https://nginx.org/)
+- [Nginx Docker Hub](https://hub.docker.com/_/nginx)
+- [Kubernetes Documentation](https://kubernetes.io/docs/)

--- a/charts/ghost/artifacthub-repo.yml
+++ b/charts/ghost/artifacthub-repo.yml
@@ -1,0 +1,1 @@
+repositoryID: TODO

--- a/charts/ghost/config.example.json
+++ b/charts/ghost/config.example.json
@@ -1,0 +1,101 @@
+{
+  "url": "https://example.com",
+  "database": {
+    "client": "mysql",
+    "connection": {
+      "host": "127.0.0.1",
+      "port": 3306,
+      "user": "your_database_user",
+      "password": "your_database_password",
+      "database": "your_database_name"
+    },
+    "pool": {
+      "min": 2,
+      "max": 10
+    }
+  },
+  "mail": {
+    "transport": "SMTP",
+    "options": {
+      "service": "Mailgun",
+      "host": "smtp.mailgun.org",
+      "port": 465,
+      "secure": true,
+      "auth": {
+        "user": "postmaster@example.mailgun.org",
+        "pass": "1234567890"
+      }
+    },
+    "from": "support@example.com"
+  },
+  "admin": {
+    "url": "https://example.com"
+  },
+  "server": {
+    "host": "127.0.0.1",
+    "port": 2368
+  },
+  "privacy": {
+    "useUpdateCheck": false,
+    "useGravatar": false,
+    "useRpcPing": false,
+    "useStructuredData": false
+  },
+  "security": {
+    "staffDeviceVerification": false
+  },
+  "paths": {
+    "contentPath": "content/"
+  },
+  "referrerPolicy": "origin-when-crossorigin",
+  "logging": {
+    "path": "content/logs/",
+    "useLocalTime": true,
+    "level": "info",
+    "rotation": {
+      "enabled": true,
+      "count": 10,
+      "period": "1d"
+    },
+    "transports": ["stdout", "file"]
+  },
+  "caching": {
+    "frontend": { "maxAge": 0 },
+    "contentAPI": { "maxAge": 10 },
+    "robotstxt": { "maxAge": 3600 },
+    "sitemap": { "maxAge": 3600 },
+    "sitemapXSL": { "maxAge": 86400 },
+    "wellKnown": { "maxAge": 86400 },
+    "cors": { "maxAge": 86400 },
+    "publicAssets": { "maxAge": 31536000 },
+    "301": { "maxAge": 31536000 },
+    "customRedirects": { "maxAge": 31536000 }
+  },
+  "compress": true,
+  "imageOptimization": {
+    "resize": false
+  },
+  "storage": {
+    "active": "local-file-store"
+  },
+  "adapters": {
+    "cache": {
+      "imageSizes": {
+        "adapter": "Redis",
+        "ttl": 3600,
+        "keyPrefix": "image-sizes:"
+      }
+    }
+  },
+  "portal": {
+    "url": "https://cdn.jsdelivr.net/npm/@tryghost/portal@~{version}/umd/portal.min.js"
+  },
+  "sodoSearch": {
+    "url": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/sodo-search.min.js",
+    "styles": "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/main.css"
+  },
+  "comments": {
+    "url": "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/comments-ui.min.js",
+    "styles": "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/main.css"
+  }
+}

--- a/charts/ghost/templates/NOTES.txt
+++ b/charts/ghost/templates/NOTES.txt
@@ -1,0 +1,6 @@
+
+{{- if .Values.ingress.enabled }}
+URLS:
+ 1) Website: https://{{ (first .Values.ingress.hosts).host  }}
+ 2) Admin: https://{{ (index .Values.ingress.hosts 1).host }}/ghost
+{{- end }}

--- a/charts/ghost/templates/_helpers.tpl
+++ b/charts/ghost/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ghost.name" -}}
+{{- include "common.name" . -}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "ghost.fullname" -}}
+{{- include "common.fullname" . -}}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ghost.chart" -}}
+{{- include "common.chart" . -}}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ghost.labels" -}}
+{{- include "common.labels" . }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ghost.selectorLabels" -}}
+{{- include "common.selectorLabels" . -}}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "ghost.annotations" -}}
+{{- include "common.annotations" . -}}
+{{- end }}
+
+{{/*
+Return the proper Ghost image name
+*/}}
+{{- define "ghost.image" -}}
+{{- include "common.image" (dict "image" .Values.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "ghost.imagePullSecrets" -}}
+{{ include "common.images.renderPullSecrets" (dict "images" (list .Values.image) "context" .) }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ghost.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ghost.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ghost/templates/configmap.yaml
+++ b/charts/ghost/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   config.production.json: |-
     {
-      "url": {{ .Values.config.url | quote }},
+      "url": {{ printf "https://%s" (first .Values.ingress.hosts).host | quote }},
       "database": {
         "client": {{ .Values.config.database.client | quote }},
         "connection": {
@@ -38,7 +38,7 @@ data:
         "from": {{ .Values.config.mail.from | quote }}
       },
       "admin": {
-        "url": {{ .Values.config.admin.url | quote }}
+        "url": {{ printf "https://%s" (index .Values.ingress.hosts 1).host | quote }}
       },
       "server": {
         "host": {{ .Values.config.server.host | quote }},
@@ -84,18 +84,6 @@ data:
       "imageOptimization": {
         "resize": {{ .Values.config.imageOptimization.resize }}
       },
-      "storage": {
-        "active": {{ .Values.config.storage.active | quote }}
-      },
-      "adapters": {
-        "cache": {
-          "imageSizes": {
-            "adapter": {{ .Values.config.adapters.cache.imageSizes.adapter | quote }},
-            "ttl": {{ .Values.config.adapters.cache.imageSizes.ttl }},
-            "keyPrefix": {{ .Values.config.adapters.cache.imageSizes.keyPrefix | quote }}
-          }
-        }
-      },
       "portal": {
         "url": {{ .Values.config.portal.url | quote }}
       },
@@ -106,5 +94,8 @@ data:
       "comments": {
         "url": {{ .Values.config.comments.url | quote }},
         "styles": {{ .Values.config.comments.styles | quote }}
+      },
+      "enableDeveloperExperiments": {
+        "enableDeveloperExperiments": false
       }
     }

--- a/charts/ghost/templates/configmap.yaml
+++ b/charts/ghost/templates/configmap.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ghost.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+data:
+  config.production.json: |-
+    {
+      "url": {{ .Values.config.url | quote }},
+      "database": {
+        "client": {{ .Values.config.database.client | quote }},
+        "connection": {
+          "host": {{ .Values.config.database.connection.host | quote }},
+          "port": {{ .Values.config.database.connection.port }},
+          "user": {{ .Values.config.database.connection.user | quote }},
+          "password": {{ .Values.config.database.connection.password | quote }},
+          "database": {{ .Values.config.database.connection.database | quote }}
+        },
+        "pool": {
+          "min": {{ .Values.config.database.pool.min }},
+          "max": {{ .Values.config.database.pool.max }}
+        }
+      },
+      "mail": {
+        "transport": {{ .Values.config.mail.transport | quote }},
+        "options": {
+          "service": {{ .Values.config.mail.options.service | quote }},
+          "host": {{ .Values.config.mail.options.host | quote }},
+          "port": {{ .Values.config.mail.options.port }},
+          "secure": {{ .Values.config.mail.options.secure }},
+          "auth": {
+            "user": {{ .Values.config.mail.options.auth.user | quote }},
+            "pass": {{ .Values.config.mail.options.auth.pass | quote }}
+          }
+        },
+        "from": {{ .Values.config.mail.from | quote }}
+      },
+      "admin": {
+        "url": {{ .Values.config.admin.url | quote }}
+      },
+      "server": {
+        "host": {{ .Values.config.server.host | quote }},
+        "port": {{ .Values.config.server.port }}
+      },
+      "privacy": {
+        "useUpdateCheck": {{ .Values.config.privacy.useUpdateCheck }},
+        "useGravatar": {{ .Values.config.privacy.useGravatar }},
+        "useRpcPing": {{ .Values.config.privacy.useRpcPing }},
+        "useStructuredData": {{ .Values.config.privacy.useStructuredData }}
+      },
+      "security": {
+        "staffDeviceVerification": {{ .Values.config.security.staffDeviceVerification }}
+      },
+      "paths": {
+        "contentPath": {{ .Values.config.paths.contentPath | quote }}
+      },
+      "referrerPolicy": {{ .Values.config.referrerPolicy | quote }},
+      "logging": {
+        "path": {{ .Values.config.logging.path | quote }},
+        "useLocalTime": {{ .Values.config.logging.useLocalTime }},
+        "level": {{ .Values.config.logging.level | quote }},
+        "rotation": {
+          "enabled": {{ .Values.config.logging.rotation.enabled }},
+          "count": {{ .Values.config.logging.rotation.count }},
+          "period": {{ .Values.config.logging.rotation.period | quote }}
+        },
+        "transports": {{ .Values.config.logging.transports | toJson }}
+      },
+      "caching": {
+        "frontend": { "maxAge": {{ .Values.config.caching.frontend.maxAge }} },
+        "contentAPI": { "maxAge": {{ .Values.config.caching.contentAPI.maxAge }} },
+        "robotstxt": { "maxAge": {{ .Values.config.caching.robotstxt.maxAge }} },
+        "sitemap": { "maxAge": {{ .Values.config.caching.sitemap.maxAge }} },
+        "sitemapXSL": { "maxAge": {{ .Values.config.caching.sitemapXSL.maxAge }} },
+        "wellKnown": { "maxAge": {{ .Values.config.caching.wellKnown.maxAge }} },
+        "cors": { "maxAge": {{ .Values.config.caching.cors.maxAge }} },
+        "publicAssets": { "maxAge": {{ .Values.config.caching.publicAssets.maxAge }} },
+        "301": { "maxAge": {{ .Values.config.caching.threeHundredOne.maxAge }} },
+        "customRedirects": { "maxAge": {{ .Values.config.caching.customRedirects.maxAge }} }
+      },
+      "compress": {{ .Values.config.compress }},
+      "imageOptimization": {
+        "resize": {{ .Values.config.imageOptimization.resize }}
+      },
+      "storage": {
+        "active": {{ .Values.config.storage.active | quote }}
+      },
+      "adapters": {
+        "cache": {
+          "imageSizes": {
+            "adapter": {{ .Values.config.adapters.cache.imageSizes.adapter | quote }},
+            "ttl": {{ .Values.config.adapters.cache.imageSizes.ttl }},
+            "keyPrefix": {{ .Values.config.adapters.cache.imageSizes.keyPrefix | quote }}
+          }
+        }
+      },
+      "portal": {
+        "url": {{ .Values.config.portal.url | quote }}
+      },
+      "sodoSearch": {
+        "url": {{ .Values.config.sodoSearch.url | quote }},
+        "styles": {{ .Values.config.sodoSearch.styles | quote }}
+      },
+      "comments": {
+        "url": {{ .Values.config.comments.url | quote }},
+        "styles": {{ .Values.config.comments.styles | quote }}
+      }
+    }

--- a/charts/ghost/templates/configmap.yaml
+++ b/charts/ghost/templates/configmap.yaml
@@ -10,6 +10,16 @@ data:
     {
       "url": {{ printf "https://%s" (first .Values.ingress.hosts).host | quote }},
       "database": {
+        {{- if .Values.mariadb.enabled }}
+        "client": "mysql",
+        "connection": {
+          "host": "{{ include "ghost.fullname" . }}-mariadb",
+          "port": {{ .Values.mariadb.service.port }},
+          "user": {{ .Values.mariadb.auth.username | quote }},
+          "password": {{ .Values.mariadb.auth.password | quote }},
+          "database": {{ .Values.mariadb.auth.database | quote }}
+        },
+        {{- else }}
         "client": {{ .Values.config.database.client | quote }},
         "connection": {
           "host": {{ .Values.config.database.connection.host | quote }},
@@ -18,6 +28,7 @@ data:
           "password": {{ .Values.config.database.connection.password | quote }},
           "database": {{ .Values.config.database.connection.database | quote }}
         },
+        {{- end }}
         "pool": {
           "min": {{ .Values.config.database.pool.min }},
           "max": {{ .Values.config.database.pool.max }}

--- a/charts/ghost/templates/configmap.yaml
+++ b/charts/ghost/templates/configmap.yaml
@@ -22,11 +22,11 @@ data:
         {{- else }}
         "client": {{ .Values.config.database.client | quote }},
         "connection": {
-          "host": {{ .Values.config.database.connection.host | quote }},
-          "port": {{ .Values.config.database.connection.port }},
-          "user": {{ .Values.config.database.connection.user | quote }},
-          "password": {{ .Values.config.database.connection.password | quote }},
-          "database": {{ .Values.config.database.connection.database | quote }}
+          "host": {{ .Values.config.database.externalConnection.host | quote }},
+          "port": {{ .Values.config.database.externalConnection.port }},
+          "user": {{ .Values.config.database.externalConnection.user | quote }},
+          "password": {{ .Values.config.database.externalConnection.password | quote }},
+          "database": {{ .Values.config.database.externalConnection.database | quote }}
         },
         {{- end }}
         "pool": {

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -34,6 +34,32 @@ spec:
       serviceAccountName: {{ include "ghost.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.mariadb.enabled }}
+      initContainers:
+        - name: wait-for-mariadb
+          image: "{{ .Values.initContainers.waitForMariadb.image | default "mariadb:12.0.2" }}"
+          command:
+            - sh
+            - -c
+            - >
+              retries=0;
+              max_retries=1500;
+              until [ $retries -ge $max_retries ] || mariadb-admin ping -h {{ include "ghost.fullname" . }}-mariadb 
+              -P {{ .Values.mariadb.service.port }} 
+              -u{{ .Values.mariadb.auth.username }} 
+              -p{{ .Values.mariadb.auth.password }} 
+              --silent; do 
+                retries=$((retries+1));
+                echo "Waiting for MariaDB to become ready... (Attempt: $retries/$max_retries)"; 
+                if [ $retries -ge $max_retries ]; then
+                  echo "Maximum number of retries reached. Exiting.";
+                  exit 1;
+                fi;
+                sleep 2; 
+              done;
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - -c
             - >
               retries=0;
-              max_retries=1500;
+              max_retries=15;
               until [ $retries -ge $max_retries ] || mariadb-admin ping -h {{ include "ghost.fullname" . }}-mariadb 
               -P {{ .Values.mariadb.service.port }} 
               -u{{ .Values.mariadb.auth.username }} 
@@ -65,7 +65,6 @@ spec:
           securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           image: {{ include "ghost.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
-          #command: ['tail', '-f', '/dev/null']
           ports:
             {{- range .Values.containerPorts }}
             - name: {{ .name }}

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -1,0 +1,135 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+  {{- with (include "ghost.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ghost.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ghost.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- with (include "ghost.annotations" .) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- if or .Values.serverConfig .Values.streamServerConfig }}
+        checksum/server-configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+    spec:
+{{- with (include "ghost.imagePullSecrets" .) }}
+{{ . | nindent 6 }}
+{{- end }}
+      serviceAccountName: {{ include "ghost.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          image: {{ include "ghost.image" . | quote }}
+          imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
+          #command: ['tail', '-f', '/dev/null']
+          ports:
+            {{- range .Values.containerPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: {{ .protocol | default "TCP" }}
+            {{- end }}
+          {{- if .Values.extraEnv }}
+          env:
+            {{- range .Values.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- if eq .Values.livenessProbe.type "httpGet" }}
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ (index .Values.containerPorts 0).name }}
+            {{- else }}
+            tcpSocket:
+              port: {{ (index .Values.containerPorts 0).name }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- if eq .Values.readinessProbe.type "httpGet" }}
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ (index .Values.containerPorts 0).name }}
+            {{- else }}
+            tcpSocket:
+              port: {{ (index .Values.containerPorts 0).name }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: emptydir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: data
+              mountPath: /var/lib/ghost/content
+            - name: ghost-config
+              mountPath: /var/lib/ghost/config.production.json
+              subPath: config.production.json
+          {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: emptydir
+          emptyDir: {}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            {{- if .Values.persistence.existingClaim }}
+            claimName: {{ .Values.persistence.existingClaim }}
+            {{- else }}
+            claimName: {{ include "ghost.fullname" . }}
+            {{- end }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: ghost-config
+          configMap:
+            name: {{ include "ghost.fullname" . }}
+            items:
+              - key: config.production.json
+                path: config.production.json
+      {{- if .Values.extraVolumes }}
+      {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/ghost/templates/extraobjects.yaml
+++ b/charts/ghost/templates/extraobjects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/ghost/templates/hpa.yaml
+++ b/charts/ghost/templates/hpa.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ghost.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+  {{- with (include "ghost.annotations" .) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ghost.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/ghost/templates/ingress.yaml
+++ b/charts/ghost/templates/ingress.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "ghost.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ghost/templates/ingress.yaml
+++ b/charts/ghost/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ghost.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := (first .Values.service.ports).port -}}
 {{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
 {{- end }}

--- a/charts/ghost/templates/pvc.yaml
+++ b/charts/ghost/templates/pvc.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ghost.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  {{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/ghost/templates/service.yaml
+++ b/charts/ghost/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range .Values.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: {{ .protocol | default "TCP" }}
+      name: {{ .name }}
+    {{- end }}
+  selector:
+    {{- include "ghost.selectorLabels" . | nindent 4 }}

--- a/charts/ghost/templates/serviceaccount.yaml
+++ b/charts/ghost/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ghost.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/ghost/tests/common-parameters_test.yaml
+++ b/charts/ghost/tests/common-parameters_test.yaml
@@ -1,0 +1,174 @@
+suite: test ghost. common parameters
+templates:
+  - deployment.yaml
+set:
+  image:
+    tag: 1.6.31@sha256:testdigest123
+tests:
+  - it: should use default values when nothing is overridden
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ghost.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: ghost.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/ghost.:1.6.31@sha256:testdigest123
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should respect global.imageRegistry override
+    set:
+      global:
+        imageRegistry: "my-registry.com"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: my-registry.com/ghost.:1.6.31@sha256:testdigest123
+
+  - it: should respect global.imagePullSecrets
+    set:
+      global:
+        imagePullSecrets:
+          - name: my-secret-1
+          - name: my-secret-2
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: my-secret-1
+      - equal:
+          path: spec.template.spec.imagePullSecrets[1].name
+          value: my-secret-2
+
+  - it: should respect nameOverride
+    set:
+      nameOverride: "custom-name"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-custom-name
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: custom-name
+
+  - it: should respect fullnameOverride
+    set:
+      fullnameOverride: "completely-custom-name"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: completely-custom-name
+
+  - it: should add commonLabels to all resources
+    set:
+      commonLabels:
+        environment: "test"
+        team: "platform"
+    asserts:
+      - equal:
+          path: metadata.labels.environment
+          value: test
+      - equal:
+          path: metadata.labels.team
+          value: platform
+
+  - it: should add commonAnnotations to all resources
+    set:
+      commonAnnotations:
+        deployment.kubernetes.io/revision: "1"
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["deployment.kubernetes.io/revision"]
+          value: "1"
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should respect image.registry override
+    set:
+      image:
+        registry: "custom-registry.io"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: custom-registry.io/ghost.:1.6.31@sha256:testdigest123
+
+  - it: should respect image.repository override
+    set:
+      image:
+        repository: "custom/ghost."
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/custom/ghost.:1.6.31@sha256:testdigest123
+
+  - it: should respect image.tag override
+    set:
+      image:
+        tag: "1.6.30@sha256:newdigest123"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/ghost.:1.6.30@sha256:newdigest123
+
+  - it: should respect image.imagePullPolicy override
+    set:
+      image:
+        imagePullPolicy: "IfNotPresent"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should prioritize global.imageRegistry over image.registry
+    set:
+      global:
+        imageRegistry: "global-registry.com"
+      image:
+        registry: "image-registry.com"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: global-registry.com/ghost.:1.6.31@sha256:testdigest123
+
+  - it: should combine all overrides correctly
+    set:
+      global:
+        imageRegistry: "global-reg.io"
+        imagePullSecrets:
+          - name: global-secret
+      nameOverride: "custom-ghost."
+      commonLabels:
+        env: "prod"
+      commonAnnotations:
+        version: "v1.0.0"
+      image:
+        repository: "custom/ghost."
+        tag: "1.6.29@sha256:custom123"
+        imagePullPolicy: "Never"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-custom-ghost.
+      - equal:
+          path: metadata.labels.env
+          value: prod
+      - equal:
+          path: metadata.annotations.version
+          value: v1.0.0
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: global-reg.io/custom/ghost.:1.6.29@sha256:custom123
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: global-secret

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Nginx Helm Chart Values Schema",
+  "description": "Schema for Nginx Helm chart values",
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": { "type": "string" },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": ["string", "object"],
+            "properties": {
+              "name": { "type": "string" }
+            },
+            "required": ["name"]
+          }
+        }
+      }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "commonLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+    "commonAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": { "type": "string" },
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+    "containerPorts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+          "protocol": { "type": "string", "enum": ["TCP", "UDP"], "default": "TCP" }
+        },
+        "required": ["name", "containerPort"]
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+              "targetPort": { "type": "string" },
+              "protocol": { "type": "string", "enum": ["TCP", "UDP"], "default": "TCP" },
+              "name": { "type": "string" }
+            },
+            "required": ["port", "targetPort", "name"]
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": { "type": "string" }
+                  },
+                  "required": ["path", "pathType"]
+                }
+              }
+            },
+            "required": ["host", "paths"]
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": { "type": "array", "items": { "type": "string" } },
+              "secretName": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "name": { "type": "string" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": ["integer", "string"] },
+        "maxReplicas": { "type": ["integer", "string"] },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"] },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+      }
+    },
+    "resources": { "type": "object" },
+    "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+    "tolerations": { "type": "array", "items": { "type": "object" } },
+    "affinity": { "type": "object" },
+    "containerSecurityContext": {
+      "type": "object",
+      "properties": {
+        "runAsUser": { "type": "integer" },
+        "runAsNonRoot": { "type": "boolean" },
+        "allowPrivilegeEscalation": { "type": "boolean" }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "fsGroup": { "type": "integer" }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "type": { "type": "string", "enum": ["tcpSocket", "httpGet"], "default": "tcpSocket" },
+        "path": { "type": "string", "default": "/" },
+        "initialDelaySeconds": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" },
+        "failureThreshold": { "type": "integer" },
+        "successThreshold": { "type": "integer" }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "type": { "type": "string", "enum": ["tcpSocket", "httpGet"], "default": "tcpSocket" },
+        "path": { "type": "string", "default": "/" },
+        "initialDelaySeconds": { "type": "integer" },
+        "periodSeconds": { "type": "integer" },
+        "timeoutSeconds": { "type": "integer" },
+        "failureThreshold": { "type": "integer" },
+        "successThreshold": { "type": "integer" }
+      }
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "value": { "type": "string" }
+        },
+        "required": ["name", "value"]
+      }
+    },
+    "extraVolumes": { "type": "array", "items": { "type": "object" } },
+    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraObjects": { "type": "array", "items": { "type": "object" } },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "existingClaim": { "type": "string" },
+        "storageClass": { "type": "string" },
+        "accessMode": { "type": "string" },
+        "size": { "type": "string" }
+      }
+    }
+  }
+}

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -1,0 +1,309 @@
+## @section Global parameters
+global:
+  ## @param global.imageRegistry Global Docker Image registry
+  imageRegistry: ""
+  ## @param global.imagePullSecrets Global Docker registry secret names as an array
+  imagePullSecrets: []
+
+## @section Common parameters
+## @param nameOverride String to partially override nginx.fullname
+nameOverride: ""
+## @param fullnameOverride String to fully override nginx.fullname
+fullnameOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+commonAnnotations: {}
+
+## @section Nginx image parameters
+image:
+  ## @param image.registry Nginx image registry
+  registry: docker.io
+  ## @param image.repository Nginx image repository
+  repository: ghost
+  ## @param image.tag Nginx image tag
+  tag: "6.0.9@sha256:0476b5029ce6ca0dc6cc0f4b1515a3c7982e28163f0d66fb3c230b0a257b8043"
+  ## @param image.pullPolicy Nginx image pull policy
+  pullPolicy: Always
+
+## @param replicaCount Number of Nginx replicas to deploy
+replicaCount: 1
+
+## @section Container port configuration
+## @param containerPorts Array of container ports
+## Example:
+## containerPorts:
+##   - name: http
+##     containerPort: 80
+##     protocol: TCP
+##   - name: https
+##     containerPort: 443
+##     protocol: TCP
+containerPorts:
+  - name: http
+    containerPort: 80
+    protocol: TCP
+
+service:
+  ## @param service.type Kubernetes service type
+  type: ClusterIP
+  ## @param service.ports Array of service ports
+  ## Example:
+  ## ports:
+  ##   - port: 80
+  ##     targetPort: http
+  ##     protocol: TCP
+  ##     name: http
+  ##   - port: 443
+  ##     targetPort: https
+  ##     protocol: TCP
+  ##     name: https
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+
+## @section Ingress parameters
+ingress:
+  ## @param ingress.enabled Enable ingress record generation
+  enabled: false
+  ## @param ingress.className IngressClass that will be be used to implement the Ingress
+  className: ""
+  ## @param ingress.annotations Additional annotations for the Ingress resource
+  annotations: {}
+  ## @param ingress.hosts An array with hosts and paths
+  hosts:
+    - host: ghost.local
+      paths:
+        - path: /
+          pathType: Prefix
+  ## @param ingress.tls An array with the tls configuration
+  tls: []
+
+## @section Service Account parameters
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  create: true
+  ## @param serviceAccount.annotations Annotations to add to the service account
+  annotations: {}
+  ## @param serviceAccount.name The name of the service account to use
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Automatically mount service account token
+  automountServiceAccountToken: false
+
+
+autoscaling:
+  enabled: false
+  minReplicas: ""
+  maxReplicas: ""
+  targetCPUUtilizationPercentage: ""
+  targetMemoryUtilizationPercentage: ""
+
+## @param resources Resource limits and requests for Nginx pod
+resources:
+  {}
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 64Mi
+
+## @param nodeSelector Node selector for pod assignment
+nodeSelector: {}
+
+## @param tolerations Tolerations for pod assignment
+tolerations: []
+
+## @param affinity Affinity rules for pod assignment
+affinity: {}
+
+containerSecurityContext:
+  ## @param containerSecurityContext.runAsUser User ID to run the container
+  runAsUser: 101
+  ## @param containerSecurityContext.runAsNonRoot Run as non-root user
+  runAsNonRoot: true
+  ## @param containerSecurityContext.allowPrivilegeEscalation Set Nginx container's privilege escalation
+  allowPrivilegeEscalation: false
+
+## @param podSecurityContext Security context for the pod
+podSecurityContext:
+  ## @param podSecurityContext.fsGroup Set Nginx pod's Security Context fsGroup
+  fsGroup: 101
+
+livenessProbe:
+  ## @param livenessProbe.enabled Enable liveness probe
+  enabled: true
+  ## @param livenessProbe.type Probe type (tcpSocket or httpGet)
+  type: tcpSocket
+  ## @param livenessProbe.path Path for HTTP probe (only used when type is httpGet)
+  path: /
+  ## @param livenessProbe.initialDelaySeconds Initial delay before starting probes
+  initialDelaySeconds: 30
+  ## @param livenessProbe.periodSeconds How often to perform the probe
+  periodSeconds: 10
+  ## @param livenessProbe.timeoutSeconds Timeout for each probe attempt
+  timeoutSeconds: 5
+  ## @param livenessProbe.failureThreshold Number of failures before pod is restarted
+  failureThreshold: 3
+  ## @param livenessProbe.successThreshold Number of successes to mark probe as successful
+  successThreshold: 1
+
+readinessProbe:
+  ## @param readinessProbe.enabled Enable readiness probe
+  enabled: true
+  ## @param readinessProbe.type Probe type (tcpSocket or httpGet)
+  type: tcpSocket
+  ## @param readinessProbe.path Path for HTTP probe (only used when type is httpGet)
+  path: /
+  ## @param readinessProbe.initialDelaySeconds Initial delay before starting probes
+  initialDelaySeconds: 5
+  ## @param readinessProbe.periodSeconds How often to perform the probe
+  periodSeconds: 5
+  ## @param readinessProbe.timeoutSeconds Timeout for each probe attempt
+  timeoutSeconds: 5
+  ## @param readinessProbe.failureThreshold Number of failures before pod is marked unready
+  failureThreshold: 3
+  ## @param readinessProbe.successThreshold Number of successes to mark probe as successful
+  successThreshold: 1
+
+## @param extraEnv Additional environment variables to set
+extraEnv: []
+# - name: EXTRA_VAR
+#   value: "extra_value"
+
+## @param extraVolumes Additional volumes to add to the pod
+extraVolumes: []
+
+## @param extraVolumeMounts Additional volume mounts to add to the Nginx container
+extraVolumeMounts: []
+
+## @param extraObjects Array of extra objects to deploy with the release
+extraObjects: []
+
+config:
+  url: "https://example.com"
+  database:
+    client: "mysql"
+    connection:
+      host: "ghost-mariadb"
+      port: 3306
+      user: &db-user "ghost"
+      password: &db-password "ghost"
+      database: &db-database "changeme"
+    pool:
+      min: 2
+      max: 10
+  mail:
+    transport: "SMTP"
+    options:
+      service: "Mailgun"
+      host: "smtp.mailgun.org"
+      port: 465
+      secure: true
+      auth:
+        user: "postmaster@example.mailgun.org"
+        pass: "1234567890"
+    from: "support@example.com"
+  admin:
+    url: "https://example.com"
+  server:
+    host: "127.0.0.1"
+    port: 2368
+  privacy:
+    useUpdateCheck: false
+    useGravatar: false
+    useRpcPing: false
+    useStructuredData: false
+  security:
+    staffDeviceVerification: false
+  paths:
+    contentPath: "content/"
+  referrerPolicy: "origin-when-crossorigin"
+  logging:
+    path: "content/logs/"
+    useLocalTime: true
+    level: "info"
+    rotation:
+      enabled: true
+      count: 10
+      period: "1d"
+    transports:
+      - "stdout"
+      - "file"
+  caching:
+    frontend:
+      maxAge: 0
+    contentAPI:
+      maxAge: 10
+    robotstxt:
+      maxAge: 3600
+    sitemap:
+      maxAge: 3600
+    sitemapXSL:
+      maxAge: 86400
+    wellKnown:
+      maxAge: 86400
+    cors:
+      maxAge: 86400
+    publicAssets:
+      maxAge: 31536000
+    threeHundredOne:
+      maxAge: 31536000
+    customRedirects:
+      maxAge: 31536000
+  compress: true
+  imageOptimization:
+    resize: false
+  storage:
+    active: "local-file-store"
+  adapters:
+    cache:
+      imageSizes:
+        adapter: "Redis"
+        ttl: 3600
+        keyPrefix: "image-sizes:"
+  portal:
+    url: "https://cdn.jsdelivr.net/npm/@tryghost/portal@~{version}/umd/portal.min.js"
+  sodoSearch:
+    url: "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/sodo-search.min.js"
+    styles: "https://cdn.jsdelivr.net/npm/@tryghost/sodo-search@~{version}/umd/main.css"
+  comments:
+    url: "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/comments-ui.min.js"
+    styles: "https://cdn.jsdelivr.net/npm/@tryghost/comments-ui@~{version}/umd/main.css"
+
+persistence:
+  ## @param persistence.enabled Enable persistence using PVC
+  enabled: true
+  ## @param persistence.annotations Annotations to add to the PVC
+  annotations: {}
+  ## @param persistence.existingClaim Use an existing PVC by specifying its name
+  existingClaim: ""
+  ## @param persistence.storageClass Storage class of backing PVC
+  ## If defined as "-", it will use the default storage class
+  storageClass: ""
+  ## @param persistence.accessMode Access mode of the PVC
+  accessModes:
+  - ReadWriteOnce
+  ## @param persistence.size Size of persistent volume claim
+  size: 8Gi
+
+mariadb:
+  ## @param mariadb.enabled Enable MariaDB database deployment (default)
+  enabled: true
+
+  auth:
+    ## @param mariadb.auth.database MariaDB custom database
+    database: *db-database
+    ## @param mariadb.auth.username MariaDB custom user name
+    username: *db-user
+    ## @param mariadb.auth.password MariaDB custom user password
+    password: *db-password
+    ## @param mariadb.auth.existingSecret Name of existing secret to use for MariaDB credentials
+    existingSecret: ""
+    ## @param mariadb.auth.allowEmptyRootPassword Allow the root user of MariaDB to have no password set
+    allowEmptyRootPassword: false

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -41,7 +41,7 @@ replicaCount: 1
 ##     protocol: TCP
 containerPorts:
   - name: http
-    containerPort: 80
+    containerPort: 2368
     protocol: TCP
 
 service:
@@ -67,14 +67,18 @@ service:
 ## @section Ingress parameters
 ingress:
   ## @param ingress.enabled Enable ingress record generation
-  enabled: false
+  enabled: true
   ## @param ingress.className IngressClass that will be be used to implement the Ingress
   className: ""
   ## @param ingress.annotations Additional annotations for the Ingress resource
   annotations: {}
   ## @param ingress.hosts An array with hosts and paths
   hosts:
-    - host: ghost.local
+    - host: ghost.localhost
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: admin.ghost.localhost
       paths:
         - path: /
           pathType: Prefix
@@ -124,7 +128,7 @@ affinity: {}
 
 containerSecurityContext:
   ## @param containerSecurityContext.runAsUser User ID to run the container
-  runAsUser: 101
+  runAsUser: 1000
   ## @param containerSecurityContext.runAsNonRoot Run as non-root user
   runAsNonRoot: true
   ## @param containerSecurityContext.allowPrivilegeEscalation Set Nginx container's privilege escalation
@@ -133,7 +137,7 @@ containerSecurityContext:
 ## @param podSecurityContext Security context for the pod
 podSecurityContext:
   ## @param podSecurityContext.fsGroup Set Nginx pod's Security Context fsGroup
-  fsGroup: 101
+  fsGroup: 1000
 
 livenessProbe:
   ## @param livenessProbe.enabled Enable liveness probe
@@ -163,11 +167,11 @@ readinessProbe:
   ## @param readinessProbe.initialDelaySeconds Initial delay before starting probes
   initialDelaySeconds: 5
   ## @param readinessProbe.periodSeconds How often to perform the probe
-  periodSeconds: 5
+  periodSeconds: 12
   ## @param readinessProbe.timeoutSeconds Timeout for each probe attempt
   timeoutSeconds: 5
   ## @param readinessProbe.failureThreshold Number of failures before pod is marked unready
-  failureThreshold: 3
+  failureThreshold: 12
   ## @param readinessProbe.successThreshold Number of successes to mark probe as successful
   successThreshold: 1
 
@@ -186,15 +190,14 @@ extraVolumeMounts: []
 extraObjects: []
 
 config:
-  url: "https://example.com"
   database:
     client: "mysql"
     connection:
       host: "ghost-mariadb"
       port: 3306
       user: &db-user "ghost"
-      password: &db-password "ghost"
-      database: &db-database "changeme"
+      password: &db-password "changeme"
+      database: &db-database "ghost"
     pool:
       min: 2
       max: 10
@@ -209,10 +212,8 @@ config:
         user: "postmaster@example.mailgun.org"
         pass: "1234567890"
     from: "support@example.com"
-  admin:
-    url: "https://example.com"
   server:
-    host: "127.0.0.1"
+    host: "0.0.0.0"
     port: 2368
   privacy:
     useUpdateCheck: false

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -167,11 +167,11 @@ readinessProbe:
   ## @param readinessProbe.initialDelaySeconds Initial delay before starting probes
   initialDelaySeconds: 5
   ## @param readinessProbe.periodSeconds How often to perform the probe
-  periodSeconds: 12
+  periodSeconds: 5
   ## @param readinessProbe.timeoutSeconds Timeout for each probe attempt
   timeoutSeconds: 5
   ## @param readinessProbe.failureThreshold Number of failures before pod is marked unready
-  failureThreshold: 12
+  failureThreshold: 3
   ## @param readinessProbe.successThreshold Number of successes to mark probe as successful
   successThreshold: 1
 
@@ -188,6 +188,13 @@ extraVolumeMounts: []
 
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []
+
+## @section Init Container Configuration
+## Configuration for init containers
+initContainers:
+  ## @param initContainers.waitForMariadb.image MariaDB init container image for waiting
+  waitForMariadb:
+    image: "mariadb:12.0.2@sha256:8a061ef9813cf960f94a262930a32b190c3fbe5c8d3ab58456ef1df4b90fd5dc"
 
 config:
   database:
@@ -308,3 +315,6 @@ mariadb:
     existingSecret: ""
     ## @param mariadb.auth.allowEmptyRootPassword Allow the root user of MariaDB to have no password set
     allowEmptyRootPassword: false
+
+  service:
+    port: 3306

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -199,12 +199,12 @@ initContainers:
 config:
   database:
     client: "mysql"
-    connection:
-      host: "ghost-mariadb"
+    externalConnection:
+      host: "my-external-db"
       port: 3306
-      user: &db-user "ghost"
-      password: &db-password "changeme"
-      database: &db-database "ghost"
+      user: "ghost"
+      password: "changeme"
+      database: "ghost"
     pool:
       min: 2
       max: 10
@@ -306,11 +306,11 @@ mariadb:
 
   auth:
     ## @param mariadb.auth.database MariaDB custom database
-    database: *db-database
+    database: ghost
     ## @param mariadb.auth.username MariaDB custom user name
-    username: *db-user
+    username: ghost
     ## @param mariadb.auth.password MariaDB custom user password
-    password: *db-password
+    password: changeme
     ## @param mariadb.auth.existingSecret Name of existing secret to use for MariaDB credentials
     existingSecret: ""
     ## @param mariadb.auth.allowEmptyRootPassword Allow the root user of MariaDB to have no password set

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -80,7 +80,7 @@ ingress:
           pathType: Prefix
     - host: admin.ghost.localhost
       paths:
-        - path: /
+        - path: /ghost
           pathType: Prefix
   ## @param ingress.tls An array with the tls configuration
   tls: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

This chart adds the ghost helm chart, similar to [Bitnamis Ghost helm chart ](https://github.com/bitnami/charts/tree/main/bitnami/ghost) 

It uses the cloudpirates mariadb chart as a default option for the DB. But it is possible to use an external Database. 

<img width="1098" height="542" alt="image" src="https://github.com/user-attachments/assets/ce4744b0-4512-46ac-9a30-fd9ab7a3caca" />


### Benefits

Just another nail for Bitnami's coffin 😄 

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
- Needs an icon and a artefacts.io ID

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
