### PR TITLE
[ghost] switch helm-chart icon to a new svg

### DIFF
--- a/charts/ghost/CHANGELOG.md
+++ b/charts/ghost/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
-## 0.1.0 (2025-09-24)
+## 0.2.1 (2025-10-01)
 
-* [postgres] fix: Change default name for CUSTOM_PASSWORD ([#144](https://github.com/CloudPirates-io/helm-charts/pull/144))
+* [ghost] switch helm-chart icon to a new svg ([#199](https://github.com/CloudPirates-io/helm-charts/pull/199))
+
+## 0.2.0 (2025-10-01)
+
+* make ghost run on openshift (#195) ([93762d4](https://github.com/CloudPirates-io/helm-charts/commit/93762d4)), closes [#195](https://github.com/CloudPirates-io/helm-charts/issues/195)
+* add artifacthub repo ID ([665bf26](https://github.com/CloudPirates-io/helm-charts/commit/665bf26))
+* add ghost ([83ef05d](https://github.com/CloudPirates-io/helm-charts/commit/83ef05d))
+* add ghost logo ([6a4df33](https://github.com/CloudPirates-io/helm-charts/commit/6a4df33))
+* add maintainer information ([7eec72b](https://github.com/CloudPirates-io/helm-charts/commit/7eec72b))
+* fix app version ([688338c](https://github.com/CloudPirates-io/helm-charts/commit/688338c))
+* fix Chart.lock for linting ([40c4159](https://github.com/CloudPirates-io/helm-charts/commit/40c4159))
+* fix configuration and installation ([40a2729](https://github.com/CloudPirates-io/helm-charts/commit/40a2729))
+* fix unittest typo ([cc31439](https://github.com/CloudPirates-io/helm-charts/commit/cc31439))
+* improve configuration settings for more clearity with 'externaldb' ([d539bf8](https://github.com/CloudPirates-io/helm-charts/commit/d539bf8))
+* improve startup, wait for mariadb to be ready ([8baec0a](https://github.com/CloudPirates-io/helm-charts/commit/8baec0a))
+* Update CHANGELOG.md ([dc9fbd8](https://github.com/CloudPirates-io/helm-charts/commit/dc9fbd8))
+* Update CHANGELOG.md ([1bee7fe](https://github.com/CloudPirates-io/helm-charts/commit/1bee7fe))
+* update docs ([333b4e3](https://github.com/CloudPirates-io/helm-charts/commit/333b4e3))
+* update docs ([d503408](https://github.com/CloudPirates-io/helm-charts/commit/d503408))
+* update docs for external database connection ([1fa8f61](https://github.com/CloudPirates-io/helm-charts/commit/1fa8f61))
+* update values schema with missing fields ([3f38991](https://github.com/CloudPirates-io/helm-charts/commit/3f38991))
+* chore: add Newline for the linter ([a667374](https://github.com/CloudPirates-io/helm-charts/commit/a667374))
+* chore: fix linting, remove trailing spaces ([0f2465d](https://github.com/CloudPirates-io/helm-charts/commit/0f2465d))

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "6.0.9"
 keywords:
   - ghost
@@ -25,4 +25,4 @@ dependencies:
     version: "0.3.x"
     repository: oci://registry-1.docker.io/cloudpirates
     condition: mariadb.enabled
-icon: https://a.storyblok.com/f/143071/512x512/a130ba5305/ghost-logo.svg
+icon: https://a.storyblok.com/f/143071/512x512/28cdb1ef38/ghost-logo.svg


### PR DESCRIPTION
### Description of the change

Because the current Ghost icon can not be used from artifact-hub, we created a new icon. 

### Benefits

The Helm-Chart Icon will be shown in Artifact-hub

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
