### PR TITLE
[keycloak] add truststoreExistingSecretKey, add truststorePassword to env-Vars

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: "26.4.2"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -148,28 +148,29 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### TLS Configuration
 
-| Parameter                         | Description                                                                                     | Default                                     |
-| --------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `tls.enabled`                     | Enable TLS/HTTPS support using custom certificates                                              | `false`                                     |
-| `tls.existingSecret`              | Name of existing secret containing TLS certificate and key (PEM format, keys: tls.crt, tls.key) | `""`                                        |
-| `tls.certificateFile`             | Path where the TLS certificate file will be mounted (internal)                                  | `"/opt/keycloak/certs/tls.crt"`             |
-| `tls.certificateKeyFile`          | Path where the TLS certificate key file will be mounted (internal)                              | `"/opt/keycloak/certs/tls.key"`             |
-| `tls.certManager.enabled`         | Enable cert-manager integration for automatic certificate provisioning                          | `false`                                     |
-| `tls.certManager.issuerRef.name`  | Name of the cert-manager Issuer or ClusterIssuer                                                | `""`                                        |
-| `tls.certManager.issuerRef.kind`  | Kind of the cert-manager issuer (Issuer or ClusterIssuer)                                       | `ClusterIssuer`                             |
-| `tls.certManager.issuerRef.group` | Group of the cert-manager issuer                                                                | `cert-manager.io`                           |
-| `tls.certManager.duration`        | Certificate duration (e.g., 2160h for 90 days)                                                  | `""`                                        |
-| `tls.certManager.renewBefore`     | Time before expiry to renew certificate (e.g., 360h for 15 days)                                | `""`                                        |
-| `tls.certManager.commonName`      | Certificate common name (defaults to first dnsName if not specified)                            | `""`                                        |
-| `tls.certManager.dnsNames`        | List of DNS names for the certificate (uses ingress.hosts if not specified)                     | `[]`                                        |
-| `tls.certManager.ipAddresses`     | List of IP addresses for the certificate                                                        | `[]`                                        |
-| `tls.certManager.secretName`      | Name for the generated secret (defaults to `<fullname>-tls`)                                    | `""`                                        |
-| `tls.certManager.usages`          | Certificate key usages                                                                          | `["digital signature", "key encipherment"]` |
-| `tls.certManager.annotations`     | Additional annotations for the Certificate resource                                             | `{}`                                        |
-| `tls.truststoreEnabled`           | Enable truststore for client certificate validation or outgoing HTTPS requests                  | `false`                                     |
-| `tls.truststoreExistingSecret`    | Name of existing secret containing truststore file (Java Keystore format, key: truststore.jks)  | `""`                                        |
-| `tls.truststorePassword`          | Password for the truststore (use with caution - consider using existing secret)                 | `""`                                        |
-| `tls.truststoreFile`              | Path where the truststore file will be mounted (internal)                                       | `"/opt/keycloak/truststore/truststore.jks"` |
+| Parameter                         | Description                                                                                            | Default                                     |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| `tls.enabled`                     | Enable TLS/HTTPS support using custom certificates                                                     | `false`                                     |
+| `tls.existingSecret`              | Name of existing secret containing TLS certificate and key (PEM format, keys: tls.crt, tls.key)        | `""`                                        |
+| `tls.certificateFile`             | Path where the TLS certificate file will be mounted (internal)                                         | `"/opt/keycloak/certs/tls.crt"`             |
+| `tls.certificateKeyFile`          | Path where the TLS certificate key file will be mounted (internal)                                     | `"/opt/keycloak/certs/tls.key"`             |
+| `tls.certManager.enabled`         | Enable cert-manager integration for automatic certificate provisioning                                 | `false`                                     |
+| `tls.certManager.issuerRef.name`  | Name of the cert-manager Issuer or ClusterIssuer                                                       | `""`                                        |
+| `tls.certManager.issuerRef.kind`  | Kind of the cert-manager issuer (Issuer or ClusterIssuer)                                              | `ClusterIssuer`                             |
+| `tls.certManager.issuerRef.group` | Group of the cert-manager issuer                                                                       | `cert-manager.io`                           |
+| `tls.certManager.duration`        | Certificate duration (e.g., 2160h for 90 days)                                                         | `""`                                        |
+| `tls.certManager.renewBefore`     | Time before expiry to renew certificate (e.g., 360h for 15 days)                                       | `""`                                        |
+| `tls.certManager.commonName`      | Certificate common name (defaults to first dnsName if not specified)                                   | `""`                                        |
+| `tls.certManager.dnsNames`        | List of DNS names for the certificate (uses ingress.hosts if not specified)                            | `[]`                                        |
+| `tls.certManager.ipAddresses`     | List of IP addresses for the certificate                                                               | `[]`                                        |
+| `tls.certManager.secretName`      | Name for the generated secret (defaults to `<fullname>-tls`)                                           | `""`                                        |
+| `tls.certManager.usages`          | Certificate key usages                                                                                 | `["digital signature", "key encipherment"]` |
+| `tls.certManager.annotations`     | Additional annotations for the Certificate resource                                                    | `{}`                                        |
+| `tls.truststoreEnabled`           | Enable truststore for client certificate validation or outgoing HTTPS requests                         | `false`                                     |
+| `tls.truststoreExistingSecret`    | Name of existing secret containing truststore file (Java Keystore format, default-key: truststore.jks) | `""`                                        |
+| `tls.truststoreExistingSecretKey` | Key of the secret to get the trustStorePassword from                                                   | `"truststore.jks"`                          |
+| `tls.truststorePassword`          | Password for the truststore (use with caution - consider using existing secret)                        | `""`                                        |
+| `tls.truststoreFile`              | Path where the truststore file will be mounted (internal)                                              | `"/opt/keycloak/truststore/truststore.jks"` |
 
 ### Database Configuration
 

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -138,6 +138,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "keycloak.secretName" . }}
                   key: {{ include "keycloak.adminPasswordKey" . }}
