### PR TITLE
[redis] Add support for extraPorts in Services and StatefulSet

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "8.2.2"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -281,6 +281,7 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | `extraVolumes`      | Additional volumes to add to the pod                                    | `[]`    |
 | `extraVolumeMounts` | Additional volume mounts for Redis container                            | `[]`    |
 | `extraObjects`      | A list of additional Kubernetes objects to deploy alongside the release | `[]`    |
+| `extraPorts`        | Additional ports to be exposed by Services and StatefulSet              | `[]`    |
 
 #### Extra Objects
 

--- a/charts/redis/templates/headless-service.yaml
+++ b/charts/redis/templates/headless-service.yaml
@@ -17,6 +17,11 @@ spec:
       targetPort: redis
       protocol: TCP
       name: redis
+    {{- range .Values.extraPorts }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort | default .name }}
+      name: {{ .name }}
+    {{- end }}
     {{- if and .Values.sentinel.enabled (eq .Values.architecture "replication") }}
     - port: {{ .Values.sentinel.port }}
       targetPort: sentinel

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -25,6 +25,11 @@ spec:
       targetPort: redis
       protocol: TCP
       name: redis
+    {{- range .Values.extraPorts }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort | default .name }}
+      name: {{ .name }}
+    {{- end }}
   selector:
     {{- include "redis.selectorLabels" . | nindent 4 }}
   {{- if and .Values.sentinel.enabled (eq .Values.architecture "replication") }}

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -206,6 +206,10 @@ spec:
             - name: redis
               containerPort: 6379
               protocol: TCP
+            {{- range .Values.extraPorts }}
+            - containerPort: {{ .containerPort }}
+              name: {{ .name }}
+            {{- end }}
           {{- if or .Values.auth.enabled .Values.extraEnv }}
           env:
             {{- if .Values.auth.enabled }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -132,6 +132,9 @@
         "extraObjects": {
             "type": "array"
         },
+        "extraPorts":{
+            "type": "array"
+        },
         "extraVolumeMounts": {
             "type": "array"
         },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -214,6 +214,15 @@ extraEnvVars: []
 ##   - --maxmemory-policy volatile-lru
 extraFlags: []
 
+## @param extraPorts Additional ports to add to the pod and service
+## Example:
+## extraPorts:
+## - name: redis-cluster
+##   port: 16379
+##   targetPort: redis-cluster
+##   containerPort: 16379
+extraPorts: []
+
 ## @param extraVolumes Additional volumes to add to the pod
 extraVolumes: []
 


### PR DESCRIPTION
### Description of the change

Adding support for extraPorts, same way as it's done for rabbitmq.

### Benefits

Allows to expose additional ports. It's entry change for enabling redis in cluster mode, as cluster is exposed via 16379 port.

### Possible drawbacks

Not found

### Applicable issues

Not created.

### Additional information

I plan to add support for cluster mode in this chart. I'm actively testing it right now in my workspace. I'm starting with sharing minimal change that can unblock such feature.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
