### PR TITLE
[auto-label] Don't add `_No response_` as label

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -17,7 +17,7 @@ jobs:
               .trim()
               .split(",")
               .map((s) => s.trim())
-              .filter((s) => s && s !== "_No response_")
+              .filter((s) => s && s !== "_No response_");
             if (labels.length) {
               await github.rest.issues.addLabels({
                 ...context.repo,

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -17,7 +17,7 @@ jobs:
               .trim()
               .split(",")
               .map((s) => s.trim())
-              .filter(Boolean);
+              .filter((s) => s && s !== "_No response_")
             if (labels.length) {
               await github.rest.issues.addLabels({
                 ...context.repo,


### PR DESCRIPTION
### Description of the change

This prevents the `auto-label` workflow to add the label `_No response_` when the user hasn't selected a helm chart the issue applies to.