### PR TITLE
[workflows] Don't auto-label pull requests from forks

### DIFF
--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   label:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
### Description of the change

The auto-label pipeline fails with a 403 if we try to apply labels to a pull request created from a fork.
This just adds a simple `if`, so it only runs when not triggered from a fork.

### Benefits

The auto-label pipeline gets skipped if it would fail anyways - then there is no red X wich can't be fixed.
