### PR TITLE
[documentation] Add Discord server to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <a href="https://artifacthub.io/packages/search?org=cloudpirates">
       <img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudpirates" />
     </a>
-    <a href="https://discord.gg/XUn9Kt5dsy">
+    <a href="https://github.com/CloudPirates-io/helm-charts/blob/main/CONTRIBUTING.md">
       <img src="https://img.shields.io/badge/contributions-welcome-purple.svg" />
     </a>
     <a href="https://discord.gg/XUn9Kt5dsy">


### PR DESCRIPTION
### Description of the change

Added the invite link for our new CloudPirates discord server to the readme.
Also added a "contributions welcome" badge (:

### Benefits

A better place to chat than discussions.
Planned to use as a weekly or monthly meeting platform to discuss future changes and improvements of this project.