### PR TITLE
[postgres]: Fix invalid data dir path on postgres 18

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.5.4
-appVersion: "17.6"
+version: 0.6.0
+appVersion: "18.0"
 keywords:
   - postgres
   - postgresql

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
             - 'config_file={{ include "postgres.configDir" . }}/postgresql.conf'
           env:
             - name: PGDATA
-              value: {{ include "postgres.dataDir" . }}/pgdata
+              value: {{ include "postgres.pgdataPath" . }}
             {{- if .Values.initdb.args }}
             - name: POSTGRES_INITDB_ARGS
               value: {{ .Values.initdb.args | quote }}

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -22,7 +22,7 @@ image:
   ## @param image.repository PostgreSQL image repository
   repository: postgres
   ## @param image.tag PostgreSQL image tag (immutable tags are recommended)
-  tag: "17.6@sha256:0b6428e8c09651398137d2b3308a6ad87e73ac15fc38729891c16d942e947d3d"
+  tag: "18.0@sha256:9685e09573f19eeb99d259547a1cb7a7a77cd15877f55f51e215ad06edf5c721"
   ## @param image.imagePullPolicy PostgreSQL image pull policy
   imagePullPolicy: Always
 


### PR DESCRIPTION
### Description of the change

Dynamically get the correct path per major version of Postgres

### Benefits

Actually get ready on Postgres 18 and not crash

### Possible drawbacks

/

### Applicable issues

- fixes #164 

### Additional information



### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
