### PR TITLE
[redis] Add initContainer securityContext and improve security defaults

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: "8.2.2"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -191,13 +191,17 @@ redis-cli -h my-redis -a $REDIS_PASSWORD
 
 ### Security Context
 
-| Parameter                                           | Description                    | Default |
-| --------------------------------------------------- | ------------------------------ | ------- |
-| `containerSecurityContext.runAsUser`                | User ID to run the container   | `999`   |
-| `containerSecurityContext.runAsNonRoot`             | Run as non-root user           | `true`  |
-| `containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation     | `false` |
-| `containerSecurityContext.readOnlyRootFilesystem`   | Read-only root filesystem      | `true`  |
-| `podSecurityContext.fsGroup`                        | Pod's Security Context fsGroup | `999`   |
+| Parameter                                           | Description                       | Default          |
+| --------------------------------------------------- | --------------------------------- | ---------------- |
+| `containerSecurityContext.runAsUser`                | User ID to run the container      | `999`            |
+| `containerSecurityContext.runAsGroup`               | Group ID to run the container     | `999`            |
+| `containerSecurityContext.runAsNonRoot`             | Run as non-root user              | `true`           |
+| `containerSecurityContext.privileged`               | Set container's privileged mode   | `false`          |
+| `containerSecurityContext.allowPrivilegeEscalation` | Allow privilege escalation        | `false`          |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Read-only root filesystem         | `true`           |
+| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped  | `["ALL"]`        |
+| `containerSecurityContext.seccompProfile.type`      | Seccomp profile for the container | `RuntimeDefault` |
+| `podSecurityContext.fsGroup`                        | Pod's Security Context fsGroup    | `999`            |
 
 ### Health Checks
 

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
       initContainers:
         - name: redis-init
           image: {{ include "redis.image" . | quote }}
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           imagePullPolicy: {{ include "cloudpirates.imagePullPolicy" (dict "image" .Values.image) }}
           command:
             - /bin/sh

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -135,14 +135,25 @@ affinity: {}
 topologySpreadConstraints: []
 
 containerSecurityContext:
-  ## @param securityContext.runAsUser User ID to run the container
+  ## @param containerSecurityContext.runAsUser User ID to run the container
   runAsUser: 999
-  ## @param securityContext.runAsNonRoot Run as non-root user
+  ## @param containerSecurityContext.runAsGroup Group ID to run the container
+  runAsGroup: 999
+  ## @param containerSecurityContext.runAsNonRoot Run as non-root user
   runAsNonRoot: true
+  ## @param containerSecurityContext.privileged Set container's privileged mode
+  privileged: false
   ## @param containerSecurityContext.allowPrivilegeEscalation Set Redis container's privilege escalation
   allowPrivilegeEscalation: false
   ## @param containerSecurityContext.readOnlyRootFilesystem Read-only root filesystem
   readOnlyRootFilesystem: true
+  ## @param containerSecurityContext.capabilities Linux capabilities to be dropped
+  capabilities:
+    drop:
+      - ALL
+  ## @param containerSecurityContext.seccompProfile Seccomp profile for the container
+  seccompProfile:
+    type: RuntimeDefault
 
 ## @param podSecurityContext Security context for the pod
 podSecurityContext:


### PR DESCRIPTION
### Description of the change

Add security context for redis initContainers and improve defaults for all containers following security best practices:

drop all capabilities, set seccompprofile, set group uid, set privileged to false

### Benefits

Redis deployment will be more secure and compliant with security standards and best practices

### Possible drawbacks

### Applicable issues

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
