### PR TITLE
[keycloak] Provide empty mounts for themes and providers

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "26.4.2"
 keywords:
   - keycloak
@@ -51,8 +51,5 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |2
-        - kind: changed
-          description: "fix: use metrics service targetPort configuration (#493)"
-          links:
-            - name: "Commit bd3cc53"
-              url: "https://github.com/CloudPirates-io/helm-charts/commit/bd3cc53"
+        - kind: added
+          description: "feat: add emptyDir volumes for /opt/keycloak/themes and /opt/keycloak/providers to support custom themes and providers via initContainers"

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -528,6 +528,53 @@ realm:
     }
 ```
 
+### Using Custom Themes and Providers
+
+The Keycloak deployment automatically mounts empty directories at `/opt/keycloak/themes` and `/opt/keycloak/providers`. You can use initContainers to copy custom themes and providers into these directories.
+
+**Example: Adding custom themes and providers with an initContainer**
+
+```yaml
+# values-custom-themes.yaml
+extraInitContainers:
+  - name: add-custom-themes
+    image: your-registry/keycloak-themes:latest
+    imagePullPolicy: Always
+    command:
+      - sh
+      - -c
+      - |
+        cp -r /themes/* /opt/keycloak/themes/
+        cp -r /providers/* /opt/keycloak/providers/
+    volumeMounts:
+      - name: keycloak-themes
+        mountPath: /opt/keycloak/themes
+      - name: keycloak-providers
+        mountPath: /opt/keycloak/providers
+```
+
+In this example:
+- Create a Docker image containing your custom themes in `/themes` and providers in `/providers`
+- The initContainer copies these files to the mounted volumes
+- Keycloak will automatically detect and use them on startup
+
+You can also use this approach to download themes/providers from external sources:
+
+```yaml
+extraInitContainers:
+  - name: download-themes
+    image: curlimages/curl:latest
+    command:
+      - sh
+      - -c
+      - |
+        curl -L -o /tmp/theme.zip https://example.com/theme.zip
+        unzip /tmp/theme.zip -d /opt/keycloak/themes/
+    volumeMounts:
+      - name: keycloak-themes
+        mountPath: /opt/keycloak/themes
+```
+
 ### Using Custom TLS Certificates
 
 #### Option 1: Using cert-manager (Recommended)

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -255,6 +255,10 @@ spec:
               mountPath: /opt/keycloak/work
             - name: keycloak-lib-quarkus
               mountPath: /opt/keycloak/lib/quarkus
+            - name: keycloak-themes
+              mountPath: /opt/keycloak/themes
+            - name: keycloak-providers
+              mountPath: /opt/keycloak/providers
             {{- if .Values.realm.configFile }}
             - name: realm-config
               mountPath: /opt/keycloak/data/import
@@ -292,6 +296,10 @@ spec:
         - name: keycloak-work
           emptyDir: {}
         - name: keycloak-lib-quarkus
+          emptyDir: {}
+        - name: keycloak-themes
+          emptyDir: {}
+        - name: keycloak-providers
           emptyDir: {}
         {{- if .Values.realm.configFile }}
         - name: realm-config


### PR DESCRIPTION
### Description of the change

Adding two empty mount paths for themes and providers, e.g. 

/opt/keycloak/themes

/opt/keycloak/providers

### Benefits

Working themes and providers

### Possible drawbacks

None

### Applicable issues

- fixes #500 

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
