### PR TITLE
chore: auto-generate values.schema.json for updated charts

### DIFF
--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -181,6 +181,9 @@
                 }
             }
         },
+        "podAnnotations": {
+            "type": "object"
+        },
         "podSecurityContext": {
             "type": "object",
             "properties": {

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -358,6 +358,12 @@
                 }
             }
         },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podLabels": {
+            "type": "object"
+        },
         "podSecurityContext": {
             "type": "object",
             "properties": {
@@ -419,6 +425,9 @@
         "service": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object"
+                },
                 "port": {
                     "type": "integer"
                 },

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -433,6 +433,9 @@
         "service": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object"
+                },
                 "ports": {
                     "type": "array",
                     "items": {

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -238,6 +238,9 @@
         "service": {
             "type": "object",
             "properties": {
+                "annotations": {
+                    "type": "object"
+                },
                 "ports": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Automatically generated JSON schemas for Helm values files.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [ ] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
