### PR TITLE
[redis] return fqdn for sentinel master lookup

### DIFF
--- a/charts/mongodb/CHANGELOG.md
+++ b/charts/mongodb/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.2.0 (2025-09-24)
+## 0.2.0 (2025-09-25)
 
-* [mongodb] add custom user creation at initialization ([#153](https://github.com/CloudPirates-io/helm-charts/pull/153))
+* [redis] return fqdn for sentinel master lookup ([#156](https://github.com/CloudPirates-io/helm-charts/pull/156))

--- a/charts/redis/CHANGELOG.md
+++ b/charts/redis/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.4.5 (2025-09-24)
+## 0.4.6 (2025-09-25)
 
-* [redis] fix requirepass for sentinels when password is set ([#152](https://github.com/CloudPirates-io/helm-charts/pull/152))
+* [redis] return fqdn for sentinel master lookup ([#156](https://github.com/CloudPirates-io/helm-charts/pull/156))

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: "8.2.1"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -296,7 +296,7 @@ spec:
               if [ "$SENTINEL_FOUND_MASTER" = false ]; then
                 echo "No Sentinels available, checking Redis instances directly..."
                 for i in $(seq 0 $(({{ if eq .Values.architecture "standalone" }}1{{ else }}{{ .Values.replicaCount }}{{ end }} - 1))); do
-                  REDIS_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless"
+                  REDIS_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local"
                   ROLE_INFO=$(redis-cli -h "${REDIS_HOST}" -p {{ .Values.service.port }} {{- if .Values.auth.enabled }} -a "${REDIS_PASSWORD}"{{- end }} info replication 2>/dev/null | grep "role:master" || echo "")
                   if [ -n "$ROLE_INFO" ]; then
                     MASTER_HOST="$REDIS_HOST"
@@ -308,7 +308,7 @@ spec:
 
               # Final fallback: Use pod-0 hostname for initial bootstrap only
               if [ -z "$MASTER_HOST" ]; then
-                MASTER_HOST="{{ include "redis.fullname" . }}-0.{{ include "redis.fullname" . }}-headless"
+                MASTER_HOST="{{ include "redis.fullname" . }}-0.{{ include "redis.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local"
                 echo "No existing master found, using pod-0 for initial bootstrap: $MASTER_HOST"
               fi
 


### PR DESCRIPTION
### Description of the change

Use fqdn for redis master to avoid problems when reaching sentinels from other namespaces:

* currently only the shortened dns is returned:

```yaml
redis-cli -u redis://redis-sentinel.redis:26379
redis-sentinel.redis:26379> sentinel get-master-addr-by-name mymaster
1) "redis-0.redis-headless"
2) "6379"
```

* this works from the same namespace, but from other namespaces we have to use the extended one:

```terminal
 nslookup redis-0.redis-headless
Server:         10.100.0.10
Address:        10.100.0.10#53

** server can't find redis-0.redis-headless: NXDOMAIN
```

* using extended one works:
```terminal
 nslookup redis-0.redis-headless.redis
Server:         10.100.0.10
Address:        10.100.0.10#53

Name:   redis-0.redis-headless.redis.svc.cluster.local
Address: 172.24.22.44
;; Got recursion not available from 10.100.0.10

```

### Benefits

fqdn will be returned, and the master address will work from all namespaces:

```yaml
redis-sentinel.redis:26379> sentinel get-master-addr-by-name mymaster
1) "redis-0.redis-headless.redis.svc.cluster.local"
2) "6379"
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
