### PR TITLE
[redis] fix: extraEnvVars parameter in statefulset template

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: "8.2.2"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -210,7 +210,7 @@ spec:
             - containerPort: {{ .containerPort }}
               name: {{ .name }}
             {{- end }}
-          {{- if or .Values.auth.enabled .Values.extraEnv }}
+          {{- if or .Values.auth.enabled .Values.extraEnvVars }}
           env:
             {{- if .Values.auth.enabled }}
             - name: REDIS_PASSWORD


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

When .Values.auth.enabled is false then env: never being rendered in Pod manifest due to .Values.extraEnv instead of .Values.extraEnvVars in condition check:
{{- if or .Values.auth.enabled .Values.extraEnv }}

### Benefits

Fix rendering `env` parameters in StatefulSet manifest.

### Possible drawbacks

none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes https://github.com/CloudPirates-io/helm-charts/issues/496

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
