### PR TITLE
[rabbitmq] Add automatically generated fields to volumeClaimTemplates

### DIFF
--- a/charts/rabbitmq/CHANGELOG.md
+++ b/charts/rabbitmq/CHANGELOG.md
@@ -1,22 +1,22 @@
 # Changelog
 
-## 0.2.12 (2025-09-24)
+## 0.2.13 (2025-10-02)
 
-* [RabbitMQ] several new configuration options ([#148](https://github.com/CloudPirates-io/helm-charts/pull/148))
+* [rabbitmq] Add automatically generated fields to volumeClaimTemplates ([#210](https://github.com/CloudPirates-io/helm-charts/pull/210))
 
 ## <small>0.1.1 (2025-09-08)</small>
 
-* Fix erlang.cookie creation ([640e725](https://github.com/younessof2m/helm-charts/commit/640e725))
-* Update CHANGELOG.md ([63b1299](https://github.com/younessof2m/helm-charts/commit/63b1299))
+* Fix erlang.cookie creation ([640e725](https://github.com/rsaladra/helm-charts/commit/640e725))
+* Update CHANGELOG.md ([63b1299](https://github.com/rsaladra/helm-charts/commit/63b1299))
 
 ## 0.1.0 (2025-09-02)
 
-* Fix clustering and metrics configurations ([f571ab3](https://github.com/younessof2m/helm-charts/commit/f571ab3))
-* Fix ingress port and added test ([67ae961](https://github.com/younessof2m/helm-charts/commit/67ae961))
-* Release 0.0.2 ([3f33f07](https://github.com/younessof2m/helm-charts/commit/3f33f07))
-* add extraObject array to all charts ([34772b7](https://github.com/younessof2m/helm-charts/commit/34772b7))
-* Add initial Changelogs to all Charts ([68f10ca](https://github.com/younessof2m/helm-charts/commit/68f10ca))
-* bump all chart versions for new extraObjects feature ([aaa57f9](https://github.com/younessof2m/helm-charts/commit/aaa57f9))
-* Fix missing t in tag ([3ba5c21](https://github.com/younessof2m/helm-charts/commit/3ba5c21))
-* Fix values.yaml / Chart.yaml linting issues ([043c7e0](https://github.com/younessof2m/helm-charts/commit/043c7e0))
-* initial implementation ([549034c](https://github.com/younessof2m/helm-charts/commit/549034c))
+* Fix clustering and metrics configurations ([f571ab3](https://github.com/rsaladra/helm-charts/commit/f571ab3))
+* Fix ingress port and added test ([67ae961](https://github.com/rsaladra/helm-charts/commit/67ae961))
+* Release 0.0.2 ([3f33f07](https://github.com/rsaladra/helm-charts/commit/3f33f07))
+* add extraObject array to all charts ([34772b7](https://github.com/rsaladra/helm-charts/commit/34772b7))
+* Add initial Changelogs to all Charts ([68f10ca](https://github.com/rsaladra/helm-charts/commit/68f10ca))
+* bump all chart versions for new extraObjects feature ([aaa57f9](https://github.com/rsaladra/helm-charts/commit/aaa57f9))
+* Fix missing t in tag ([3ba5c21](https://github.com/rsaladra/helm-charts/commit/3ba5c21))
+* Fix values.yaml / Chart.yaml linting issues ([043c7e0](https://github.com/rsaladra/helm-charts/commit/043c7e0))
+* initial implementation ([549034c](https://github.com/rsaladra/helm-charts/commit/549034c))

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "4.1.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -249,7 +249,9 @@ spec:
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1	
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with .Values.persistence.annotations }}
         annotations:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Adding fields that are automatically generated by StatefulSet

### Benefits

Deployment orchestrators (such as ArgoCD) will not report constant 'diff' on STS object.

### Possible drawbacks

Not found

### Applicable issues

N/A

### Additional information

Tested on own cluster

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
