### PR TITLE
[minio] Remove securitycontext on empty obejct

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: "2025.09.07"
 keywords:
   - minio

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -33,10 +33,14 @@ spec:
 {{ . | nindent 6 }}
 {{- end }}
       serviceAccountName: {{ template "minio.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- if .Values.containerSecurityContext }}
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
+          {{- end }}
           image: {{ include "minio.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           command: ["/bin/sh"]


### PR DESCRIPTION

### Description of the change

If the securityContext object is "null" the whole attribute will be left out of the deployment. 

### Benefits

This allows an user to disable the securityContext if needed.


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
