### PR TITLE
[nginx]: feat: remove optional bitnami script sourcing

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: "1.29.3"
 keywords:
   - nginx

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -55,7 +55,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"
               git clone {{ .Values.cloneStaticSiteFromGit.repository }} --branch {{ .Values.cloneStaticSiteFromGit.branch }} /app
           {{- end }}
           {{- if .Values.cloneStaticSiteFromGit.gitClone.args }}
@@ -181,7 +180,6 @@ spec:
             - /bin/sh
             - -ec
             - |
-              [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && source "/opt/bitnami/scripts/git/entrypoint.sh"
               while true; do
                 cd /app && git pull origin {{ .Values.cloneStaticSiteFromGit.branch }}
                 sleep {{ .Values.cloneStaticSiteFromGit.interval }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

Fix change fixes both default `cloneStaticSiteFromGit` commands, which throw an error when used (`/bin/sh: 1: [[: not found`)                                                 

### Description of the change

Both commands use `/bin/sh`, and the double bracket syntax is bash-only (see https://github.com/canonical/tdx/issues/173 for a good explanation).


### Benefits

The `cloneStaticSiteFromGit` integration doesn't throw an error when using the default commands.

### Possible drawbacks

None 

### Applicable issues

None

### Additional information

The  `cloneStaticSiteFromGit` integration throws this eror when using the default commands:

```
/bin/sh: 1: [[: not found                                                 
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
