### PR TITLE
[universal]: Add non verified commit warning github action

### DIFF
--- a/.github/workflows/check-signed-commits.yaml
+++ b/.github/workflows/check-signed-commits.yaml
@@ -106,7 +106,7 @@ jobs:
           cat << 'EOF' | gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} -F -
           ## ⚠️ Unsigned Commits Detected
 
-          This pull request contains **${{ steps.check-commits.outputs.unsigned_commits }}** out of **${{ steps.check-commits.outputs.total_commits }}** unsigned commits.
+          This pull request contains unsigned commits.
 
           ### What does this mean?
 


### PR DESCRIPTION
### Description of the change

Add a warning, once per pr, if a unsigned commit is in the pr

### Benefits

Kindly nudge the user into signing their commits

### Possible drawbacks

Annoying / deterring any new contributors.

### Applicable issues

- fixes #

### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [N/A] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [N/A] Variables are documented in the values.yaml and added to the `README.md`
- [N/A] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
