### PR TITLE
[postgres] add options to set service load balancer ip and external traffic policy

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.10.6
+version: 0.10.7
 appVersion: "18.0.0"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -155,12 +155,14 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 
 ### Service configuration
 
-| Parameter             | Description               | Default     |
-| --------------------- | ------------------------- | ----------- |
-| `service.type`        | PostgreSQL service type   | `ClusterIP` |
-| `service.port`        | PostgreSQL service port   | `5432`      |
-| `service.targetPort`  | PostgreSQL container port | `5432`      |
-| `service.annotations` | Service annotations       | `{}`        |
+| Parameter                       | Description                                                                       | Default     |
+| ------------------------------- | --------------------------------------------------------------------------------- | ----------- |
+| `service.type`                  | PostgreSQL service type                                                           | `ClusterIP` |
+| `service.port`                  | PostgreSQL service port                                                           | `5432`      |
+| `service.targetPort`            | PostgreSQL container port                                                         | `5432`      |
+| `service.annotations`           | Service annotations                                                               | `{}`        |
+| `service.loadBalancerIP`        | Load balancer IP (applies if service type is `LoadBalancer`)                      | `""`        |
+| `service.externalTrafficPolicy` | External traffic policy (applies if service type is `LoadBalancer` or `NodePort`) | `Cluster`   |
 
 ### Ingress configuration
 

--- a/charts/postgres/templates/service.yaml
+++ b/charts/postgres/templates/service.yaml
@@ -12,6 +12,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) (not (empty .Values.service.externalTrafficPolicy)) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}


### PR DESCRIPTION


### Description of the change

If service type is set to LoadBalancer, most of the time you want to also control load balancer ip and external traffic policy.

I added such options.

### Benefits

<!-- What benefits will be realized by the code change? -->

Postgres can be exposed using load balancer.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
