### PR TITLE
[redis] fix requirepass for sentinels when password is set

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "8.2.1"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -325,6 +325,7 @@ spec:
               sentinel parallel-syncs {{ .Values.sentinel.masterName }} {{ .Values.sentinel.parallelSyncs }}
               {{- if .Values.auth.enabled }}
               sentinel auth-pass {{ .Values.sentinel.masterName }} "${REDIS_PASSWORD}"
+              requirepass "${REDIS_PASSWORD}"
               {{- end }}
               # Make automatic failover more aggressive for Kubernetes force deletions
               sentinel deny-scripts-reconfig yes


### PR DESCRIPTION

### Description of the change

If password is enabled for redis, also redis-cli for sentinel should respect it. Currently it is not required, even if password is set:

* For values:

```
architecture: replication
sentinel:
  enabled: true
auth:
  enabled: true
  password: password
replicaCount: 3

```

* inside of the container:

```
# Inside of sentinel container
redis@my-release-redis-0:/data$ redis-cli -p 26379
127.0.0.1:26379> acl list
1) "user default on nopass sanitize-payload ~* &* +@all"
127.0.0.1:26379>
```

### Benefits

This adds the password to the sentinels, so it is required when set:

```yaml
redis@redis-1:/data$ redis-cli -p 26379
127.0.0.1:26379> acl list
(error) NOAUTH Authentication required.
127.0.0.1:26379> auth password
OK
127.0.0.1:26379> acl list
1) "user default on sanitize-payload #<hash> ~* &* +@all"
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
