### PR TITLE
[rabbitmq] make rabbitmq run on openshift

### DIFF
--- a/charts/rabbitmq/Chart.lock
+++ b/charts/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 1.0.0
-digest: sha256:4dc4489391e65614af4cd64d56a213e353a7a70b231faf64c584779774304d96
-generated: "2025-08-15T10:49:14.642643+02:00"
+  version: 1.1.1
+digest: sha256:8da3c04e2c4a1ebfff4f21936399938e0f3fcf9fbd2f7135e7e907ce725b8f00
+generated: "2025-10-01T21:19:36.926334+02:00"

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.2.12
+version: 0.3.0
 appVersion: "4.1.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -210,18 +210,12 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 | Parameter                                                | Description                                       | Default   |
 | -------------------------------------------------------- | ------------------------------------------------- | --------- |
 | `podSecurityContext.fsGroup`                             | Group ID for the volumes of the pod               | `999`     |
-| `securityContext.allowPrivilegeEscalation`               | Enable container privilege escalation             | `false`   |
-| `securityContext.runAsNonRoot`                           | Configure the container to run as a non-root user | `true`    |
-| `securityContext.runAsUser`                              | User ID for the RabbitMQ container                | `999`     |
-| `securityContext.runAsGroup`                             | Group ID for the RabbitMQ container               | `999`     |
-| `securityContext.readOnlyRootFilesystem`                 | Mount container root filesystem as read-only      | `true`    |
-| `securityContext.capabilities.drop`                      | Linux capabilities to be dropped                  | `["ALL"]` |
-| `initContainer.securityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
-| `initContainer.securityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
-| `initContainer.securityContext.runAsUser`                | User ID for the RabbitMQ container                | `999`     |
-| `initContainer.securityContext.runAsGroup`               | Group ID for the RabbitMQ container               | `999`     |
-| `initContainer.securityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `true`    |
-| `initContainer.securityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
+| `containerSecurityContext.allowPrivilegeEscalation`      | Enable container privilege escalation             | `false`   |
+| `containerSecurityContext.runAsNonRoot`                  | Configure the container to run as a non-root user | `true`    |
+| `containerSecurityContext.runAsUser`                     | User ID for the RabbitMQ container                | `999`     |
+| `containerSecurityContext.runAsGroup`                    | Group ID for the RabbitMQ container               | `999`     |
+| `containerSecurityContext.readOnlyRootFilesystem`        | Mount container root filesystem as read-only      | `true`    |
+| `containerSecurityContext.capabilities.drop`             | Linux capabilities to be dropped                  | `["ALL"]` |
 
 ### Liveness and readiness probes
 

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -28,27 +28,21 @@ spec:
       {{ . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "rabbitmq.serviceAccountName" . }}
-      {{- if .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- end }}
+      securityContext: {{ include "common.renderPodSecurityContext" . | nindent 8 }}
       {{- if or .Values.auth.enabled .Values.installPlugins .Values.customScripts.initContainers }}
       initContainers:
         {{- if .Values.auth.enabled }}
         - name: init-erlang-cookie
           image: "{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}/{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
-          {{- if .Values.initContainer.securityContext }}
-          securityContext:
-            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
-          {{- end }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           command:
             - sh
             - -c
             - |
               echo "$RABBITMQ_ERLANG_COOKIE" > /var/lib/rabbitmq/.erlang.cookie
               chmod 400 /var/lib/rabbitmq/.erlang.cookie
-              chown {{ .Values.securityContext.runAsUser | default 999 }}:{{ .Values.securityContext.runAsGroup | default 999 }} /var/lib/rabbitmq/.erlang.cookie
+              chown $(id -u):$(id -g) /var/lib/rabbitmq/.erlang.cookie
           env:
             - name: RABBITMQ_ERLANG_COOKIE
               valueFrom:
@@ -63,10 +57,7 @@ spec:
         - name: download-plugins
           image: "{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}/{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
-          {{- if .Values.initContainer.securityContext }}
-          securityContext:
-            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
-          {{- end }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           command:
             - sh
             - -c
@@ -91,10 +82,7 @@ spec:
         - name: copy-plugins
           image: {{ include "rabbitmq.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
-          {{- if .Values.initContainer.securityContext }}
-          securityContext:
-            {{- toYaml .Values.initContainer.securityContext | nindent 12 }}
-          {{- end }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           command:
             - sh
             - -c
@@ -112,10 +100,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.securityContext }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          {{- end }}
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "rabbitmq.image" . | quote }}
           imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.image) }}
           {{- if .Values.customScripts.postStart.enabled }}

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -118,21 +118,6 @@ initContainer:
     tag: "1.37.0@sha256:d82f458899c9696cb26a7c02d5568f81c8c8223f8661bb2a7988b269c8b9051e"
     ## @param initContainer.image.pullPolicy Init container image pull policy
     pullPolicy: IfNotPresent
