### PR TITLE
[nginx] Add prometheus nginx metrics exporter

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "1.29.1"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -306,6 +306,46 @@ readinessProbe:
 | `ingress.tls`         | TLS configuration for the Ingress                                             | `[]`                                                                                            |
 
 
+### Metrics Parameters
+
+| Parameter                       | Description                                                        | Default   |
+|----------------------------------|--------------------------------------------------------------------|-----------|
+| `metrics.enabled`                | Start a sidecar Prometheus exporter to expose Nginx metrics        | `false`   |
+| `metrics.image.registry`         | Nginx exporter image registry                                      | `docker.io` |
+| `metrics.image.repository`       | Nginx exporter image repository                                    | `nginx/nginx-prometheus-exporter` |
+| `metrics.image.tag`              | Nginx exporter image tag                                           | `"1.4@sha256:..."` |
+| `metrics.image.pullPolicy`       | Nginx exporter image pull policy                                   | `Always`  |
+| `metrics.resources.limits.memory`| Memory limit for metrics container                                 | `64Mi`    |
+| `metrics.resources.requests.cpu` | CPU request for metrics container                                  | `50m`     |
+| `metrics.resources.requests.memory`| Memory request for metrics container                              | `64Mi`    |
+| `metrics.extraArgs`              | Extra arguments for nginx exporter                                 | `[]`      |
+| `metrics.service.type`           | Metrics service type                                               | `ClusterIP` |
+| `metrics.service.port`           | Metrics service port                                               | `9113`    |
+| `metrics.service.annotations`    | Additional custom annotations for Metrics service                  | `{}`      |
+| `metrics.service.loadBalancerIP` | Load balancer IP if metrics service type is `LoadBalancer`         | `""`      |
+| `metrics.service.loadBalancerSourceRanges` | Allowed addresses for LoadBalancer metrics service         | `[]`      |
+| `metrics.service.clusterIP`      | Static clusterIP or None for headless metrics service              | `""`      |
+| `metrics.service.nodePort`       | NodePort value for LoadBalancer/NodePort metrics service types     | `""`      |
+| `metrics.serviceMonitor.enabled` | Create ServiceMonitor resource(s) for PrometheusOperator           | `false`   |
+| `metrics.serviceMonitor.namespace`| Namespace for ServiceMonitor resource(s)                          | `""`      |
+| `metrics.serviceMonitor.interval`| Interval for scraping metrics                                      | `30s`     |
+| `metrics.serviceMonitor.scrapeTimeout`| Timeout for scraping metrics                                 | `""`      |
+| `metrics.serviceMonitor.relabelings`| Additional relabeling of metrics                              | `[]`      |
+| `metrics.serviceMonitor.metricRelabelings`| Additional metric relabeling of metrics                    | `[]`      |
+| `metrics.serviceMonitor.honorLabels`| Honor metrics labels                                         | `false`   |
+| `metrics.serviceMonitor.selector`| Prometheus instance selector labels                               | `{}`      |
+| `metrics.serviceMonitor.annotations`| Additional annotations for ServiceMonitor                     | `{}`      |
+| `metrics.serviceMonitor.namespaceSelector`| Namespace selector for ServiceMonitor                      | `{}`      |
+
+**Note:**  
+To enable metrics, set `metrics.enabled: true` and ensure your Nginx configuration includes a stub status endpoint, e.g.:
+```nginx
+location /stub_status {
+  stub_status on;
+}
+```
+
+
 ### Extra Configuration Parameters
 
 | Parameter           | Description                                                                         | Default |

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -98,3 +98,10 @@ Return the custom NGINX stream server config configmap.
     {{- include "common.fullname" . -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the proper Nginx metrics image name
+*/}}
+{{- define "nginx.metrics.image" -}}
+{{- include "common.image" (dict "image" .Values.metrics.image "global" .Values.global) -}}
+{{- end }}

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -202,6 +202,49 @@ spec:
             {{- toYaml .Values.cloneStaticSiteFromGit.extraVolumeMounts | nindent 12 }}
             {{- end }}
         {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          securityContext: {{ include "common.renderContainerSecurityContext" . | nindent 12 }}
+          image: {{ include "nginx.metrics.image" . | quote }}
+          imagePullPolicy: {{ include "common.imagePullPolicy" (dict "image" .Values.metrics.image) }}
+          command:
+            - nginx-prometheus-exporter
+            - --nginx.scrape-uri=http://localhost:8080/stub_status
+            {{- range .Values.metrics.extraArgs }}
+            - {{ . }}
+            {{- end }}
+          args:
+            {{- if .Values.metrics.extraArgs }}
+            {{- range .Values.metrics.extraArgs }}
+            {{- if not (hasPrefix "--" .) }}
+            - {{ . }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 9113
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+            successThreshold: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            failureThreshold: 3
+            successThreshold: 1
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+        {{- end }}
       volumes:
         - name: emptydir
           emptyDir: {}

--- a/charts/nginx/templates/metrics-service.yaml
+++ b/charts/nginx/templates/metrics-service.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nginx.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range .Values.metrics.service.loadBalancerSourceRanges }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- if and (eq .Values.metrics.service.type "ClusterIP") .Values.metrics.service.clusterIP }}
+  clusterIP: {{ .Values.metrics.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      targetPort: metrics
+      {{- if and (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) .Values.metrics.service.nodePort }}
+      nodePort: {{ .Values.metrics.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "nginx.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/nginx/templates/servicemonitor.yaml
+++ b/charts/nginx/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "nginx.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ include "nginx.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "nginx.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -26,6 +26,7 @@
     "commonAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
     "image": {
       "type": "object",
+      "description": "NGINX image configuration",
       "properties": {
         "registry": { "type": "string" },
         "repository": { "type": "string" },
@@ -37,6 +38,7 @@
     "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
     "containerPorts": {
       "type": "array",
+      "description": "List of container ports",
       "items": {
         "type": "object",
         "properties": {
@@ -117,6 +119,7 @@
     },
     "autoscaling": {
       "type": "object",
+      "description": "Autoscaling configuration",
       "properties": {
         "enabled": { "type": "boolean" },
         "minReplicas": { "type": ["integer", "string"] },
@@ -125,12 +128,27 @@
         "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
       }
     },
-    "resources": { "type": "object" },
-    "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
-    "tolerations": { "type": "array", "items": { "type": "object" } },
-    "affinity": { "type": "object" },
+    "resources": {
+      "type": "object",
+      "description": "Resource requests and limits"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod scheduling",
+      "additionalProperties": { "type": "string" }
+    },
+    "tolerations": {
+      "type": "array",
+      "description": "Tolerations for pod scheduling",
+      "items": { "type": "object" }
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod scheduling"
+    },
     "containerSecurityContext": {
       "type": "object",
+      "description": "Container-level security context settings",
       "properties": {
         "runAsUser": { "type": "integer" },
         "runAsNonRoot": { "type": "boolean" },
@@ -139,6 +157,7 @@
     },
     "podSecurityContext": {
       "type": "object",
+      "description": "Pod-level security context settings",
       "properties": {
         "fsGroup": { "type": "integer" }
       }
@@ -171,6 +190,7 @@
     },
     "extraEnv": {
       "type": "array",
+      "description": "Extra environment variables",
       "items": {
         "type": "object",
         "properties": {
@@ -180,14 +200,117 @@
         "required": ["name", "value"]
       }
     },
-    "extraVolumes": { "type": "array", "items": { "type": "object" } },
-    "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Additional volumes",
+      "items": { "type": "object" }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Additional volume mounts",
+      "items": { "type": "object" }
+    },
     "extraObjects": { "type": "array", "items": { "type": "object" } },
-    "config": { "type": "string" },
-    "existingConfigConfigmap": { "type": "string" },
-    "serverConfig": { "type": "string" },
-    "existingServerConfigConfigmap": { "type": "string" },
-    "streamServerConfig": { "type": "string" },
-    "existingStreamServerConfigmap": { "type": "string" }
+    "config": {
+      "type": "string",
+      "description": "Custom NGINX configuration"
+    },
+    "existingConfigConfigmap": {
+      "type": "string",
+      "description": "Name of existing ConfigMap for NGINX config"
+    },
+    "serverConfig": {
+      "type": "string",
+      "description": "Custom server configuration"
+    },
+    "existingServerConfigConfigmap": {
+      "type": "string",
+      "description": "Name of existing ConfigMap for server config"
+    },
+    "streamServerConfig": {
+      "type": "string",
+      "description": "Custom stream server configuration"
+    },
+    "existingStreamServerConfigmap": {
+      "type": "string",
+      "description": "Name of existing ConfigMap for stream server config"
+    },
+    "serviceAccountName": {
+      "type": "string",
+      "description": "Service account name for the pod"
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Prometheus metrics configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Start a sidecar prometheus exporter to expose Nginx metrics"
+        },
+        "image": {
+          "type": "object",
+          "description": "Nginx exporter image configuration",
+          "properties": {
+            "registry": { "type": "string" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource limits and requests for metrics container",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "memory": { "type": "string" }
+              }
+            },
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": { "type": "string" },
+                "memory": { "type": "string" }
+              }
+            }
+          }
+        },
+        "extraArgs": {
+          "type": "array",
+          "description": "Extra arguments for nginx exporter",
+          "items": { "type": "string" }
+        },
+        "service": {
+          "type": "object",
+          "description": "Metrics service configuration",
+          "properties": {
+            "type": { "type": "string" },
+            "port": { "type": "integer" },
+            "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+            "loadBalancerIP": { "type": "string" },
+            "loadBalancerSourceRanges": { "type": "array", "items": { "type": "string" } },
+            "clusterIP": { "type": "string" },
+            "nodePort": { "type": "string" }
+          }
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "description": "Prometheus ServiceMonitor configuration",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "interval": { "type": "string" },
+            "scrapeTimeout": { "type": "string" },
+            "relabelings": { "type": "array", "items": { "type": "object" } },
+            "metricRelabelings": { "type": "array", "items": { "type": "object" } },
+            "honorLabels": { "type": "boolean" },
+            "selector": { "type": "object", "additionalProperties": { "type": "string" } },
+            "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+            "namespaceSelector": { "type": "object", "additionalProperties": { "type": "string" } }
+          }
+        }
+      }
+    }
   }
 }

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -231,6 +231,72 @@ extraVolumes: []
 ## @param extraVolumeMounts Additional volume mounts to add to the Nginx container
 extraVolumeMounts: []
 
+## @section Nginx metrics parameters
+## Prometheus metrics configuration
+## @see https://nginx.org/en/docs/http/ngx_http_stub_status_module.html#stub_status
+metrics:
+  ## @param metrics.enabled Start a sidecar prometheus exporter to expose Nginx metrics
+  enabled: false
+  ## @param metrics.image.registry Nginx exporter image registry
+  ## @param metrics.image.repository Nginx exporter image repository
+  ## @param metrics.image.tag Nginx exporter image tag
+  ## @param metrics.image.pullPolicy Nginx exporter image pull policy
+  image:
+    registry: docker.io
+    repository: nginx/nginx-prometheus-exporter
+    tag: "1.4@sha256:6edfb73afd11f2d83ea4e8007f5068c3ffaa38078a6b0ad1339e5bd2f637aacd"
+    pullPolicy: Always
+  ## @param metrics.resources Resource limits and requests for metrics container
+  resources:
+    limits:
+      memory: 64Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  ## @param metrics.extraArgs Extra arguments for nginx exporter, for example:
+  ## extraArgs:
+  ##   - --log.level=info 
+  ##   - --log.format=logfmt
+  extraArgs: []
+  ## Metrics service configuration
+  service:
+    ## @param metrics.service.type Metrics service type
+    type: ClusterIP
+    ## @param metrics.service.port Metrics service port
+    port: 9113
+    ## @param metrics.service.annotations Additional custom annotations for Metrics service
+    annotations: {}
+    ## @param metrics.service.loadBalancerIP Load balancer IP if metrics service type is `LoadBalancer`
+    loadBalancerIP: ""
+    ## @param metrics.service.loadBalancerSourceRanges Addresses that are allowed when metrics service is LoadBalancer
+    loadBalancerSourceRanges: []
+    ## @param metrics.service.clusterIP Static clusterIP or None for headless services when metrics service type is ClusterIP
+    clusterIP: ""
+    ## @param metrics.service.nodePort Specify the nodePort value for the LoadBalancer and NodePort service types
+    nodePort: ""
+  ## Prometheus ServiceMonitor configuration
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace in which to create ServiceMonitor resource(s)
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.relabelings Specify additional relabeling of metrics
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings Specify additional metric relabeling of metrics
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Honor metrics labels
+    honorLabels: false
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    selector: {}
+    ## @param metrics.serviceMonitor.annotations Additional custom annotations for the ServiceMonitor
+    annotations: {}
+    ## @param metrics.serviceMonitor.namespaceSelector Namespace selector for ServiceMonitor
+    namespaceSelector: {}
+
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add the [nginx-prometheus-exporter](https://hub.docker.com/r/nginx/nginx-prometheus-exporter) as a sidecar container to gather metrics.

### Benefits

Add nginx-prometheus-metrics-exporter to the chart to gather metrics.

### Possible drawbacks

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
