### PR TITLE
[postgres] make postgres run on openshift

### DIFF
--- a/charts/postgres/Chart.lock
+++ b/charts/postgres/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 1.0.0
-digest: sha256:4dc4489391e65614af4cd64d56a213e353a7a70b231faf64c584779774304d96
-generated: "2025-08-14T12:32:38.1323+02:00"
+  version: 1.1.1
+digest: sha256:8da3c04e2c4a1ebfff4f21936399938e0f3fcf9fbd2f7135e7e907ce725b8f00
+generated: "2025-09-29T21:42:58.149716+02:00"

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: "18.0"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -96,15 +96,15 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 
 ### Security Context
 
-| Parameter                                  | Description                                       | Default   |
-| ------------------------------------------ | ------------------------------------------------- | --------- |
-| `podSecurityContext.fsGroup`               | Group ID for the volumes of the pod               | `999`     |
-| `securityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
-| `securityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
-| `securityContext.runAsUser`                | User ID for the PostgreSQL container              | `999`     |
-| `securityContext.runAsGroup`               | Group ID for the PostgreSQL container             | `999`     |
-| `securityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `false`   |
-| `securityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
+| Parameter                                           | Description                                       | Default   |
+| --------------------------------------------------- | ------------------------------------------------- | --------- |
+| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod               | `999`     |
+| `containerSecurityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
+| `containerSecurityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
+| `containerSecurityContext.runAsUser`                | User ID for the PostgreSQL container              | `999`     |
+| `containerSecurityContext.runAsGroup`               | Group ID for the PostgreSQL container             | `999`     |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `false`   |
+| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
 
 ### PostgreSQL Authentication
 

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -34,12 +34,10 @@ spec:
 {{- with (include "postgres.imagePullSecrets" .) }}
 {{ . | nindent 6 }}
 {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "common.renderPodSecurityContext" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "postgres.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           args:

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -41,18 +41,18 @@ podSecurityContext:
   ## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
   fsGroup: 999
 
-securityContext:
-  ## @param securityContext.allowPrivilegeEscalation Enable container privilege escalation
+containerSecurityContext:
+  ## @param containerSecurityContext.allowPrivilegeEscalation Enable container privilege escalation
   allowPrivilegeEscalation: false
-  ## @param securityContext.runAsNonRoot Configure the container to run as a non-root user
+  ## @param containerSecurityContext.runAsNonRoot Configure the container to run as a non-root user
   runAsNonRoot: true
-  ## @param securityContext.runAsUser User ID for the PostgreSQL container
+  ## @param containerSecurityContext.runAsUser User ID for the PostgreSQL container
   runAsUser: 999
-  ## @param securityContext.runAsGroup Group ID for the PostgreSQL container
+  ## @param containerSecurityContext.runAsGroup Group ID for the PostgreSQL container
   runAsGroup: 999
-  ## @param securityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
+  ## @param containerSecurityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
   readOnlyRootFilesystem: false
-  ## @param securityContext.capabilities.drop Linux capabilities to be dropped
+  ## @param containerSecurityContext.capabilities.drop Linux capabilities to be dropped
   capabilities:
     drop:
       - ALL


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
> I will make a series of smaller PR to introduce common v1.1.1 and make all the charts Openshift ready. 

Openshift handles security context configuration in a special way. This changes makes sure, the postgres chart runs in a openshift cluster with the changes made in common v1.1.1 

### Benefits

<!-- What benefits will be realized by the code change? -->
How it fails on Openshift
<img width="1711" height="242" alt="SCR-20250929-sthv" src="https://github.com/user-attachments/assets/1274c84a-b3cb-4b45-a3d2-04b429948da5" />

Fixed in Openshift
<img width="815" height="457" alt="SCR-20250929-swod" src="https://github.com/user-attachments/assets/df52a022-4386-483f-8b9d-db6052716be2" />

Still running as before in other clusters
<img width="650" height="854" alt="SCR-20250929-sxqc" src="https://github.com/user-attachments/assets/7f070167-0685-4dfc-9556-a47cf4953ecb" />


### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
- 
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
