### PR TITLE
 [minio, mongodb, postgres, timescaledb] Update securityContext to containerSecurityContext in the values schema

### DIFF
--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -244,7 +244,7 @@
         }
       }
     },
-    "securityContext": {
+    "containerSecurityContext": {
       "type": "object",
       "title": "Security Context",
       "description": "Container security context",

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -262,7 +262,7 @@
       "title": "Affinity Configuration",
       "description": "Affinity rules for pod assignment"
     },
-    "securityContext": {
+    "containerSecurityContext": {
       "type": "object",
       "title": "Security Context",
       "description": "Security context configuration",

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -121,7 +121,7 @@
         }
       }
     },
-    "securityContext": {
+    "containerSecurityContext": {
       "type": "object",
       "title": "Security Context",
       "description": "Container security context",

--- a/charts/timescaledb/values.schema.json
+++ b/charts/timescaledb/values.schema.json
@@ -105,7 +105,7 @@
         }
       }
     },
-    "securityContext": {
+    "containerSecurityContext": {
       "type": "object",
       "title": "Security Context",
       "description": "Container security context",


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
I checked all other charts for the change i made for openshift compatibility. I missed some schema updates

### Benefits

<!-- What benefits will be realized by the code change? -->
Fixes some some schemas.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
- 
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