+            {{- if or .Values.tls.truststorePassword .Values.tls.truststoreExistingSecret }}
+            - name: KC_HTTPS_TRUST_STORE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.tls.truststoreExistingSecret | default (include "keycloak.fullname" .) }}
+                  key: {{ .Values.tls.truststoreExistingSecretKey }}
+            {{- end }}
             {{- if .Values.database.type }}
             - name: KC_DB
               value: {{ .Values.database.type }}

--- a/charts/keycloak/templates/secret.yaml
+++ b/charts/keycloak/templates/secret.yaml
@@ -13,6 +13,9 @@ metadata:
 type: Opaque
 data:
   admin-password: {{ (.Values.keycloak.adminPassword | default (randAlphaNum 32)) | b64enc | quote }}
+  {{- if .Values.tls.truststorePassword }}
+  {{ .Values.tls.truststoreExistingSecretKey }}: {{ .Values.tls.truststorePassword | b64enc }}
+  {{- end }}
 {{- end }}
 ---
 {{- if and (not .Values.database.existingSecret) (or (eq .Values.database.type "postgres") (eq .Values.database.type "mysql") (eq .Values.database.type "mariadb")) }}

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -26,4 +26,6 @@ spec:
     {{- end }}
   selector:
     {{- include "keycloak.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.trafficDistribution }}
   trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -161,8 +161,10 @@ tls:
   ## @param tls.truststoreEnabled Enable truststore for client certificate validation or outgoing HTTPS requests
   truststoreEnabled: false
   ## @param tls.truststoreExistingSecret Name of existing secret containing truststore file (Java Keystore format)
-  ## The secret should contain 'truststore.jks' key
+  ## The secret should contain 'truststore.jks' key or the key specified in the value 'tls.truststoreExistingSecretKey'
   truststoreExistingSecret: ""
+  ## @param tls.truststoreExistingSecretKey Key of the secret to get the trustStorePassword from
+  truststoreExistingSecretKey: "truststore.jks"
   ## @param tls.truststorePassword Password for the truststore (use with caution - consider using existingSecret)
   truststorePassword: ""
   ## @param tls.truststoreFile Path where the truststore file will be mounted (internal)


### PR DESCRIPTION
### Description of the change

This PR solves the problem described in the discussion #483
By adding the truststorePassword to the env-Vars if set. Also a new values was added to dynamically set the key to read the password from the existingSecret.

### Benefits

Better Configuration of the trustStore Password

### Applicable issues

- fixes #483 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
