### PR TITLE
[ghost] make ghost run on openshift

### DIFF
--- a/charts/ghost/Chart.lock
+++ b/charts/ghost/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 1.0.0
+  version: 1.1.1
 - name: mariadb
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 0.2.7
-digest: sha256:0184e5d0bc6577f2895705084ba0b10d13116d202f6b0d1a239f3aa3db931837
-generated: "2025-09-19T13:08:15.586897+02:00"
+  version: 0.3.0
+digest: sha256:4e89daee4a04df25da46810f73b277003ebff8ca938c308ed55214e9a8893183
+generated: "2025-09-30T22:09:51.820397+02:00"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "6.0.9"
 keywords:
   - ghost
@@ -22,7 +22,7 @@ dependencies:
     version: "1.x.x"
     repository: oci://registry-1.docker.io/cloudpirates
   - name: mariadb
-    version: "0.2.x"
+    version: "0.3.x"
     repository: oci://registry-1.docker.io/cloudpirates
     condition: mariadb.enabled
 icon: https://a.storyblok.com/f/143071/512x512/a130ba5305/ghost-logo.svg

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -32,8 +32,7 @@ spec:
 {{ . | nindent 6 }}
 {{- end }}
       serviceAccountName: {{ include "ghost.serviceAccountName" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "common.renderPodSecurityContext" . | nindent 8 }}
       {{- if .Values.mariadb.enabled }}
       initContainers:
         - name: wait-for-mariadb
@@ -44,7 +43,7 @@ spec:
             - >
               retries=0;
               max_retries=15;
-              until [ $retries -ge $max_retries ] || mariadb-admin ping -h {{ include "ghost.fullname" . }}-mariadb 
+              until [ $retries -ge $max_retries ] || mariadb-admin ping -h {{ include "ghost.name" . }}-mariadb 
               -P {{ .Values.mariadb.service.port }} 
               -u{{ .Values.mariadb.auth.username }} 
               -p{{ .Values.mariadb.auth.password }} 
@@ -57,14 +56,14 @@ spec:
                 fi;
                 sleep 2; 
               done;
-          securityContext:
-            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "ghost.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
+          #command: ["tail", "-f", "/dev/null"]
           ports:
             {{- range .Values.containerPorts }}
             - name: {{ .name }}

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -230,10 +230,10 @@ config:
   security:
     staffDeviceVerification: false
   paths:
-    contentPath: "content/"
+    contentPath: "/var/lib/ghost/content"
   referrerPolicy: "origin-when-crossorigin"
   logging:
-    path: "content/logs/"
+    path: "/var/lib/ghost/content/logs/"
     useLocalTime: true
     level: "info"
     rotation:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
> I will make a series of smaller PR to introduce common v1.1.1 and make all the charts Openshift ready. 

Openshift handles security context configuration in a special way. This changes makes sure, the ghost chart runs in a openshift cluster with the changes made in common v1.1.1 

Tested on Openshift Version : 4.19.12 

### Benefits

<!-- What benefits will be realized by the code change? -->
Runs on Openshift
<img width="1019" height="775" alt="image" src="https://github.com/user-attachments/assets/559c9485-e8c8-4e25-837d-b4dc73d7232e" />

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
This change fixes a miss configuration too. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
