### PR TITLE
[common] feat: add "common.namespace", defaults to .Release.Namespace…

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for common templates and helper functions
 type: library
-version: 1.1.1
+version: 1.1.2
 appVersion: "1.0.0"
 
 home: https://www.cloudpirates.io

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -24,6 +24,15 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Return the namespace to use for resources.
+Defaults to .Release.Namespace but can be overridden via .Values.namespaceOverride.
+Useful for multi-namespace deployments in combined charts.
+*/}}
+{{- define "common.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "common.chart" -}}


### PR DESCRIPTION
### Description of the change

Add "common.namespace", defaults to .Release.Namespace but can be overridden via .Values.namespaceOverride

### Benefits

"common.namespace" returns the namespace to use for resources.
Defaults to .Release.Namespace but can be overridden via .Values.namespaceOverride.
Useful for multi-namespace deployments in combined charts.

### Possible drawbacks

None that I know of.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