-  securityContext:
-    ## @param initContainer.securityContext.allowPrivilegeEscalation Enable container privilege escalation
-    allowPrivilegeEscalation: false
-    ## @param initContainer.securityContext.runAsNonRoot Configure the container to run as a non-root user
-    runAsNonRoot: true
-    ## @param initContainer.securityContext.runAsUser User ID for the RabbitMQ container
-    runAsUser: 999
-    ## @param initContainer.securityContext.runAsGroup Group ID for the RabbitMQ container
-    runAsGroup: 999
-    ## @param initContainer.securityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
-    readOnlyRootFilesystem: true
-    ## @param initContainer.securityContext.capabilities.drop Linux capabilities to be dropped
-    capabilities:
-      drop:
-        - ALL
 
 ## @section Metrics configuration
 metrics:
@@ -218,18 +203,18 @@ tolerations: []
 ## @param affinity Affinity settings for pod assignment
 affinity: {}
 
-securityContext:
-  ## @param securityContext.allowPrivilegeEscalation Enable container privilege escalation
+containerSecurityContext:
+  ## @param containerSecurityContext.allowPrivilegeEscalation Enable container privilege escalation
   allowPrivilegeEscalation: false
-  ## @param securityContext.runAsNonRoot Configure the container to run as a non-root user
+  ## @param containerSecurityContext.runAsNonRoot Configure the container to run as a non-root user
   runAsNonRoot: true
-  ## @param securityContext.runAsUser User ID for the RabbitMQ container
+  ## @param containerSecurityContext.runAsUser User ID for the RabbitMQ container
   runAsUser: 999
-  ## @param securityContext.runAsGroup Group ID for the RabbitMQ container
+  ## @param containerSecurityContext.runAsGroup Group ID for the RabbitMQ container
   runAsGroup: 999
-  ## @param securityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
+  ## @param containerSecurityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
   readOnlyRootFilesystem: true
-  ## @param securityContext.capabilities.drop Linux capabilities to be dropped
+  ## @param containerSecurityContext.capabilities.drop Linux capabilities to be dropped
   capabilities:
     drop:
       - ALL

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -121,7 +121,7 @@
         }
       }
     },
-    "securityContext": {
+    "containerSecurityContext": {
       "type": "object",
       "title": "Security Context",
       "description": "Security context for the container",


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
> I will make a series of smaller PR to introduce common v1.1.1 and make all the charts Openshift ready. 

Openshift handles security context configuration in a special way. This changes makes sure, the rabbitmq chart runs in a openshift cluster with the changes made in common v1.1.1 

Tested on Openshift Version : 4.19.12 


### Benefits

<!-- What benefits will be realized by the code change? -->
Runs on Openshift cluster

<img width="1081" height="314" alt="SCR-20251001-svfm" src="https://github.com/user-attachments/assets/2a61c5b9-22be-4a3f-bc85-b9b26d27046c" />

<img width="994" height="377" alt="image" src="https://github.com/user-attachments/assets/8cc71195-9b58-4707-bdac-f045d3a85991" />

### Possible drawbacks

<!-- Describe any known limitations with your change -->
In case somebody has used `securitContext` for a custom configuration, must rename the var to `containerSecurityContex`

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
The initcontianers have now the same securityContext as the actual running contianer. I can't see a need for a separate scrutiycontext configuration. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
