### PR TITLE
[postgres] implement support for existingClaim

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: "18.0"
 keywords:
   - postgres

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -198,6 +198,11 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if .Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+        {{- end }}
         {{- if not .Values.config.existingConfigmap }}
         - name: config
           configMap:
@@ -239,6 +244,7 @@ spec:
     whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
     whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
   {{- end }}
+  {{- if not .Values.persistence.existingClaim }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -261,4 +267,5 @@ spec:
       storageClassName: {{ .Values.persistence.storageClass | quote }}
       {{- end }}
       {{- end }}
+    {{- end }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

Adds support for existingClaims in the statefulset, instead of always creating a new pvc. 

### Benefits

With deployment of this Helm-Chart you can use an existing PVC which can contain data from a previous deployment.


### Applicable issues

- fixes #211 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
