### PR TITLE
[keycloak] add topologySpreadConstraints and trafficDistribution opti…

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -1,43 +1,5 @@
 # Changelog
 
-## 0.1.7 (2025-09-29)
+## 0.1.9 (2025-10-02)
 
-* [keycloak] replace deprecated 'proxy' with new proxy parameters ([#183](https://github.com/CloudPirates-io/helm-charts/pull/183))
-
-## <small>0.1.6 (2025-09-26)</small>
-
-* [postgres] chore(deps): update postgres:17.6 Docker digest to 0b6428e (#162) ([6293612](https://github.com/CloudPirates-io/helm-charts/commit/6293612)), closes [#162](https://github.com/CloudPirates-io/helm-charts/issues/162)
-
-## <small>0.1.5 (2025-09-25)</small>
-
-* add namespaces to templates, change user/group-ids to 1001 ([31b203b](https://github.com/CloudPirates-io/helm-charts/commit/31b203b))
-* add readme documentation and values.schema.json ([369448b](https://github.com/CloudPirates-io/helm-charts/commit/369448b))
-* add support for extra env vars from an existing secret (#158) ([263604f](https://github.com/CloudPirates-io/helm-charts/commit/263604f)), closes [#158](https://github.com/CloudPirates-io/helm-charts/issues/158)
-* Fix resolving template expressions in extraobjects ([12a1cb5](https://github.com/CloudPirates-io/helm-charts/commit/12a1cb5))
-* [postgres] chore(deps): update postgres:17.6 Docker digest to 0f4f200 ([b4a6a30](https://github.com/CloudPirates-io/helm-charts/commit/b4a6a30))
-* Add keycloak logo ([bf1e1c2](https://github.com/CloudPirates-io/helm-charts/commit/bf1e1c2))
-* Add TODO ([8162d60](https://github.com/CloudPirates-io/helm-charts/commit/8162d60))
-* Artifact hub id ([02540ae](https://github.com/CloudPirates-io/helm-charts/commit/02540ae))
-* Bump the correct thing ([35e7901](https://github.com/CloudPirates-io/helm-charts/commit/35e7901))
-* Fix chart version bump ([aae07b1](https://github.com/CloudPirates-io/helm-charts/commit/aae07b1))
-* Fix deprecated env vars warning ([50d9fa0](https://github.com/CloudPirates-io/helm-charts/commit/50d9fa0))
-* Fix lint ([4bf9e77](https://github.com/CloudPirates-io/helm-charts/commit/4bf9e77))
-* Fix lint 2 ([a38fc35](https://github.com/CloudPirates-io/helm-charts/commit/a38fc35))
-* Fix lint 3 ([0875bfa](https://github.com/CloudPirates-io/helm-charts/commit/0875bfa))
-* Fix lint 4 ([7fcbd78](https://github.com/CloudPirates-io/helm-charts/commit/7fcbd78))
-* Improvements ([cea8f2c](https://github.com/CloudPirates-io/helm-charts/commit/cea8f2c))
-* Initial implementation ([c5d41ec](https://github.com/CloudPirates-io/helm-charts/commit/c5d41ec))
-* Rework keycloak ([2afb0fd](https://github.com/CloudPirates-io/helm-charts/commit/2afb0fd))
-* Update CHANGELOG.md ([b7572a8](https://github.com/CloudPirates-io/helm-charts/commit/b7572a8))
-* Update CHANGELOG.md ([245f9b6](https://github.com/CloudPirates-io/helm-charts/commit/245f9b6))
-* Update CHANGELOG.md ([0bf9f75](https://github.com/CloudPirates-io/helm-charts/commit/0bf9f75))
-* Update CHANGELOG.md ([03d476e](https://github.com/CloudPirates-io/helm-charts/commit/03d476e))
-* Update CHANGELOG.md ([20c19bb](https://github.com/CloudPirates-io/helm-charts/commit/20c19bb))
-* Update CHANGELOG.md ([68435aa](https://github.com/CloudPirates-io/helm-charts/commit/68435aa))
-* Update CHANGELOG.md ([b8adca8](https://github.com/CloudPirates-io/helm-charts/commit/b8adca8))
-* Update CHANGELOG.md ([62e51b9](https://github.com/CloudPirates-io/helm-charts/commit/62e51b9))
-* Update CHANGELOG.md ([54f725e](https://github.com/CloudPirates-io/helm-charts/commit/54f725e))
-* Update CHANGELOG.md ([2ed9b3f](https://github.com/CloudPirates-io/helm-charts/commit/2ed9b3f))
-* Update CHANGELOG.md ([2178148](https://github.com/CloudPirates-io/helm-charts/commit/2178148))
-* Update CHANGELOG.md ([8d6710f](https://github.com/CloudPirates-io/helm-charts/commit/8d6710f))
-* chore: fix changelog ([bd9f1a8](https://github.com/CloudPirates-io/helm-charts/commit/bd9f1a8))
+* [keycloak] add topologySpreadConstraints and trafficDistribution opti… ([#209](https://github.com/CloudPirates-io/helm-charts/pull/209))

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -162,14 +162,15 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Service configuration
 
-| Parameter                 | Description                   | Default     |
-| ------------------------- | ----------------------------- | ----------- |
-| `service.type`            | Keycloak service type         | `ClusterIP` |
-| `service.httpPort`        | Keycloak HTTP service port    | `8080`      |
-| `service.httpsPort`       | Keycloak HTTPS service port   | `8443`      |
-| `service.httpTargetPort`  | Keycloak HTTP container port  | `8080`      |
-| `service.httpsTargetPort` | Keycloak HTTPS container port | `8443`      |
-| `service.annotations`     | Service annotations           | `{}`        |
+| Parameter                     | Description                   | Default     |
+| ----------------------------- | ----------------------------- | ----------- |
+| `service.type`                | Keycloak service type         | `ClusterIP` |
+| `service.httpPort`            | Keycloak HTTP service port    | `8080`      |
+| `service.httpsPort`           | Keycloak HTTPS service port   | `8443`      |
+| `service.httpTargetPort`      | Keycloak HTTP container port  | `8080`      |
+| `service.httpsTargetPort`     | Keycloak HTTPS container port | `8443`      |
+| `service.annotations`         | Service annotations           | `{}`        |
+| `service.trafficDistribution` | Service traffic distribution  | `""`        |
 
 ### Ingress configuration
 
@@ -225,11 +226,12 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Node Selection
 
-| Parameter      | Description                          | Default |
-| -------------- | ------------------------------------ | ------- |
-| `nodeSelector` | Node labels for pod assignment       | `{}`    |
-| `tolerations`  | Toleration labels for pod assignment | `[]`    |
-| `affinity`     | Affinity settings for pod assignment | `{}`    |
+| Parameter                   | Description                                    | Default |
+| --------------------------- | ---------------------------------------------- | ------- |
+| `nodeSelector`              | Node labels for pod assignment                 | `{}`    |
+| `tolerations`               | Toleration labels for pod assignment           | `[]`    |
+| `affinity`                  | Affinity settings for pod assignment           | `{}`    |
+| `topologySpreadConstraints` | Topology Spread Constraints for pod assignment | `[]`    |
 
 ### Service Account
 
@@ -522,21 +524,18 @@ kubectl get secret my-keycloak -o jsonpath="{.data.admin-password}" | base64 --d
 ### Common Issues
 
 1. **Pod fails to start with database connection errors**
-
    - Verify database connection parameters
    - Ensure the database is running and accessible
    - Check database credentials in secrets
    - Review pod logs: `kubectl logs <pod-name>`
 
 2. **Cannot access Keycloak via ingress**
-
    - Verify ingress configuration and annotations
    - Check if ingress controller is installed
    - Ensure DNS resolves to the correct IP
    - Check TLS certificate configuration
 
 3. **Admin login fails**
-
    - Verify admin password in the secret
    - Check if the admin user exists in the database
    - Review Keycloak logs for authentication errors

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -247,3 +247,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -24,3 +24,4 @@ spec:
     {{- end }}
   selector:
     {{- include "keycloak.selectorLabels" . | nindent 4 }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -313,6 +313,10 @@
         "annotations": {
           "type": "object",
           "description": "Service annotations"
+        },
+        "trafficDistribution": {
+          "type": "string",
+          "description": "Traffic distribution policy"
         }
       }
     },
@@ -530,6 +534,10 @@
     "affinity": {
       "type": "object",
       "description": "Affinity settings for pod assignment"
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "description": "Topology Spread Constraints for pod assignment"
     },
     "serviceAccount": {
       "type": "object",

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -146,6 +146,8 @@ service:
   httpsTargetPort: 8443
   ## @param service.annotations Service annotations
   annotations: {}
+  ## @param service.trafficDistribution Traffic distribution preference for the keycloak service. If the field is not set, the implementation will apply its default routing strategy.
+  trafficDistribution: ""
 
 ## @section Ingress configuration
 ingress:
@@ -252,6 +254,9 @@ nodeSelector: {}
 
 ## @param tolerations Toleration labels for pod assignment
 tolerations: []
+
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment
+topologySpreadConstraints: []
 
 ## @param affinity Affinity settings for pod assignment
 affinity: {}


### PR DESCRIPTION
### Description of the change

Adding `topologySpreadConstraints` and `service.trafficDistribution` options to Keycloak chart.

### Benefits

User will now be able to configure topologySpreadConstraints for keycloak deployment, and trafficDistribution for keycloak service.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
