### PR TITLE
[keycloak] add support for extra env vars from an existing secret

### DIFF
--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.0.0
 - name: postgres
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 0.3.0
+  version: 0.5.2
 - name: mariadb
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.2.7
-digest: sha256:bccee500d13542983b6457429aaf672ad1459d3dfd0dd5638ce5a1e126f19de6
-generated: "2025-09-16T14:57:21.446014+02:00"
+digest: sha256:58c0f4427699c161ee51d1b1f92323b1ec6ac3f9bcf29ab4df842e12a614c7da
+generated: "2025-09-25T11:46:09.5087928+02:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -240,9 +240,10 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Extra Environment
 
-| Parameter  | Description                                           | Default |
-| ---------- | ----------------------------------------------------- | ------- |
-| `extraEnv` | Additional environment variables from key-value pairs | `{}`    |
+| Parameter  | Description                                                            | Default |
+| ---------- |------------------------------------------------------------------------| ----- |
+| `extraEnv` | Additional environment variables from key-value pairs                  | `{}`  |
+| `extraEnvVarsSecret` | Name of an existing secret containing additional environment variables | ``    |
 
 ### Extra Configuration Parameters
 

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -141,6 +141,11 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- if .Values.extraEnvVarsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.keycloak.httpPort }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -544,6 +544,11 @@
       "type": "object",
       "description": "Additional environment variables from key-value pairs"
     },
+    "extraEnvVarsSecret": {
+      "type": "string",
+      "title": "Extra Environment Secret",
+      "description": "Name of an existing Secret containing additional environment variables"
+    },
     "extraObjects": {
       "type": "array",
       "title": "Extra Objects",

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -266,6 +266,9 @@ extraEnv: {}
 # VARNAME1: value1
 # VARNAME2: value2
 
+## @param extraEnvVarsSecret Name of a secret containing additional environment variables
+extraEnvVarsSecret: ""
+
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change
Support for adding extra environment variables from an existing secret to the keycloak container.

### Benefits
For example, it can be used for providing credentials in an init or migration script.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
