### PR TITLE
[zookeeper] #170 fix for command whitelist

### DIFF
--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -76,6 +76,11 @@ zkCli.sh -server my-zookeeper:2181
 | `zookeeperConfig.commandsWhitelist` | 4-letter word commands whitelist | `srvr` |
 | `zookeeperConfig.autopurge.purgeInterval` | Autopurge purge interval (hours) | `24` |
 | `zookeeperConfig.autopurge.snapRetainCount` | Autopurge snapshot retain count | `3` |
+| `zookeeperConfig.admin.enableServer` | Enable the admin server | `"false"` |
+| `zookeeperConfig.admin.serverPort` | Admin server port | `8080` |
+| `zookeeperConfig.admin.serverAddress` | Admin server address | `0.0.0.0` |
+| `zookeeperConfig.admin.idleTimeout` | Admin server connection idle timeout (milliseconds) | `30000` |
+| `zookeeperConfig.admin.commandUrl` | Admin server command URL | `/commands` |
 
 ### Metrics
 

--- a/charts/zookeeper/templates/configmap.yaml
+++ b/charts/zookeeper/templates/configmap.yaml
@@ -15,8 +15,14 @@ data:
     electionPortBindRetry={{ .Values.zookeeperConfig.electionPortBindRetry | default 10 }}
     maxClientCnxns={{ .Values.zookeeperConfig.maxClientCnxns | default 60 }}
     #standaloneEnabled={{ .Values.zookeeperConfig.standaloneEnabled | default "false" }}
-    adminServerEnabled={{ .Values.zookeeperConfig.adminServerEnabled | default "false" }}
-    commandsWhitelist={{ .Values.zookeeperConfig.commandsWhitelist | default "srvr" }}
+    {{- if eq .Values.zookeeperConfig.admin.enableServer "true" }}
+    admin.enableServer={{ .Values.zookeeperConfig.admin.enableServer | default "false" }}
+    admin.serverPort={{ .Values.zookeeperConfig.admin.serverPort | default 8080 }}
+    admin.serverAddress={{ .Values.zookeeperConfig.admin.serverAddress | default "0.0.0.0" }}
+    admin.idleTimeout={{ .Values.zookeeperConfig.admin.idleTimeout | default 30000 }}
+    admin.commandUrl={{ .Values.zookeeperConfig.admin.commandUrl | default "/commands" }}
+    {{- end }}
+    4lw.commands.whitelist={{ .Values.zookeeperConfig.commandsWhitelist | default "srvr" }}
     autopurge.purgeInterval={{ .Values.zookeeperConfig.autopurge.purgeInterval | default 24 }}
     autopurge.snapRetainCount={{ .Values.zookeeperConfig.autopurge.snapRetainCount | default 3 }}
     quorumListenOnAllIPs=true

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -67,6 +67,18 @@ zookeeperConfig:
     purgeInterval: 24
     ## @param zookeeperConfig.autopurge.snapRetainCount Zookeeper autopurge snapshot retain count
     snapRetainCount: 3
+  admin:
+    ## @param zookeeperConfig.admin.enableServer Enable Zookeeper Admin server
+    enableServer: "false"
+    ## @param zookeeperConfig.admin.serverPort Zookeeper Admin server port
+    serverPort: 8080
+    ## @param zookeeperConfig.admin.serverAddress Zookeeper Admin server address
+    serverAddress: "0.0.0.0"
+    ## @param zookeeperConfig.admin.idleTimeout Zookeeper Admin server connection idle timeout (in milliseconds)
+    idleTimeout: 30000
+    ## @param zookeeperConfig.admin.commandUrl Zookeeper Admin server command URL
+    commandUrl: "/commands"
+
 
 ## @section Zookeeper Metrics configuration
 metrics:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -61,7 +61,7 @@ zookeeperConfig:
   ## @param zookeeperConfig.4lwCommandsWhitelist Zookeeper 4-letter word commands whitelist
   ## possible values are: "srvr,ruok,conf,cons,dump,envi,ruok,mntr,stat" or "*" to allow all commands
   ## @see https://zookeeper.apache.org/doc/r3.5.9/zookeeperAdmin.html#sc_clusterOptions
-  commandsWhitelist: "srvr,mntr,ruok"
+  commandsWhitelist: "srvr"
   autopurge:
     ## @param zookeeperConfig.autopurge.purgeInterval Zookeeper autopurge purge interval (in hours)
     purgeInterval: 24


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

This fixes the configuration for commands whitelists.

### Benefits

<!-- What benefits will be realized by the code change? -->
Zookeeper applied only standard command "srvr". 

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None. It is backward compatible since it uses the default "srvr".

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #170 

### Additional information

I also added the admin section which might be relevant later, since Four Letter Words will be deprecated, in favour for  [AdminServer](https://zookeeper.apache.org/doc/r3.9.4/zookeeperAdmin.html#sc_adminserver) (there is no schedule yet).

<img width="1001" height="283" alt="image" src="https://github.com/user-attachments/assets/a82b7a9a-e559-4481-8246-fc921c8d6641" />


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [ ] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
