### PR TITLE
[mongodb] add custom user creation at initialization

### DIFF
--- a/charts/mongodb/CHANGELOG.md
+++ b/charts/mongodb/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.1.9 (2025-09-16)
+## 0.2.0 (2025-09-24)
 
-* [mongo] chore(deps): update docker.io/mongo:8.0.13 Docker digest to cf340b1 ([#98](https://github.com/CloudPirates-io/helm-charts/pull/98))
+* [mongodb] add custom user creation at initialization ([#153](https://github.com/CloudPirates-io/helm-charts/pull/153))

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.1.9
+version: 0.2.0
 appVersion: "8.0.13"
 keywords:
   - mongodb

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -101,6 +101,16 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | `auth.existingSecretPasswordKey` | Key in existing secret containing MongoDB password                  | `""`    |
 | `config`                         | MongoDB configuration options                                       | `{}`    |
 
+### Custom User Configuration
+| Parameter                   | Description                                                                        | Default                                  |
+| --------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------- |
+| `customUser`                | Optional user to be created at initialisation with a custom password and database  | `{}`                                     |
+| `customUser.name`           | Name of the custom user to be created                                              | `""`                                     |
+| `customUser.database`       | Name of the database to be created                                                 | `""`                                     |
+| `customUser.password`       | Password to be used for the custom user                                            | `""`                                     |
+| `customUser.existingSecret` | Existing secret, in which username, password and database name are saved           | `""`                                     |
+| `customUser.secretKeys`     | Name of keys in existing secret to use the custom user name, password and database | `{name: "", database: "", password: ""}` |
+
 ### Persistence Parameters
 
 | Parameter                  | Description                                | Default         |

--- a/charts/mongodb/templates/custom-user-script.yaml
+++ b/charts/mongodb/templates/custom-user-script.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.customUser (or .Values.customUser.name .Values.customUser.existingSecret) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mongodb.fullname" . }}-custom-user-script
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+data:
+  custom-user.sh: |
+    #!/bin/sh
+    set -e
+    mongosh --eval "db.getSiblingDB(\"$MONGO_INITDB_DATABASE\").createUser({user: \"$MONGO_CUSTOM_USERNAME\", pwd: \"$MONGO_CUSTOM_USER_PASSWORD\", roles: [ \"readWrite\", \"dbAdmin\" ]})"
+{{- end }}

--- a/charts/mongodb/templates/custom-user-secret.yaml
+++ b/charts/mongodb/templates/custom-user-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.customUser .Values.customUser.name (not .Values.customUser.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mongodb.fullname" . }}-custom-user-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- include "mongodb.annotations" . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  CUSTOM_DB: {{ .Values.customUser.database | default .Values.customUser.name | b64enc | quote }}
+  CUSTOM_USER: {{ .Values.customUser.name | b64enc | quote }}
+  CUSTOM_PASSWORD: {{ .Values.customUser.password | default (randAlphaNum 32) | b64enc | quote }}
+{{- end }}

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -48,6 +48,47 @@ spec:
                   name: {{ include "mongodb.secretName" . }}
                   key: {{ include "mongodb.secretPasswordKey" . }}
             {{- end }}
+            {{- if and .Values.customUser (or .Values.customUser.name .Values.customUser.existingSecret) }}
+            - name: MONGO_CUSTOM_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.customUser.existingSecret }}
+                  name: {{ .Values.customUser.existingSecret }}
+                  {{- else }}
+                  name: {{ include "mongodb.fullname" . }}-custom-user-secret
+                  {{- end }}
+                  {{- if and .Values.customUser.secretKeys .Values.customUser.secretKeys.name }}
+                  key: {{ .Values.customUser.secretKeys.name }}
+                  {{- else }}
+                  key: CUSTOM_USER
+                  {{- end }}
+            - name: MONGO_CUSTOM_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.customUser.existingSecret }}
+                  name: {{ .Values.customUser.existingSecret }}
+                  {{- else }}
+                  name: {{ include "mongodb.fullname" . }}-custom-user-secret
+                  {{- end }}
+                  {{- if and .Values.customUser.secretKeys .Values.customUser.secretKeys.password }}
+                  key: {{ .Values.customUser.secretKeys.password }}
+                  {{- else }}
+                  key: CUSTOM_PASSWORD
+                  {{- end }}
+            - name: MONGO_INITDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.customUser.existingSecret }}
+                  name: {{ .Values.customUser.existingSecret }}
+                  {{- else }}
+                  name: {{ include "mongodb.fullname" . }}-custom-user-secret
+                  {{- end }}
+                  {{- if and .Values.customUser.secretKeys .Values.customUser.secretKeys.database }}
+                  key: {{ .Values.customUser.secretKeys.database }}
+                  {{- else }}
+                  key: CUSTOM_DB
+                  {{- end }}
+            {{- end }}
             {{- range .Values.extraEnv }}
             - name: {{ .name }}
               value: {{ .value | quote }}
@@ -82,6 +123,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- if and .Values.customUser (or .Values.customUser.name .Values.customUser.existingSecret) }}
+            - name: custom-user-script
+              mountPath: /docker-entrypoint-initdb.d/
+            {{- end }}
             {{- if or .Values.config.content .Values.config.existingConfigmap }}
             - name: config
               mountPath: /etc/mongo
@@ -93,6 +138,11 @@ spec:
         {{- if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
+        {{- if and .Values.customUser (or .Values.customUser.name .Values.customUser.existingSecret) }}
+        - name: custom-user-script
+          configMap:
+            name: mongodb-custom-user-script
         {{- end }}
         {{- if or .Values.config.content .Values.config.existingConfigmap }}
         - name: config

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -54,7 +54,7 @@ config:
   ## @param config.content Include your custom MongoDB configurations here as string
   content: |
     systemLog:
-      quiet: false
+      quiet: true
       verbosity: 0
     net:
       bindIpAll: true
@@ -62,6 +62,22 @@ config:
   existingConfigmap: ""
   ## param config.existingConfigmapKey Name of the key in the Configmap that should be used
   existingConfigmapKey: ""
+
+## @section customUser Optional user to be created at initialisation with a custom password and database
+customUser: {}
+  ## @param customUser.name Name of the custom user to be created
+  # name: ""
+  ## @param customUser.database Name of the database to be created
+  # database: ""
+  ## @param customUser.password Password to be used for the custom user
+  # password: ""
+  ## @param customUser.existingSecret Existing secret, in which username, password and database name are saved
+  # existingSecret: ""
+  ## @param customUser.secretKeys Name of keys in existing secret to use the custom user name, password and database
+  # secretKeys:
+  #   name: ""
+  #   password: ""
+  #   database: ""
 
 persistence:
   ## @param persistence.enabled Enable persistent storage
@@ -137,8 +153,6 @@ readinessProbe:
 
 ## @param extraEnv Additional environment variables to set
 extraEnv: []
-# - name: EXTRA_VAR
-#   value: "extra_value"
 
 ## @param extraVolumes Additional volumes to add to the pod
 extraVolumes: []


### PR DESCRIPTION
### Description of the change

Adds support to create a custom user at initialization. 

### Benefits

Create a custom user for a new database with the initialization. Takes away a few manual steps to use this chart. 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
