### PR TITLE
[Postgres] update default postgres config files

### DIFF
--- a/charts/postgres/CHANGELOG.md
+++ b/charts/postgres/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## 0.5.5 (2025-09-26)
+## 0.6.1 (2025-09-29)
 
-* [postgres]: Default config ([#163](https://github.com/CloudPirates-io/helm-charts/pull/163))
+* [Postgres] update default postgres config files ([#180](https://github.com/CloudPirates-io/helm-charts/pull/180))
+
+## <small>0.5.5 (2025-09-29)</small>
+
+* [postgres]: Default config (#163) ([fc0da25](https://github.com/CloudPirates-io/helm-charts/commit/fc0da25)), closes [#163](https://github.com/CloudPirates-io/helm-charts/issues/163)
+
+## 0.6.0 (2025-09-26)
+
+* [postgres]: Fix invalid data dir path on postgres 18 (#165) ([7592892](https://github.com/CloudPirates-io/helm-charts/commit/7592892)), closes [#165](https://github.com/CloudPirates-io/helm-charts/issues/165)
 
 ## <small>0.5.4 (2025-09-26)</small>
 

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "18.0"
 keywords:
   - postgres

--- a/charts/postgres/templates/configmap.yaml
+++ b/charts/postgres/templates/configmap.yaml
@@ -17,8 +17,9 @@ data:
   {{- end }}
   postgresql.conf: |
     # PostgreSQL configuration file
-    
+
     # Connection Settings
+    listen_addresses = '*'
     {{- if .Values.config.postgresqlMaxConnections }}
     max_connections = {{ .Values.config.postgresqlMaxConnections }}
     {{- else }}

--- a/charts/postgres/templates/configmap.yaml
+++ b/charts/postgres/templates/configmap.yaml
@@ -11,10 +11,28 @@ metadata:
     {{- include "postgres.annotations" . | nindent 4 }}
   {{- end }}
 data:
-  {{- if .Values.config.pgHbaConfig }}
   pg_hba.conf: |
+{{- if .Values.config.pgHbaConfig }}
 {{ .Values.config.pgHbaConfig | indent 4 }}
-  {{- end }}
+{{- else }}
+    # Default pg_hba.conf configuration
+    # TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+    # "local" is for Unix domain socket connections only
+    local   all             all                                     trust
+    # IPv4 local connections:
+    host    all             all             127.0.0.1/32            trust
+    # IPv6 local connections:
+    host    all             all             ::1/128                 trust
+    # Allow replication connections from localhost, by a user with the
+    # replication privilege.
+    local   replication     all                                     trust
+    host    replication     all             127.0.0.1/32            trust
+    host    replication     all             ::1/128                 trust
+
+    # Allow connections from any host with password authentication
+    host    all             all             all                     md5
+{{- end }}
   postgresql.conf: |
     # PostgreSQL configuration file
 
@@ -104,10 +122,8 @@ data:
     lc_time = 'en_US.utf8'
     default_text_search_config = 'pg_catalog.english'
     
-    {{ if .Values.config.pgHbaConfig }}
-    # Set custom pg_hba.conf file to use
+    # Set pg_hba.conf file to use
     hba_file = '{{ include "postgres.configDir" . }}/pg_hba.conf'
-    {{- end }}
 
     # Additional Configuration
     {{- range .Values.config.extraConfig }}


### PR DESCRIPTION
### Description of the change

Add listen_addresses = '*'  to default postgresql.conf and a default pg_hba.conf.

### Benefits

The default configmaps will now be working better and no customization from users will be needed

### Applicable issues

- fixes #160

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
