### PR TITLE
[memcached]: add missing automountServiceAccountToken key to deployment spec

### DIFF
--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.6.39"
 
 keywords:

--- a/charts/memcached/templates/deployment.yaml
+++ b/charts/memcached/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
 {{- with (include "memcached.imagePullSecrets" .) }}
 {{ . | nindent 6 }}
 {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "memcached.serviceAccountName" . }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
       containers:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

While the value itself is present in the `values.yaml`, setting it didn't have any affect because it was missing in the spec of the deployment.

### Benefits

The boolean Helm-Value can actually be used to define the desired target state

### Possible drawbacks

-

### Applicable issues

-

### Additional information

-

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
