### PR TITLE
make memcached run on openshift

### DIFF
--- a/charts/memcached/Chart.lock
+++ b/charts/memcached/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-  - name: common
-    repository: oci://registry-1.docker.io/cloudpirates
-    version: 1.0.0
-digest: sha256:4dc4489391e65614af4cd64d56a213e353a7a70b231faf64c584779774304d96
-generated: "2025-08-22T09:30:25.620882+02:00"
+- name: common
+  repository: oci://registry-1.docker.io/cloudpirates
+  version: 1.1.1
+digest: sha256:8da3c04e2c4a1ebfff4f21936399938e0f3fcf9fbd2f7135e7e907ce725b8f00
+generated: "2025-09-30T21:16:48.901325+02:00"

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -3,7 +3,7 @@ name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
 
-version: 0.1.3
+version: 0.2.0
 appVersion: "1.6.39"
 
 keywords:

--- a/charts/memcached/templates/deployment.yaml
+++ b/charts/memcached/templates/deployment.yaml
@@ -23,11 +23,10 @@ spec:
 {{ . | nindent 6 }}
 {{- end }}
       serviceAccountName: {{ include "memcached.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "common.renderPodSecurityContext" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "memcached.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
           args:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
> I will make a series of smaller PR to introduce common v1.1.1 and make all the charts Openshift ready. 

Openshift handles security context configuration in a special way. This changes makes sure, the memcached chart runs in a openshift cluster with the changes made in common v1.1.1 

Tested on Openshift Version : 4.19.12 

### Benefits

<!-- What benefits will be realized by the code change? -->
Runs on Openshift
<img width="749" height="558" alt="SCR-20250930-smpc" src="https://github.com/user-attachments/assets/143f323f-35c2-4194-998d-e7d0a9d6497f" />

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [ ] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
