### PR TITLE
[minio] add more configuration options for the minio server

### DIFF
--- a/charts/minio/CHANGELOG.md
+++ b/charts/minio/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 0.2.3 (2025-09-15)
+## 0.2.4 (2025-09-30)
 
-* [minio] Minio set deployment update strategy ([#87](https://github.com/CloudPirates-io/helm-charts/pull/87))
+* [minio] add more configuration options for the minio server ([#189](https://github.com/CloudPirates-io/helm-charts/pull/189))
 
 ## <small>0.2.1 (2025-09-08)</small>
 

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "2025.09.07"
 keywords:
   - minio

--- a/charts/minio/README.md
+++ b/charts/minio/README.md
@@ -76,14 +76,14 @@ The following table lists the configurable parameters of the MinIO chart and the
 
 ### MinIO image configuration
 
-| Parameter          | Description                                                                                           | Default                          |
-| ------------------ | ----------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `image.registry`   | MinIO image registry                                                                                  | `docker.io`                      |
-| `image.repository` | MinIO image repository                                                                                | `minio/minio`                    |
-| `image.tag`        | MinIO image tag (immutable tags are recommended)                                                      | `"RELEASE.2024-08-17T01-24-54Z"` |
-| `image.useCpuV1`     | image.useCpuV1 Use the Minio image tags suitable for old cpus (see https://github.com/minio/minio/issues/18365)                 | `false` |
-| `image.tagCpuV1`     | image.useCpuV1 Use the Minio image tags suitable for old cpus (see https://github.com/minio/minio/issues/18365)                 | `RELEASE.2025-09-07T16-13-09Z-cpuv1@sha256:13582eff79c6605a2d315bdd0e70164142ea7e98fc8411e9e10d089502a6d883` |
-| `image.imagePullPolicy` | MinIO image pull policy                                                                               | `IfNotPresent`                   |
+| Parameter               | Description                                                                                                     | Default                                                                                                      |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `image.registry`        | MinIO image registry                                                                                            | `docker.io`                                                                                                  |
+| `image.repository`      | MinIO image repository                                                                                          | `minio/minio`                                                                                                |
+| `image.tag`             | MinIO image tag (immutable tags are recommended)                                                                | `"RELEASE.2024-08-17T01-24-54Z"`                                                                             |
+| `image.useCpuV1`        | image.useCpuV1 Use the Minio image tags suitable for old cpus (see https://github.com/minio/minio/issues/18365) | `false`                                                                                                      |
+| `image.tagCpuV1`        | image.useCpuV1 Use the Minio image tags suitable for old cpus (see https://github.com/minio/minio/issues/18365) | `RELEASE.2025-09-07T16-13-09Z-cpuv1@sha256:13582eff79c6605a2d315bdd0e70164142ea7e98fc8411e9e10d089502a6d883` |
+| `image.imagePullPolicy` | MinIO image pull policy                                                                                         | `IfNotPresent`                                                                                               |
 
 ### MinIO Authentication
 
@@ -97,13 +97,21 @@ The following table lists the configurable parameters of the MinIO chart and the
 
 ### MinIO configuration
 
-| Parameter               | Description                                               | Default |
-| ----------------------- | --------------------------------------------------------- | ------- |
-| `config.region`         | MinIO server default region                               | `""`    |
-| `config.browserEnabled` | Enable MinIO web browser                                  | `true`  |
-| `config.domain`         | MinIO server domain                                       | `""`    |
-| `config.serverUrl`      | MinIO server URL for console                              | `""`    |
-| `config.extraEnvVars`   | Extra environment variables to be set on MinIO containers | `[]`    |
+| Parameter                                | Description                                                                                                                                                                                           | Default |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `config.region`                          | MinIO server default region                                                                                                                                                                           | `""`    |
+| `config.browserEnabled`                  | Enable MinIO web browser                                                                                                                                                                              | `true`  |
+| `config.domain`                          | MinIO server domain                                                                                                                                                                                   | `""`    |
+| `config.serverUrl`                       | MinIO server URL for console                                                                                                                                                                          | `""`    |
+| `config.minioOpts`                       | String of parameteres to use when starting the MinIO Server (example: '--console-address=":9001"')                                                                                                    | `""`    |
+| `config.minioVolumes`                    | The directories or drives the minio server uses as the storage backend (example: '/mnt/drive1/minio')                                                                                                 | `""`    |
+| `config.minioConfigEnvFile`              | Specifies the full path to the file the MinIO server process uses for loading environment variables                                                                                                   | `""`    |
+| `config.minioScannerSpeed`               | Manage the maximum wait period for the scanner when balancing MinIO read/write performance to scanner processes (fastest, fast, default, slow, slowest)                                               | `""`    |
+| `config.minioCompressionEnabled`         | Set to on to enable data compression for new objects. Defaults to off.                                                                                                                                | `""`    |
+| `config.minioCompressionAllowEncryption` | Set to on to encrypt objects after compressing them. Defaults to off.                                                                                                                                 | `""`    |
+| `config.minioCompressionExtensions`      | Comma-separated list of the file extensions to compress. Setting a new list of file extensions replaces the previously configured list. Defaults to "*"                                               | `""`    |
+| `config.minioCompressionMimeTypes`       | Comma-separated list of the MIME types to compress. Setting a new list of types replaces the previously configured list. Defaults to "text/*, application/json, application/xml, binary/octet-stream" | `""`    |
+| `config.extraEnvVars`                    | Extra environment variables to be set on MinIO containers                                                                                                                                             | `[]`    |
 
 ### Deployment configuration
 
@@ -215,9 +223,9 @@ The following table lists the configurable parameters of the MinIO chart and the
 
 ### Extra Configuration Parameters
 
-| Parameter           | Description                                                                         | Default |
-| ------------------- | ----------------------------------------------------------------------------------- | ------- |
-| `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release             | `[]`    |
+| Parameter      | Description                                                             | Default |
+| -------------- | ----------------------------------------------------------------------- | ------- |
+| `extraObjects` | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
 
 #### Extra Objects
 

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -73,6 +73,39 @@ spec:
             - name: MINIO_SERVER_URL
               value: {{ .Values.config.serverUrl | quote }}
             {{- end }}
+            {{- if .Values.config.minioOpts }}
+            - name: MINIO_OPTS
+              value: {{ .Values.config.minioOpts | quote }}
+            {{- end }}
+            {{- if .Values.config.minioVolumes }}
+            - name: MINIO_VOLUMES
+              value: {{ .Values.config.minioVolumes | quote }}
+            {{- end }}
+            {{- if .Values.config.minioConfigEnvFile }}
+            - name: MINIO_CONFIG_ENV_FILE
+              value: {{ .Values.config.minioConfigEnvFile | quote }}
+            {{- end }}
+            {{- if .Values.config.minioScannerSpeed }}
+            - name: MINIO_SCANNER_SPEED
+              value: {{ .Values.config.minioScannerSpeed | quote }}
+            {{- end }}
+            {{- if .Values.config.minioCompressionEnabled }}
+            - name: MINIO_COMPRESSION_ENABLE
+              value: {{ .Values.config.minioCompressionEnabled | quote }}
+            {{- end }}
+            {{- if and .Values.config.minioCompressionEnabled .Values.config.minioCompressionAllowEncryption }}
+            - name: MINIO_COMPRESSION_ALLOW_ENCRYPTION
+              value: {{ .Values.config.minioCompressionAllowEncryption | quote }}
+            {{- end }}
+            {{- if and .Values.config.minioCompressionEnabled .Values.config.minioCompressionExtensions }}
+            - name: MINIO_COMPRESSION_EXTENSIONS
+              value: {{ .Values.config.minioCompressionExtensions | quote }}
+            {{- end }}
+            {{- if and .Values.config.minioCompressionEnabled .Values.config.minioCompressionMimeTypes }}
+            - name: MINIO_COMPRESSION_MIME_TYPES
+              value: {{ .Values.config.minioCompressionMimeTypes | quote }}
+            {{- end }}
+
             {{- with .Values.config.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -117,6 +117,49 @@
           "title": "MinIO Server URL",
           "description": "MinIO server URL for console"
         },
+        "minioOpts": {
+          "type": "string",
+          "title": "MinIO Server Options",
+          "description": "String of parameteres to use when starting the MinIO Server"
+        },
+        "minioVolumes": {
+          "type": "string",
+          "title": "MinIO Volume directories",
+          "description": "The directories or drives the minio server uses as the storage backend"
+        },
+        "minioConfigEnvFile": {
+          "type": "string",
+          "title": "MinIO Config Environment File",
+          "description": "Path to environment file for MinIO to load variables from"
+        },
+        "minioScannerSpeed": {
+          "type": "string",
+          "enum": ["fastest", "fast", "default", "slow", "slowest", ""],
+          "title": "MinIO Scanner Speed",
+          "description": "Manage the maximum wait period for the scanner when balancing MinIO read/write performance to scanner processes"
+        },
+        "minioCompressionEnabled": {
+          "type": "string",
+          "enum": ["on", "off", ""],
+          "title": "MinIO Compression Enabled",
+          "description": "Set to on to enable data compression for new objects"
+        },
+        "minioCompressionAllowEncryption": {
+          "type": "string",
+          "enum": ["on", "off", ""],
+          "title": "MinIO Compression Allow Encryption",
+          "description": "Set to on to encrypt objects after compressing them"
+        },
+        "minioCompressionExtensions": {
+          "type": "string",
+          "title": "MinIO Compression Extentions",
+          "description": "Comma-separated list of the file extensions to compress"
+        },
+        "minioCompressionMimeTypes": {
+          "type": "string",
+          "title": "MinIO Compression MimeTypes",
+          "description": "Comma-separated list of the MIME types to compress"
+        },
         "extraEnvVars": {
           "type": "array",
           "title": "Extra Environment Variables",

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -53,6 +53,23 @@ config:
   domain: ""
   ## @param config.serverUrl MinIO server URL for console
   serverUrl: ""
+  ## @param config.minioOpts String of parameteres to use when starting the MinIO Server (example: '--console-address=":9001"')
+  minioOpts: ""
+  ## @param config.minioVolumes The directories or drives the minio server uses as the storage backend (example: '/mnt/drive1/minio')
+  minioVolumes: ""
+  ## @param config.minioConfigEnvFile Specifies the full path to the file the MinIO server process uses for loading environment variables
+  minioConfigEnvFile: ""
+  ## @param config.minioScannerSpeed Manage the maximum wait period for the scanner when balancing MinIO read/write performance to scanner processes (fastest, fast, default, slow, slowest)
+  minioScannerSpeed: ""
+  ## @param config.minioCompressionEnabled Set to on to enable data compression for new objects. Defaults to off.
+  minioCompressionEnabled: ""
+  ## @param config.minioCompressionAllowEncryption Set to on to encrypt objects after compressing them. Defaults to off.
+  minioCompressionAllowEncryption: ""
+  ## @param config.minioCompressionExtensions Comma-separated list of the file extensions to compress. Setting a new list of file extensions replaces the previously configured list. Defaults to "*"
+  minioCompressionExtensions: ""
+  ## @param config.minioCompressionMimeTypes Comma-separated list of the MIME types to compress. Setting a new list of types replaces the previously configured list. Defaults to "text/*, application/json, application/xml, binary/octet-stream"
+  minioCompressionMimeTypes: ""
+
   ## @param config.extraEnvVars Extra environment variables to be set on MinIO containers
   extraEnvVars: []
 


### PR DESCRIPTION
### Description of the change

Adds more options to configure the minio server via environment variables. 

### Benefits

The configuration of the minio server is standardized and documented

### Possible drawbacks

Adds more options and complexity to the chart

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
