### PR TITLE
[keycloak] Fix resolving template expressions in extraobjects

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/extraobjects.yaml
+++ b/charts/keycloak/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{ . | toYaml }}
+{{- include "common.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -546,7 +546,12 @@
     },
     "extraObjects": {
       "type": "array",
-      "description": "Array of extra objects to deploy with the release"
+      "title": "Extra Objects",
+      "description": "A list of additional Kubernetes objects to deploy alongside the release. Helm templating is supported in any field, but all template expressions must be quoted. Each item should be a valid Kubernetes manifest object.",
+      "items": {
+        "type": "object",
+        "description": "A Kubernetes manifest object. All fields are allowed."
+      }
     },
     "initContainers": {
       "type": "object",


### PR DESCRIPTION
### Description of the change

Use the same template for extraobjects as in the other charts and update the schema accordingly.

### Benefits

Template expressions can be used in extraobjects.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
