### PR TITLE
[keycloak] add readme documentation and values.schema.json

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -1,0 +1,581 @@
+<p align="center">
+    <a href="https://artifacthub.io/packages/search?repo=cloudpirates-keycloak"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudpirates-keycloak" /></a>
+</p>
+
+# Keycloak
+
+A Helm chart for Keycloak - Open Source Identity and Access Management Solution. Keycloak provides user federation, strong authentication, user management, fine-grained authorization, and more. It supports modern standards like OpenID Connect, OAuth 2.0, and SAML.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure (if persistence is enabled)
+
+## Installing the Chart
+
+To install the chart with the release name `my-keycloak`:
+
+```bash
+helm install my-keycloak oci://registry-1.docker.io/cloudpirates/keycloak
+```
+
+Or install directly from the local chart:
+
+```bash
+helm install my-keycloak ./charts/keycloak
+```
+
+The command deploys Keycloak on the Kubernetes cluster in the default configuration. The [Configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-keycloak` deployment:
+
+```bash
+helm uninstall my-keycloak
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Security & Signature Verification
+
+This Helm chart is cryptographically signed with Cosign to ensure authenticity and prevent tampering.
+
+**Public Key:**
+
+```
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7BgqFgKdPtHdXz6OfYBklYwJgGWQ
+mZzYz8qJ9r6QhF3NxK8rD2oG7Bk6nHJz7qWXhQoU2JvJdI3Zx9HGpLfKvw==
+-----END PUBLIC KEY-----
+```
+
+To verify the helm chart before installation, copy the public key to the file `cosign.pub` and run cosign:
+
+```bash
+cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/keycloak:<version>
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the Keycloak chart and their default values.
+
+### Global parameters
+
+| Parameter                 | Description                                     | Default |
+| ------------------------- | ----------------------------------------------- | ------- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`    |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`    |
+
+### Common parameters
+
+| Parameter           | Description                                    | Default |
+| ------------------- | ---------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override keycloak.fullname | `""`    |
+| `fullnameOverride`  | String to fully override keycloak.fullname     | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects          | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects     | `{}`    |
+
+### Keycloak image configuration
+
+| Parameter               | Description                                         | Default                                                                            |
+| ----------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `image.registry`        | Keycloak image registry                             | `docker.io`                                                                        |
+| `image.repository`      | Keycloak image repository                           | `keycloak/keycloak`                                                                |
+| `image.tag`             | Keycloak image tag (immutable tags are recommended) | `"26.3.4@sha256:2b32a51a31e8d780d9fa9a69a59ead69975263c61b5dd13559090e22aa26f100"` |
+| `image.imagePullPolicy` | Keycloak image pull policy                          | `Always`                                                                           |
+
+### Deployment configuration
+
+| Parameter      | Description                           | Default |
+| -------------- | ------------------------------------- | ------- |
+| `replicaCount` | Number of Keycloak replicas to deploy | `1`     |
+
+### Pod annotations and labels
+
+| Parameter        | Description                           | Default |
+| ---------------- | ------------------------------------- | ------- |
+| `podAnnotations` | Map of annotations to add to the pods | `{}`    |
+| `podLabels`      | Map of labels to add to the pods      | `{}`    |
+
+### Security
+
+| Parameter                                  | Description                                       | Default   |
+| ------------------------------------------ | ------------------------------------------------- | --------- |
+| `podSecurityContext.fsGroup`               | Group ID for the volumes of the pod               | `1001`    |
+| `securityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
+| `securityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
+| `securityContext.runAsUser`                | User ID for the Keycloak container                | `1001`    |
+| `securityContext.runAsGroup`               | Group ID for the Keycloak container               | `1001`    |
+| `securityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `false`   |
+| `securityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
+
+### Keycloak Configuration
+
+| Parameter                              | Description                                                   | Default            |
+| -------------------------------------- | ------------------------------------------------------------- | ------------------ |
+| `keycloak.adminUser`                   | Keycloak admin username                                       | `admin`            |
+| `keycloak.adminPassword`               | Keycloak admin password                                       | `""`               |
+| `keycloak.existingSecret`              | Name of existing secret to use for Keycloak admin credentials | `""`               |
+| `keycloak.secretKeys.adminPasswordKey` | Secret key for admin credentials                              | `"admin-password"` |
+| `keycloak.hostname`                    | Keycloak hostname                                             | `""`               |
+| `keycloak.hostnameAdmin`               | Keycloak admin hostname                                       | `""`               |
+| `keycloak.hostnameStrict`              | Enable strict hostname resolution                             | `false`            |
+| `keycloak.hostnameBackchannel`         | Keycloak backchannel hostname                                 | `""`               |
+| `keycloak.httpEnabled`                 | Enable HTTP listener                                          | `true`             |
+| `keycloak.httpPort`                    | HTTP port                                                     | `8080`             |
+| `keycloak.httpsPort`                   | HTTPS port                                                    | `8443`             |
+| `keycloak.proxy`                       | Proxy mode (edge, reencrypt, passthrough, none)               | `none`             |
+| `keycloak.production`                  | Enable production mode                                        | `false`            |
+
+### Database Configuration
+
+| Parameter                         | Description                                                                                                            | Default         |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `database.type`                   | Database type (postgres, mysql, mariadb). Note: H2 databases are not supported due to readonly filesystem restrictions | `postgres`      |
+| `database.host`                   | Database host (only used when not using embedded database)                                                             | `""`            |
+| `database.port`                   | Database port (only used when not using embedded database, defaults: postgres=5432, mysql/mariadb=3306)                | `""`            |
+| `database.name`                   | Database name (only used when not using embedded database)                                                             | `keycloak`      |
+| `database.username`               | Database username (only used when not using embedded database)                                                         | `keycloak`      |
+| `database.password`               | Database password (only used when not using embedded database)                                                         | `""`            |
+| `database.existingSecret`         | Name of existing secret for database credentials (only used when not using embedded database)                          | `""`            |
+| `database.secretKeys.passwordKey` | Name of key in existing secret for database password                                                                   | `"db-password"` |
+| `database.secretKeys.usernameKey` | Name of key in existing secret for database username                                                                   | `"db-username"` |
+| `database.jdbcParams`             | Additional JDBC parameters                                                                                             | `""`            |
+
+### Cache Configuration
+
+| Parameter          | Description                        | Default |
+| ------------------ | ---------------------------------- | ------- |
+| `cache.stack`      | Cache stack (local, ispn, default) | `local` |
+| `cache.configFile` | Custom cache configuration file    | `""`    |
+
+### Features Configuration
+
+| Parameter           | Description               | Default |
+| ------------------- | ------------------------- | ------- |
+| `features.enabled`  | List of enabled features  | `[]`    |
+| `features.disabled` | List of disabled features | `[]`    |
+
+### Service configuration
+
+| Parameter                 | Description                   | Default     |
+| ------------------------- | ----------------------------- | ----------- |
+| `service.type`            | Keycloak service type         | `ClusterIP` |
+| `service.httpPort`        | Keycloak HTTP service port    | `8080`      |
+| `service.httpsPort`       | Keycloak HTTPS service port   | `8443`      |
+| `service.httpTargetPort`  | Keycloak HTTP container port  | `8080`      |
+| `service.httpsTargetPort` | Keycloak HTTPS container port | `8443`      |
+| `service.annotations`     | Service annotations           | `{}`        |
+
+### Ingress configuration
+
+| Parameter                            | Description                                             | Default          |
+| ------------------------------------ | ------------------------------------------------------- | ---------------- |
+| `ingress.enabled`                    | Enable ingress record generation for Keycloak           | `false`          |
+| `ingress.className`                  | IngressClass that will be used to implement the Ingress | `""`             |
+| `ingress.annotations`                | Additional annotations for the Ingress resource         | `{}`             |
+| `ingress.hosts[0].host`              | Hostname for Keycloak ingress                           | `keycloak.local` |
+| `ingress.hosts[0].paths[0].path`     | Path for Keycloak ingress                               | `/`              |
+| `ingress.hosts[0].paths[0].pathType` | Path type for Keycloak ingress                          | `Prefix`         |
+| `ingress.tls`                        | TLS configuration for Keycloak ingress                  | `[]`             |
+
+### Resources
+
+| Parameter   | Description                                 | Default |
+| ----------- | ------------------------------------------- | ------- |
+| `resources` | The resources to allocate for the container | `{}`    |
+
+### Persistence
+
+| Parameter                   | Description                                        | Default             |
+| --------------------------- | -------------------------------------------------- | ------------------- |
+| `persistence.enabled`       | Enable persistence using Persistent Volume Claims  | `false`             |
+| `persistence.storageClass`  | Persistent Volume storage class                    | `""`                |
+| `persistence.annotations`   | Persistent Volume Claim annotations                | `{}`                |
+| `persistence.size`          | Persistent Volume size                             | `1Gi`               |
+| `persistence.accessModes`   | Persistent Volume access modes                     | `["ReadWriteOnce"]` |
+| `persistence.existingClaim` | The name of an existing PVC to use for persistence | `""`                |
+
+### Liveness and readiness probes
+
+| Parameter                            | Description                                  | Default |
+| ------------------------------------ | -------------------------------------------- | ------- |
+| `livenessProbe.enabled`              | Enable livenessProbe on Keycloak containers  | `true`  |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe      | `60`    |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe             | `30`    |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe            | `5`     |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe          | `3`     |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe          | `1`     |
+| `readinessProbe.enabled`             | Enable readinessProbe on Keycloak containers | `true`  |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe     | `30`    |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe            | `10`    |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe           | `5`     |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe         | `3`     |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe         | `1`     |
+| `startupProbe.enabled`               | Enable startupProbe on Keycloak containers   | `true`  |
+| `startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe       | `30`    |
+| `startupProbe.periodSeconds`         | Period seconds for startupProbe              | `10`    |
+| `startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe             | `5`     |
+| `startupProbe.failureThreshold`      | Failure threshold for startupProbe           | `60`    |
+| `startupProbe.successThreshold`      | Success threshold for startupProbe           | `1`     |
+
+### Node Selection
+
+| Parameter      | Description                          | Default |
+| -------------- | ------------------------------------ | ------- |
+| `nodeSelector` | Node labels for pod assignment       | `{}`    |
+| `tolerations`  | Toleration labels for pod assignment | `[]`    |
+| `affinity`     | Affinity settings for pod assignment | `{}`    |
+
+### Service Account
+
+| Parameter                                     | Description                                                                                                               | Default |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a service account should be created                                                                     | `false` |
+| `serviceAccount.annotations`                  | Annotations to add to the service account                                                                                 | `{}`    |
+| `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Whether to automount the SA token inside the pod                                                                          | `false` |
+
+### Extra Environment
+
+| Parameter  | Description                                           | Default |
+| ---------- | ----------------------------------------------------- | ------- |
+| `extraEnv` | Additional environment variables from key-value pairs | `{}`    |
+
+### Extra Configuration Parameters
+
+| Parameter      | Description                                       | Default |
+| -------------- | ------------------------------------------------- | ------- |
+| `extraObjects` | Array of extra objects to deploy with the release | `[]`    |
+
+### Init Container Configuration
+
+| Parameter                              | Description                                 | Default                                                                                  |
+| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `initContainers.waitForPostgres.image` | PostgreSQL init container image for waiting | `postgres:17.6@sha256:feff5b24fedd610975a1f5e743c51a4b360437f4dc3a11acf740dcd708f413f6`  |
+| `initContainers.waitForMariadb.image`  | MariaDB init container image for waiting    | `mariadb:12.0.2@sha256:8a061ef9813cf960f94a262930a32b190c3fbe5c8d3ab58456ef1df4b90fd5dc` |
+
+### PostgreSQL Configuration
+
+| Parameter                | Description                                                   | Default      |
+| ------------------------ | ------------------------------------------------------------- | ------------ |
+| `postgres.enabled`       | Enable embedded PostgreSQL database                           | `true`       |
+| `postgres.auth.database` | PostgreSQL database name                                      | `"keycloak"` |
+| `postgres.auth.username` | PostgreSQL database user (leave empty for default 'postgres') | `""`         |
+| `postgres.auth.password` | PostgreSQL database password                                  | `""`         |
+
+### MariaDB Configuration
+
+| Parameter                   | Description                                       | Default      |
+| --------------------------- | ------------------------------------------------- | ------------ |
+| `mariadb.enabled`           | Enable embedded PostgreSQL database               | `false`       |
+| `mariadb.auth.database`     | MariaDB database name                             | `"keycloak"` |
+| `mariadb.auth.username`     | MariaDB database user (leave empty for root user) | `""`         |
+| `mariadb.auth.password`     | MariaDB database password                         | `""`         |
+| `mariadb.auth.rootPassword` | MariaDB root password                             | `""`         |
+
+#### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
+## Examples
+
+### Basic Deployment
+
+Deploy Keycloak with default configuration:
+
+```bash
+helm install my-keycloak ./charts/keycloak
+```
+
+### Production Setup with External Database
+
+```yaml
+# values-production.yaml
+keycloak:
+  adminPassword: "secure-admin-password"
+  hostname: "auth.yourdomain.com"
+  production: true
+  proxy: "edge"
+
+database:
+  type: "postgres"
+  host: "postgres.database.svc.cluster.local"
+  port: "5432"
+  name: "keycloak"
+  username: "keycloak"
+  password: "secure-db-password"
+
+# Disable embedded databases
+postgres:
+  enabled: false
+mariadb:
+  enabled: false
+
+resources:
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+  hosts:
+    - host: auth.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: keycloak-tls
+      hosts:
+        - auth.yourdomain.com
+```
+
+Deploy with production values:
+
+```bash
+helm install my-keycloak ./charts/keycloak -f values-production.yaml
+```
+
+### Development Setup with Embedded Database
+
+```yaml
+# values-development.yaml
+keycloak:
+  adminPassword: "admin"
+  httpEnabled: true
+  production: false
+
+postgres:
+  enabled: true
+  auth:
+    database: "keycloak"
+    password: "keycloak-db-password"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: keycloak.local
+      paths:
+        - path: /
+          pathType: Prefix
+
+persistence:
+  enabled: true
+  size: 5Gi
+```
+
+### Using Existing Secrets for Authentication
+
+```yaml
+# values-external-secret.yaml
+keycloak:
+  existingSecret: "keycloak-credentials"
+  secretKeys:
+    adminPasswordKey: "admin-password"
+
+database:
+  type: "postgres"
+  host: "postgres.database.svc.cluster.local"
+  existingSecret: "keycloak-db-credentials"
+  secretKeys:
+    passwordKey: "db-password"
+    usernameKey: "db-username"
+
+# Disable embedded databases
+postgres:
+  enabled: false
+mariadb:
+  enabled: false
+```
+
+Create the secrets first:
+
+```bash
+kubectl create secret generic keycloak-credentials \
+  --from-literal=admin-password=your-admin-password
+
+kubectl create secret generic keycloak-db-credentials \
+  --from-literal=db-password=your-db-password \
+  --from-literal=db-username=keycloak
+```
+
+### High Availability Setup
+
+```yaml
+# values-ha.yaml
+replicaCount: 3
+
+keycloak:
+  adminPassword: "secure-admin-password"
+  hostname: "auth.yourdomain.com"
+  production: true
+  proxy: "edge"
+
+cache:
+  stack: "ispn" # Use Infinispan for clustering
+
+database:
+  type: "postgres"
+  host: "postgres-ha.database.svc.cluster.local"
+  name: "keycloak"
+  username: "keycloak"
+  password: "secure-db-password"
+
+# Disable embedded databases
+postgres:
+  enabled: false
+mariadb:
+  enabled: false
+
+resources:
+  requests:
+    memory: "2Gi"
+    cpu: "1000m"
+  limits:
+    memory: "4Gi"
+    cpu: "2000m"
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - keycloak
+          topologyKey: kubernetes.io/hostname
+```
+
+## Access Keycloak
+
+### Via kubectl port-forward
+
+```bash
+kubectl port-forward service/my-keycloak 8080:8080
+```
+
+### Connect using browser
+
+Navigate to `http://localhost:8080` and log in with the admin credentials.
+
+### Default Credentials
+
+- **Admin User**: `admin` (configurable)
+- **Admin Password**: Auto-generated (check secret) or configured value
+
+Get the auto-generated admin password:
+
+```bash
+kubectl get secret my-keycloak -o jsonpath="{.data.admin-password}" | base64 --decode
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Pod fails to start with database connection errors**
+
+   - Verify database connection parameters
+   - Ensure the database is running and accessible
+   - Check database credentials in secrets
+   - Review pod logs: `kubectl logs <pod-name>`
+
+2. **Cannot access Keycloak via ingress**
+
+   - Verify ingress configuration and annotations
+   - Check if ingress controller is installed
+   - Ensure DNS resolves to the correct IP
+   - Check TLS certificate configuration
+
+3. **Admin login fails**
+
+   - Verify admin password in the secret
+   - Check if the admin user exists in the database
+   - Review Keycloak logs for authentication errors
+
+4. **Database initialization fails**
+   - Ensure database schema permissions are correct
+   - Check if the database already exists and is empty
+   - Verify database connection and credentials
+   - Review init container logs
+
+### Performance Tuning
+
+1. **Memory Configuration**
+
+   ```yaml
+   resources:
+     requests:
+       memory: "2Gi"
+       cpu: "1000m"
+     limits:
+       memory: "4Gi"
+       cpu: "2000m"
+   ```
+
+2. **JVM Settings (via extraEnv)**
+
+   ```yaml
+   extraEnv:
+     JAVA_OPTS: "-Xms1024m -Xmx2048m -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=512m"
+   ```
+
+3. **Database Connection Pool**
+   ```yaml
+   database:
+     jdbcParams: "?prepStmtCacheSize=250&prepStmtCacheSqlLimit=2048"
+   ```
+
+### Getting Support
+
+For issues related to this Helm chart, please check:
+
+- [Keycloak Documentation](https://www.keycloak.org/documentation)
+- [Keycloak Server Administration Guide](https://www.keycloak.org/docs/latest/server_admin/)
+- [Kubernetes Documentation](https://kubernetes.io/docs/)
+- Chart repository issues

--- a/charts/keycloak/tests/common-parameters_test.yaml
+++ b/charts/keycloak/tests/common-parameters_test.yaml
@@ -149,7 +149,7 @@ tests:
       postgres:
         enabled: false
       database:
-        type: dev-mem
+        type: postgres
     asserts:
       - isKind:
           of: Secret

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -1,0 +1,631 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": {
+          "type": "string",
+          "description": "Global Docker Image registry"
+        },
+        "imagePullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Global Docker registry secret names as an array"
+        }
+      }
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "String to partially override keycloak.fullname"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "String to fully override keycloak.fullname"
+    },
+    "commonLabels": {
+      "type": "object",
+      "description": "Labels to add to all deployed objects"
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to all deployed objects"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "Keycloak image registry"
+        },
+        "repository": {
+          "type": "string",
+          "description": "Keycloak image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Keycloak image tag (immutable tags are recommended)"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Keycloak image pull policy"
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of Keycloak replicas to deploy"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Map of annotations to add to the pods"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Map of labels to add to the pods"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "fsGroup": {
+          "type": "integer",
+          "description": "Group ID for the volumes of the pod"
+        }
+      }
+    },
+    "securityContext": {
+      "type": "object",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "description": "Enable container privilege escalation"
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "description": "Configure the container to run as a non-root user"
+        },
+        "runAsUser": {
+          "type": "integer",
+          "description": "User ID for the Keycloak container"
+        },
+        "runAsGroup": {
+          "type": "integer",
+          "description": "Group ID for the Keycloak container"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "description": "Mount container root filesystem as read-only"
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Linux capabilities to be dropped"
+            }
+          }
+        }
+      }
+    },
+    "keycloak": {
+      "type": "object",
+      "properties": {
+        "adminUser": {
+          "type": "string",
+          "description": "Keycloak admin username"
+        },
+        "adminPassword": {
+          "type": "string",
+          "description": "Keycloak admin password"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Name of existing secret to use for Keycloak admin credentials"
+        },
+        "secretKeys": {
+          "type": "object",
+          "properties": {
+            "adminPasswordKey": {
+              "type": "string",
+              "description": "Secret key for admin password"
+            }
+          }
+        },
+        "hostname": {
+          "type": "string",
+          "description": "Keycloak hostname"
+        },
+        "hostnameAdmin": {
+          "type": "string",
+          "description": "Keycloak admin hostname"
+        },
+        "hostnameStrict": {
+          "type": "boolean",
+          "description": "Enable strict hostname resolution"
+        },
+        "hostnameBackchannel": {
+          "type": "string",
+          "description": "Keycloak backchannel hostname"
+        },
+        "httpEnabled": {
+          "type": "boolean",
+          "description": "Enable HTTP listener"
+        },
+        "httpPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "HTTP port"
+        },
+        "httpsPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "HTTPS port"
+        },
+        "proxy": {
+          "type": "string",
+          "enum": ["edge", "reencrypt", "passthrough", "none"],
+          "description": "Proxy mode (edge, reencrypt, passthrough, none)"
+        },
+        "production": {
+          "type": "boolean",
+          "description": "Enable production mode"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["postgres", "mysql", "mariadb"],
+          "description": "Database type (postgres, mysql, mariadb)"
+        },
+        "host": {
+          "type": "string",
+          "description": "Database host (only used when not using embedded database)"
+        },
+        "port": {
+          "type": "string",
+          "description": "Database port (only used when not using embedded database)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Database name (only used when not using embedded database)"
+        },
+        "username": {
+          "type": "string",
+          "description": "Database username (only used when not using embedded database)"
+        },
+        "password": {
+          "type": "string",
+          "description": "Database password (only used when not using embedded database)"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Name of existing secret for database credentials"
+        },
+        "secretKeys": {
+          "type": "object",
+          "properties": {
+            "passwordKey": {
+              "type": "string",
+              "description": "Secret key for database password"
+            },
+            "usernameKey": {
+              "type": "string",
+              "description": "Secret key for database username"
+            }
+          }
+        },
+        "jdbcParams": {
+          "type": "string",
+          "description": "Additional JDBC parameters"
+        }
+      }
+    },
+    "cache": {
+      "type": "object",
+      "properties": {
+        "stack": {
+          "type": "string",
+          "enum": ["local", "ispn", "default"],
+          "description": "Cache stack (local, ispn, default)"
+        },
+        "configFile": {
+          "type": "string",
+          "description": "Custom cache configuration file"
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of enabled features"
+        },
+        "disabled": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of disabled features"
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"],
+          "description": "Keycloak service type"
+        },
+        "httpPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Keycloak HTTP service port"
+        },
+        "httpsPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Keycloak HTTPS service port"
+        },
+        "httpTargetPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Keycloak HTTP container port"
+        },
+        "httpsTargetPort": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Keycloak HTTPS container port"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Service annotations"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress record generation for Keycloak"
+        },
+        "className": {
+          "type": "string",
+          "description": "IngressClass that will be used to implement the Ingress"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Additional annotations for the Ingress resource"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Hostname for Keycloak ingress"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string",
+                      "description": "Path for Keycloak ingress"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Exact", "Prefix", "ImplementationSpecific"],
+                      "description": "Path type for Keycloak ingress"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "description": "TLS configuration for Keycloak ingress"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource limits and requests for the container"
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable persistence using Persistent Volume Claims"
+        },
+        "storageClass": {
+          "type": "string",
+          "description": "Persistent Volume storage class"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Persistent Volume Claim annotations"
+        },
+        "size": {
+          "type": "string",
+          "description": "Persistent Volume size"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]
+          },
+          "description": "Persistent Volume access modes"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "The name of an existing PVC to use for persistence"
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable livenessProbe on Keycloak containers"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Initial delay seconds for livenessProbe"
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Period seconds for livenessProbe"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Timeout seconds for livenessProbe"
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Failure threshold for livenessProbe"
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Success threshold for livenessProbe"
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable readinessProbe on Keycloak containers"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Initial delay seconds for readinessProbe"
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Period seconds for readinessProbe"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Timeout seconds for readinessProbe"
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Failure threshold for readinessProbe"
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Success threshold for readinessProbe"
+        }
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable startupProbe on Keycloak containers"
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Initial delay seconds for startupProbe"
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Period seconds for startupProbe"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Timeout seconds for startupProbe"
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Failure threshold for startupProbe"
+        },
+        "successThreshold": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Success threshold for startupProbe"
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node labels for pod assignment"
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Toleration labels for pod assignment"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity settings for pod assignment"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Whether to automount the SA token inside the pod"
+        }
+      }
+    },
+    "extraEnv": {
+      "type": "object",
+      "description": "Additional environment variables from key-value pairs"
+    },
+    "extraObjects": {
+      "type": "array",
+      "description": "Array of extra objects to deploy with the release"
+    },
+    "initContainers": {
+      "type": "object",
+      "properties": {
+        "waitForPostgres": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "string",
+              "description": "PostgreSQL init container image for waiting"
+            }
+          }
+        },
+        "waitForMariadb": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "string",
+              "description": "MariaDB init container image for waiting"
+            }
+          }
+        }
+      }
+    },
+    "postgres": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable embedded PostgreSQL database"
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "database": {
+              "type": "string",
+              "description": "PostgreSQL database name"
+            },
+            "username": {
+              "type": "string",
+              "description": "PostgreSQL database user (leave empty for default 'postgres')"
+            },
+            "password": {
+              "type": "string",
+              "description": "PostgreSQL database password"
+            }
+          }
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable embedded MariaDB database (set to false when using postgres)"
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "database": {
+              "type": "string",
+              "description": "MariaDB database name"
+            },
+            "username": {
+              "type": "string",
+              "description": "MariaDB database user (leave empty for root user)"
+            },
+            "password": {
+              "type": "string",
+              "description": "MariaDB database password"
+            },
+            "rootPassword": {
+              "type": "string",
+              "description": "MariaDB root password"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description of the change

Adds documentation for keycloak helm-chart. Also values.schema.json

### Benefits

Readme for a quick overview of the keycloak chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
