### PR TITLE
[Postgres] support custom pg_hba.conf

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: "17.6"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -70,12 +70,12 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 
 ### PostgreSQL image configuration
 
-| Parameter            | Description                                  | Default                                                                        |
-| -------------------- | -------------------------------------------- | ------------------------------------------------------------------------------ |
-| `image.registry`     | PostgreSQL image registry                    | `docker.io`                                                                    |
-| `image.repository`   | PostgreSQL image repository                  | `postgres`                                                                     |
-| `image.tag`          | PostgreSQL image tag (immutable tags are recommended) | `"17.6@sha256:feff5b24fedd610975a1f5e743c51a4b360437f4dc3a11acf740dcd708f413f6"` |
-| `image.imagePullPolicy` | PostgreSQL image pull policy              | `Always`                                                                       |
+| Parameter               | Description                                           | Default                                                                          |
+| ----------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `image.registry`        | PostgreSQL image registry                             | `docker.io`                                                                      |
+| `image.repository`      | PostgreSQL image repository                           | `postgres`                                                                       |
+| `image.tag`             | PostgreSQL image tag (immutable tags are recommended) | `"17.6@sha256:feff5b24fedd610975a1f5e743c51a4b360437f4dc3a11acf740dcd708f413f6"` |
+| `image.imagePullPolicy` | PostgreSQL image pull policy                          | `Always`                                                                         |
 
 ### Deployment configuration
 
@@ -108,13 +108,13 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 
 ### PostgreSQL Authentication
 
-| Parameter                                | Description                                                                           | Default                  |
-| ---------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------ |
-| `auth.username`                          | Name for a custom superuser to create at initialisation. (This will also create a database with the same name)                                                      | `"openfga"`             |
-| `auth.password`                          | Password for the custom user to create                                                | `""`                     |
-| `auth.database`                          | Alternative name for the default database to be created at initialisation                                                  | `""`                     |
-| `auth.existingSecret`                    | Name of existing secret to use for PostgreSQL credentials                             | `""`                     |
-| `auth.secretKeys.passwordKey`       | Name of key in existing secret to use for PostgreSQL credentials                      | `"postgres-password"`    |
+| Parameter                     | Description                                                                                                    | Default               |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `auth.username`               | Name for a custom superuser to create at initialisation. (This will also create a database with the same name) | `"openfga"`           |
+| `auth.password`               | Password for the custom user to create                                                                         | `""`                  |
+| `auth.database`               | Alternative name for the default database to be created at initialisation                                      | `""`                  |
+| `auth.existingSecret`         | Name of existing secret to use for PostgreSQL credentials                                                      | `""`                  |
+| `auth.secretKeys.passwordKey` | Name of key in existing secret to use for PostgreSQL credentials                                               | `"postgres-password"` |
 
 ### PostgreSQL Configuration
 
@@ -133,24 +133,25 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `config.postgresqlLogMinDurationStatement`    | Sets the minimum execution time above which statements will be logged                   | `""`    |
 | `config.extraConfig`                          | Additional PostgreSQL configuration parameters                                          | `[]`    |
 | `config.existingConfigmap`                    | Name of existing ConfigMap with PostgreSQL configuration                                | `""`    |
+| `config.pgHbaConfig`                          | Content of a custom pg_hba.conf file to be used instead of the default config           | `""`    |
 
 ### Custom User Configuration
-| Parameter                                     | Description                                                                             | Default |
-| --------------------------------------------- | --------------------------------------------------------------------------------------- | ------- |
-| `customUser`     | Optional user to be created at initialisation with a custom password and database                                         | `{}`    |
-| `customUser.name`     | Name of the custom user to be created                                        | `""`    |
-| `customUser.database`     | Name of the database to be created                                        | `""`    |
-| `customUser.password`     | Password to be used for the custom user                                        | `""`    |
-| `customUser.existingSecret`     | Existing secret, in which username, password and database name are saved           | `""`    |
-| `customUser.secretKeys`     | Name of keys in existing secret to use the custom user name, password and database           | `{name: "", database: "", password: ""}`    |
+| Parameter                   | Description                                                                        | Default                                  |
+| --------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------- |
+| `customUser`                | Optional user to be created at initialisation with a custom password and database  | `{}`                                     |
+| `customUser.name`           | Name of the custom user to be created                                              | `""`                                     |
+| `customUser.database`       | Name of the database to be created                                                 | `""`                                     |
+| `customUser.password`       | Password to be used for the custom user                                            | `""`                                     |
+| `customUser.existingSecret` | Existing secret, in which username, password and database name are saved           | `""`                                     |
+| `customUser.secretKeys`     | Name of keys in existing secret to use the custom user name, password and database | `{name: "", database: "", password: ""}` |
 
 ### PostgreSQL Initdb Configuration
 
