### PR TITLE
[postgres] fix: add connection details to secret

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: "18.0"
 keywords:
   - postgres

--- a/charts/postgres/templates/secret.yaml
+++ b/charts/postgres/templates/secret.yaml
@@ -17,5 +17,15 @@ data:
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingPostgresPassword = index $existingSecret.data "postgres-password" }}
   {{- end }}
-  postgres-password: {{ $existingPostgresPassword | default (.Values.auth.password | default (randAlphaNum 32) | b64enc) | quote }}
+  {{- $postgresPassword := $existingPostgresPassword | default (.Values.auth.password | default (randAlphaNum 32) | b64enc) }}
+  {{- $host := printf "%s.%s.svc" (include "postgres.fullname" .) .Release.Namespace }}
+  {{- $port := .Values.service.port | toString }}
+  {{- $username := include "postgres.username" . }}
+  {{- $database := include "postgres.database" . }}
+  postgres-password: {{ $postgresPassword | quote }}
+  host: {{ $host | b64enc | quote }}
+  port: {{ $port | b64enc | quote }}
+  username: {{ $username | b64enc | quote }}
+  database: {{ $database | b64enc | quote }}
+  uri: {{ printf "postgresql://%s:%s@%s:%s/%s" $username ($postgresPassword | b64dec) $host $port $database | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

I would like to add more connection details to the generated `secret`.

### Benefits

Make easier to pass database credentials to the client. 

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
