### PR TITLE
[keycloak] replace deprecated 'proxy' with new proxy parameters

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 0.1.6 (2025-09-26)
+## 0.1.7 (2025-09-29)
 
-* [postgres] chore(deps): update postgres:17.6 Docker digest to 0b6428e ([#162](https://github.com/CloudPirates-io/helm-charts/pull/162))
+* [keycloak] replace deprecated 'proxy' with new proxy parameters ([#183](https://github.com/CloudPirates-io/helm-charts/pull/183))
+
+## <small>0.1.6 (2025-09-26)</small>
+
+* [postgres] chore(deps): update postgres:17.6 Docker digest to 0b6428e (#162) ([6293612](https://github.com/CloudPirates-io/helm-charts/commit/6293612)), closes [#162](https://github.com/CloudPirates-io/helm-charts/issues/162)
 
 ## <small>0.1.5 (2025-09-25)</small>
 

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -113,21 +113,23 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Keycloak Configuration
 
-| Parameter                              | Description                                                   | Default            |
-| -------------------------------------- | ------------------------------------------------------------- | ------------------ |
-| `keycloak.adminUser`                   | Keycloak admin username                                       | `admin`            |
-| `keycloak.adminPassword`               | Keycloak admin password                                       | `""`               |
-| `keycloak.existingSecret`              | Name of existing secret to use for Keycloak admin credentials | `""`               |
-| `keycloak.secretKeys.adminPasswordKey` | Secret key for admin credentials                              | `"admin-password"` |
-| `keycloak.hostname`                    | Keycloak hostname                                             | `""`               |
-| `keycloak.hostnameAdmin`               | Keycloak admin hostname                                       | `""`               |
-| `keycloak.hostnameStrict`              | Enable strict hostname resolution                             | `false`            |
-| `keycloak.hostnameBackchannel`         | Keycloak backchannel hostname                                 | `""`               |
-| `keycloak.httpEnabled`                 | Enable HTTP listener                                          | `true`             |
-| `keycloak.httpPort`                    | HTTP port                                                     | `8080`             |
-| `keycloak.httpsPort`                   | HTTPS port                                                    | `8443`             |
-| `keycloak.proxy`                       | Proxy mode (edge, reencrypt, passthrough, none)               | `none`             |
-| `keycloak.production`                  | Enable production mode                                        | `false`            |
+| Parameter                              | Description                                                                                                  | Default            |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------ |
+| `keycloak.adminUser`                   | Keycloak admin username                                                                                      | `admin`            |
+| `keycloak.adminPassword`               | Keycloak admin password                                                                                      | `""`               |
+| `keycloak.existingSecret`              | Name of existing secret to use for Keycloak admin credentials                                                | `""`               |
+| `keycloak.secretKeys.adminPasswordKey` | Secret key for admin credentials                                                                             | `"admin-password"` |
+| `keycloak.hostname`                    | Keycloak hostname                                                                                            | `""`               |
+| `keycloak.hostnameAdmin`               | Keycloak admin hostname                                                                                      | `""`               |
+| `keycloak.hostnameStrict`              | Enable strict hostname resolution                                                                            | `false`            |
+| `keycloak.hostnameBackchannel`         | Keycloak backchannel hostname                                                                                | `""`               |
+| `keycloak.httpEnabled`                 | Enable HTTP listener                                                                                         | `true`             |
+| `keycloak.httpPort`                    | HTTP port                                                                                                    | `8080`             |
+| `keycloak.httpsPort`                   | HTTPS port                                                                                                   | `8443`             |
+| `keycloak.proxyHeaders`                | The proxy headers that should be accepted by the server. (forwarded, xforwarded)                             | `""`               |
+| `keycloak.proxyProtocolEnabled`        | Whether the server should use the HA PROXY protocol when serving requests from behind a proxy. (true, false) | `false`            |
+| `keycloak.proxyTrustedAddresses`       | A comma separated list of trusted proxy addresses                                                            | `""`               |
+| `keycloak.production`                  | Enable production mode                                                                                       | `false`            |
 
 ### Database Configuration
 
@@ -240,10 +242,10 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Extra Environment
 
-| Parameter  | Description                                                            | Default |
-| ---------- |------------------------------------------------------------------------| ----- |
-| `extraEnv` | Additional environment variables from key-value pairs                  | `{}`  |
-| `extraEnvVarsSecret` | Name of an existing secret containing additional environment variables | ``    |
+| Parameter            | Description                                                            | Default |
+| -------------------- | ---------------------------------------------------------------------- | ------- |
+| `extraEnv`           | Additional environment variables from key-value pairs                  | `{}`    |
+| `extraEnvVarsSecret` | Name of an existing secret containing additional environment variables | ``      |
 
 ### Extra Configuration Parameters
 
@@ -271,7 +273,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 | Parameter                   | Description                                       | Default      |
 | --------------------------- | ------------------------------------------------- | ------------ |
-| `mariadb.enabled`           | Enable embedded PostgreSQL database               | `false`       |
+| `mariadb.enabled`           | Enable embedded PostgreSQL database               | `false`      |
 | `mariadb.auth.database`     | MariaDB database name                             | `"keycloak"` |
 | `mariadb.auth.username`     | MariaDB database user (leave empty for root user) | `""`         |
 | `mariadb.auth.password`     | MariaDB database password                         | `""`         |

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -77,8 +77,14 @@ spec:
             {{- if .Values.keycloak.hostnameBackchannel }}
             - --hostname-backchannel={{ include "keycloak.hostnameBackchannel" . }}
             {{- end }}
-            {{- if ne .Values.keycloak.proxy "none" }}
-            - --proxy={{ .Values.keycloak.proxy }}
+            {{- if .Values.keycloak.proxyHeaders }}
+            - --proxy-headers={{ .Values.keycloak.proxyHeaders }}
+            {{- end }}
+            {{- if .Values.keycloak.proxyProtocolEnabled }}
+            - --proxy-protocol-enabled={{ .Values.keycloak.proxyProtocolEnabled }}
+            {{- end }}
+            {{- if .Values.keycloak.proxyTrustedAddresses }}
+            - --proxy-trusted-addresses={{ .Values.keycloak.proxyTrustedAddresses }}
             {{- end }}
             {{- if .Values.keycloak.httpPort }}
             - --http-port={{ .Values.keycloak.httpPort }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -171,10 +171,18 @@
           "maximum": 65535,
           "description": "HTTPS port"
         },
-        "proxy": {
+        "proxyHeaders": {
           "type": "string",
-          "enum": ["edge", "reencrypt", "passthrough", "none"],
-          "description": "Proxy mode (edge, reencrypt, passthrough, none)"
+          "enum": ["", "forwarded", "xforwarded"],
+          "description": "The proxy headers that should be accepted by the server. (forwarded, xforwarded)"
+        },
+        "proxyProtocolEnabled": {
+          "type": "boolean",
+          "description": "Whether the server should use the HA PROXY protocol when serving requests from behind a proxy."
+        },
+        "proxyTrustedAddresses": {
+          "type": "string",
+          "description": "A comma separated list of trusted proxy addresses"
         },
         "production": {
           "type": "boolean",

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -82,8 +82,12 @@ keycloak:
   httpPort: 8080
   ## @param keycloak.httpsPort HTTPS port
   httpsPort: 8443
-  ## @param keycloak.proxy Proxy mode (edge, reencrypt, passthrough, none)
-  proxy: none
+  ## @param keycloak.proxyHeaders The proxy headers that should be accepted by the server. (forwarded, xforwarded)
+  proxyHeaders: ""
+  ## @param keycloak.proxyProtocolEnabled  Whether the server should use the HA PROXY protocol when serving requests from behind a proxy. (true, false(default))
+  proxyProtocolEnabled: false
+  ## @param keycloak.proxyTrustedAddresses A comma separated list of trusted proxy addresses
+  proxyTrustedAddresses: ""
   ## @param keycloak.production Enable production mode
   production: false
 


### PR DESCRIPTION
### Description of the change

Replaces the deprecated and removed start parameter `proxy` with `proxyheaders`, `proxyProtocolEnabled`, `proxyTrustedAddresses`

### Benefits

Proxy configuration will not crash the keycloak deployment. 

### Applicable issues

- fixes #159 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