-| Parameter                 | Description                                                                   | Default |
-| ------------------------- | ----------------------------------------------------------------------------- | ------- |
+| Parameter                 | Description                                                                      | Default |
+| ------------------------- | -------------------------------------------------------------------------------- | ------- |
 | `initdb.args`             | Send arguments to postgres initdb. This is a space separated string of arguments | `""`    |
-| `initdb.scripts`          | Dictionary of initdb scripts                                                   | `{}`    |
-| `initdb.scriptsConfigMap` | ConfigMap with scripts to be run at first boot                                | `""`    |
+| `initdb.scripts`          | Dictionary of initdb scripts                                                     | `{}`    |
+| `initdb.scriptsConfigMap` | ConfigMap with scripts to be run at first boot                                   | `""`    |
 
 ### Service configuration
 
@@ -193,7 +194,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 ### Persistent Volume Claim Retention Policy
 
 | Parameter                                          | Description                                                                    | Default    |
-| -------------------------------------------------- | ------------------------------------------------------------------------------ | -----------|
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | ---------- |
 | `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for the Statefulset                  | `false`    |
 | `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `"Retain"` |
 | `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `"Retain"` |
@@ -246,10 +247,10 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 
 ### Extra Configuration Parameters
 
-| Parameter            | Description                                                            | Default   |
-|----------------------|------------------------------------------------------------------------|-----------|
-| `extraObjects`       | Array of extra objects to deploy with the release                      | `[]`      |
-| `extraEnvVarsSecret` | Name of an existing Secret containing additional environment variables | ``        |
+| Parameter            | Description                                                            | Default |
+| -------------------- | ---------------------------------------------------------------------- | ------- |
+| `extraObjects`       | Array of extra objects to deploy with the release                      | `[]`    |
+| `extraEnvVarsSecret` | Name of an existing Secret containing additional environment variables | ``      |
 
 #### Extra Objects
 

--- a/charts/postgres/templates/configmap.yaml
+++ b/charts/postgres/templates/configmap.yaml
@@ -11,6 +11,10 @@ metadata:
     {{- include "postgres.annotations" . | nindent 4 }}
   {{- end }}
 data:
+  {{- if .Values.config.pgHbaConfig }}
+  pg_hba.conf: |
+{{ .Values.config.pgHbaConfig | indent 4 }}
+  {{- end }}
   postgresql.conf: |
     # PostgreSQL configuration file
     
@@ -99,6 +103,11 @@ data:
     lc_time = 'en_US.utf8'
     default_text_search_config = 'pg_catalog.english'
     
+    {{ if .Values.config.pgHbaConfig }}
+    # Set custom pg_hba.conf file to use
+    hba_file = '{{ include "postgres.configDir" . }}/pg_hba.conf'
+    {{- end }}
+
     # Additional Configuration
     {{- range .Values.config.extraConfig }}
     {{ . }}

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -42,6 +42,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "postgres.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          args:
+            - -c
+            - 'config_file={{ include "postgres.configDir" . }}/postgresql.conf'
           env:
             - name: PGDATA
               value: {{ include "postgres.dataDir" . }}/pgdata

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -99,6 +99,8 @@ config:
   extraConfig: []
   ## @param config.existingConfigmap Name of existing ConfigMap with PostgreSQL configuration
   existingConfigmap: ""
+  ## @param config.pgHbaConfig Content of a custom pg_hba.conf file to be used instead of the default config
+  pgHbaConfig: ""
 
 ## @section customUser Optional user to be created at initialisation with a custom password and database
 customUser: {}


### PR DESCRIPTION
### Description of the change

Adds another config file that will be mounted and used to overwrite the pg_hba configuration. 

### Benefits

Configuration of the postgres authentication directly in the helm-chart.

### Possible drawbacks

Using the custom hba config overwrites the default configuration completely and the default values will no longe be used in the deployed postgresql server.

### Applicable issues

- fixes #140 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
