### PR TITLE
[mariadb] add support for serviceaccounts

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: "12.0.2"
 keywords:
   - mariadb

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -207,6 +207,15 @@ For a detailed explanation of Galera parameters and usage, see [README_GALERA.md
 | `resources.limits`   | The resources limits for the MariaDB containers    | `{}`    |
 | `resources.requests` | The requested resources for the MariaDB containers | `{}`    |
 
+### Service Account
+
+| Parameter                                     | Description                                                                                                               | Default |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Specifies whether a service account should be created                                                                     | `false` |
+| `serviceAccount.annotations`                  | Annotations to add to the service account                                                                                 | `{}`    |
+| `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Whether to automount the SA token inside the pod                                                                          | `false` |
+
 ### Extra Configuration Parameters
 
 | Parameter      | Description                                                                      | Default |

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -122,3 +122,14 @@ Generate Galera node address
 {{- define "mariadb.galeraNodeAddress" -}}
 {{- printf "%s-%s.%s.%s.svc.cluster.local" (include "mariadb.fullname" .) "REPLICA_NUM" (include "mariadb.fullname" .) .Release.Namespace -}}
 {{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mariadb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mariadb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mariadb/templates/serviceaccount.yaml
+++ b/charts/mariadb/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mariadb.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -32,6 +32,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "mariadb.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- with (include "mariadb.imagePullSecrets" .) }}
 {{- . | nindent 6 }}
 {{- end }}

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -172,6 +172,17 @@ resources:
   ##   memory: 300Mi
   ##   cpu: 100m
 
+## @section Service Account
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  create: false
+  ## @param serviceAccount.annotations Annotations to add to the service account
+  annotations: {}
+  ## @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template.
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken whether to automount the SA token inside the pod
+  automountServiceAccountToken: false
+
 ## @section Extra Configs
 ## @param extraEnvVars Additional environment variables to set
 extraEnvVars: []


### PR DESCRIPTION
### Description of the change

This PR adds the option to deploy or use a ServiceAccount for the MariaDB Helm-Chart.

### Benefits

ServiceAccounts can be added to the deployment.

### Possible drawbacks

None

### Applicable issues

- fixes #586 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
