### PR TITLE
[postgres] feat: add metrics exporter

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.7.3
+version: 0.8.0
 appVersion: "18.0"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -288,6 +288,30 @@ extraObjects:
 
 All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
 
+### Metrics Configuration
+
+| Parameter                                  | Description                                                                     | Default                                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------- | --------------------------------------- |
+| `metrics.enabled`                          | Start a sidecar prometheus exporter to expose PostgreSQL metrics                | `false`                                 |
+| `metrics.image.registry`                   | PostgreSQL exporter image registry                                              | `quay.io`                               |
+| `metrics.image.repository`                 | PostgreSQL exporter image repository                                            | `prometheuscommunity/postgres-exporter` |
+| `metrics.image.tag`                        | PostgreSQL exporter image tag                                                   | `v0.18.1`                               |
+| `metrics.image.pullPolicy`                 | PostgreSQL exporter image pull policy                                           | `Always`                                |
+| `metrics.resources`                        | Resource limits and requests for metrics container                              | `{}`                                    |
+| `metrics.service.annotations`              | Additional custom annotations for Metrics service                               | `{}`                                    |
+| `metrics.service.labels`                   | Additional custom labels for Metrics service                                    | `{}`                                    |
+| `metrics.service.port`                     | Metrics service port                                                            | `9187`                                  |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator | `false`                                 |
+| `metrics.serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created                       | `""`                                    |
+| `metrics.serviceMonitor.interval`          | The interval at which metrics should be scraped                                 | `30s`                                   |
+| `metrics.serviceMonitor.scrapeTimeout`     | The timeout after which the scrape is ended                                     | `10s`                                   |
+| `metrics.serviceMonitor.selector`          | Additional labels for ServiceMonitor resource                                   | `{}`                                    |
+| `metrics.serviceMonitor.annotations`       | ServiceMonitor annotations                                                      | `{}`                                    |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels        | `false`                                 |
+| `metrics.serviceMonitor.relabelings`       | ServiceMonitor relabel configs to apply to samples before scraping              | `[]`                                    |
+| `metrics.serviceMonitor.metricRelabelings` | ServiceMonitor metricRelabelings configs to apply to samples before ingestion   | `[]`                                    |
+| `metrics.serviceMonitor.namespaceSelector` | ServiceMonitor namespace selector                                               | `{}`                                    |
+
 ## Examples
 
 ### Basic Deployment
@@ -437,6 +461,33 @@ data:
     work_mem = 16MB
     maintenance_work_mem = 256MB
     # Add your custom configuration here
+```
+
+### Monitoring with Prometheus
+
+Enable metrics collection with Prometheus:
+
+```yaml
+# values-monitoring.yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+```
+
+Deploy with monitoring enabled:
+
+```bash
+helm install my-postgres ./charts/postgres -f values-monitoring.yaml
+```
+
+The PostgreSQL exporter will expose metrics on port 9187, and if you have Prometheus Operator installed, the ServiceMonitor will automatically configure Prometheus to scrape the metrics.
+
+You can access metrics directly via port-forward:
+
+```bash
+kubectl port-forward service/my-postgres-metrics 9187:9187
+curl http://localhost:9187/metrics
 ```
 
 ## Access PostgreSQL

--- a/charts/postgres/templates/service-metrics.yaml
+++ b/charts/postgres/templates/service-metrics.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    {{- include "postgres.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/postgres/templates/servicemonitor.yaml
+++ b/charts/postgres/templates/servicemonitor.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "postgres.fullname" . }}-metrics
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ include "postgres.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "postgres.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -197,6 +197,49 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/init-custom-user.sh
               subPath: init-custom-user.sh
             {{- end }}
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+          env:
+            - name: DATA_SOURCE_NAME
+              value: "postgresql://{{ include "postgres.username" . }}:$(POSTGRES_PASSWORD)@localhost:{{ .Values.service.targetPort }}/{{ include "postgres.database" . }}?sslmode=disable"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.secretName" . }}
+                  key: {{ .Values.auth.secretKeys.passwordKey }}
+          ports:
+            - name: metrics
+              containerPort: 9187
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /
+              port: metrics
+          readinessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          livenessProbe:
+            httpGet:
+              path: /
+              port: metrics
+          {{- with .Values.metrics.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       volumes:
         {{- if not .Values.persistence.enabled }}
         - name: data

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -285,3 +285,49 @@ initContainers: []
 
 ## @param extraObjects Array of extra objects to deploy with the release
 extraObjects: []
+
+## @section Metrics configuration
+metrics:
+  ## @param metrics.enabled Start a sidecar prometheus exporter to expose PostgreSQL metrics
+  enabled: false
+  image:
+    ## @param metrics.image.registry PostgreSQL exporter image registry
+    registry: quay.io
+    ## @param metrics.image.repository PostgreSQL exporter image repository
+    repository: prometheuscommunity/postgres-exporter
+    ## @param metrics.image.tag PostgreSQL exporter image tag
+    tag: "v0.18.1@sha256:fb96c4413985d4b23ab02b19022b3d70a86c8e0a62f41ab15ebb6f4673781a5d"
+    ## @param metrics.image.pullPolicy PostgreSQL exporter image pull policy
+    pullPolicy: Always
+  ## @param metrics.resources Resource limits and requests for metrics container
+  resources: {}
+  ## Metrics service configuration
+  service:
+    ## @param metrics.service.annotations Additional custom annotations for Metrics service
+    annotations: {}
+    ## @param metrics.service.labels Additional custom labels for Metrics service
+    labels: {}
+    ## @param metrics.service.port Metrics service port
+    port: 9187
+  ## Prometheus Operator ServiceMonitor configuration
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
+    scrapeTimeout: 10s
+    ## @param metrics.serviceMonitor.selector Additional labels for ServiceMonitor resource
+    selector: {}
+    ## @param metrics.serviceMonitor.annotations ServiceMonitor annotations
+    annotations: {}
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    honorLabels: false
+    ## @param metrics.serviceMonitor.relabelings ServiceMonitor relabel configs to apply to samples before scraping
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings ServiceMonitor metricRelabelings configs to apply to samples before ingestion
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.namespaceSelector ServiceMonitor namespace selector
+    namespaceSelector: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Hi,

I would like to add the possibility to scrape metrics in the `postgres` helm chart (disabled by default).

I am not sure how the `values.schema.json` is generated, I was not able to replicate it with:

```
helm plugin install https://github.com/dadav/helm-schema
helm schema
```

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Easier to monitor/alert .

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
