### PR TITLE
[keycloak] Customizable container command

### DIFF
--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 1.0.0
+  version: 1.1.1
 - name: postgres
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 0.5.2
+  version: 0.6.0
 - name: mariadb
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 0.2.7
-digest: sha256:58c0f4427699c161ee51d1b1f92323b1ec6ac3f9bcf29ab4df842e12a614c7da
-generated: "2025-09-25T11:46:09.5087928+02:00"
+  version: 0.3.0
+digest: sha256:3b47f8a6f6c98ce0f502c33e36aa995f3aa1c52b75939433199817d1c3fc35fd
+generated: "2025-09-29T13:05:14.9766945+02:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: copy-quarkus-lib
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "keycloak.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           command: ["sh", "-c", "cp -r /opt/keycloak/lib/quarkus/* /shared-quarkus/"]

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           image: {{ include "keycloak.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           command:
-            - /opt/keycloak/bin/kc.sh
+            - {{ .Values.image.command }}
           args:
             {{- if .Values.keycloak.production }}
             - start

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -49,6 +49,10 @@
           "type": "string",
           "description": "Keycloak image tag (immutable tags are recommended)"
         },
+        "command": {
+          "type": "string",
+          "description": "Keycloak container startup command"
+        },
         "imagePullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"],

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -25,6 +25,8 @@ image:
   tag: "26.3.4@sha256:2b32a51a31e8d780d9fa9a69a59ead69975263c61b5dd13559090e22aa26f100"
   ## @param image.imagePullPolicy Keycloak image pull policy
   imagePullPolicy: Always
+  ## @param image.command Keycloak container command
+  command: "/opt/keycloak/bin/kc.sh"
 
 ## @section Deployment configuration
 ## @param replicaCount Number of Keycloak replicas to deploy
@@ -276,7 +278,7 @@ extraObjects: []
 initContainers:
   ## @param initContainers.waitForPostgres.image PostgreSQL init container image for waiting
   waitForPostgres:
-    image: "postgres:17.6@sha256:0b6428e8c09651398137d2b3308a6ad87e73ac15fc38729891c16d942e947d3d"
+    image: "postgres:17.6@sha256:0f4f20021a065d114083d1b95d9fb89ad847cbc4c3cc9238417815c7df42350f"
   ## @param initContainers.waitForMariadb.image MariaDB init container image for waiting
   waitForMariadb:
     image: "mariadb:12.0.2@sha256:8a061ef9813cf960f94a262930a32b190c3fbe5c8d3ab58456ef1df4b90fd5dc"


### PR DESCRIPTION
### Description of the change

- Enables the use of a custom container command
- Applies the security context to the init container, not only the app container

### Benefits

- Customize the startup of keycloak with a custom command.
  E.g., we have automated migration scripts, that run at startup.
- Follow possible pod security admissions of a cluster

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
