### PR TITLE
[keycloak] Allow keycloak to have a relative path

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "26.3.4"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -181,3 +181,14 @@ Return the database JDBC URL
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Return the url to use for probes
+*/}}
+{{- define "keycloak.probeUrl" -}}
+{{- if or (eq .Values.keycloak.httpRelativePath "") (eq .Values.keycloak.httpRelativePath "/") -}}
+{{- printf "/realms/master" -}}
+{{- else -}}
+{{- printf "%s/realms/master" .Values.keycloak.httpRelativePath -}}
+{{- end -}}
+{{- end }}

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -108,6 +108,8 @@ spec:
             - --features-disabled={{ join "," .Values.features.disabled }}
             {{- end }}
           env:
+            - name: KC_HTTP_RELATIVE_PATH
+              value: {{ .Values.keycloak.httpRelativePath | quote | default "/" }}
             - name: KC_BOOTSTRAP_ADMIN_USERNAME
               value: {{ .Values.keycloak.adminUser | quote }}
             - name: KC_BOOTSTRAP_ADMIN_PASSWORD
@@ -166,7 +168,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /realms/master
+              path: {{ include "keycloak.probeUrl" . }}
               port: http
               scheme: HTTP
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
@@ -178,7 +180,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /realms/master
+              path: {{ include "keycloak.probeUrl" . }}
               port: http
               scheme: HTTP
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -190,7 +192,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: /realms/master
+              path: {{ include "keycloak.probeUrl" . }}
               port: http
               scheme: HTTP
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}

--- a/charts/keycloak/tests/deployment-parameters_test.yaml
+++ b/charts/keycloak/tests/deployment-parameters_test.yaml
@@ -1,0 +1,17 @@
+suite: test service account
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: readiness probe should be original
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /realms/master
+  - it: readiness probe should include the httpRelativePath
+    set:
+      keycloak:
+        httpRelativePath: /auth
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /auth/realms/master

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -92,6 +92,8 @@ keycloak:
   proxyTrustedAddresses: ""
   ## @param keycloak.production Enable production mode
   production: false
+  ## @param keycloak.httpRelativePath Set relative path for serving resources; must start with a /
+  httpRelativePath: ""
 
 ## @section Database Configuration
 database:


### PR DESCRIPTION

### Description of the change

Allow keycloak to have a relative path

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
