### PR TITLE
[redis] Add ServiceAccount

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.14.4
+version: 0.15.0
 appVersion: "8.2.3"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -282,6 +282,15 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | `sentinel.resources.requests.memory` | Memory request for Sentinel pods                                                              | `64Mi`             |
 | `sentinel.extraVolumeMounts`         | Additional volume mounts for Sentinel container                                               | `[]`               |
 
+### ServiceAccount
+
+| Parameter           | Description                                                             | Default |
+| ------------------- | ----------------------------------------------------------------------- | ------- |
+| `serviceAccount.annotations` | Additional custom annotations for the ServiceAccount | `{}` |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token inside the Redis pods | `false` |
+| `serviceAccount.create` | Enable the creation of a ServiceAccount | `false` |
+| `serviceAccount.name` | Name of the ServiceAccount to use. If not set and `serviceAccount.create` is `true`, a name is generated using the `fullname` template. | `""` |
+
 ### Additional Configuration
 
 | Parameter           | Description                                                             | Default |

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -137,3 +137,14 @@ Common Sentinel master query command
 {{- define "redis.sentinelMasterQuery" -}}
 {{- include "redis.sentinelCli" (dict "auth" .auth "context" .context) }} sentinel get-master-addr-by-name {{ .context.Values.sentinel.masterName }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redis.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "redis.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/redis/templates/serviceaccount.yaml
+++ b/charts/redis/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "redis.serviceAccountName" . }}
+  namespace: {{ include "cloudpirates.namespace" . }}
+  labels:
+    {{- include "redis.labels" . | nindent 4 }}
+  {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -37,6 +37,11 @@ spec:
 {{- end }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
       {{- with .Values.topologySpreadConstraints }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "redis.serviceAccountName" . }}
+      serviceAccount: {{ include "redis.serviceAccountName" . }}
+      {{- end }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -584,7 +589,7 @@ spec:
   {{- end }}
   {{- if not .Values.persistence.existingClaim }}
   volumeClaimTemplates:
-    - apiVersion: v1	
+    - apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
         name: data

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -599,6 +599,23 @@
                 }
             }
         },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "startupProbe": {
             "type": "object",
             "properties": {

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -379,6 +379,17 @@ metrics:
     ## @param metrics.serviceMonitor.namespaceSelector Namespace selector for ServiceMonitor
     namespaceSelector: {}
 
+## @section Service Account
+serviceAccount:
+  ## @param serviceAccount.create Enable the creation of a ServiceAccount
+  create: false
+  ## @param serviceAccount.name Name of the ServiceAccount to use. If not set and serviceAccount.create is true, a name is generated using the `fullname` template.
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Automount service account token inside the Redis pods
+  automountServiceAccountToken: false
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  annotations: {}
+
 ## @section Network Policy
 networkPolicy:
   ## @param networkPolicy.enabled Enable NetworkPolicy


### PR DESCRIPTION
### Description of the change

This pull request introduces `ServiceAccount` support to the Redis Helm chart, allowing users to customize service account creation and usage for Redis pods.

**ServiceAccount support and configuration:**

* Added a new `serviceAccount` section to `values.yaml` and its schema in `values.schema.json`, allowing users to enable service account creation, specify a name, control token automounting, and set custom annotations.
* Added `serviceAccount.yaml` with support for custom annotations and names: If `serviceAccount.create` equals `true` a `ServiceAccount` resource is created accordingly.
* Updated the `statefulset.yaml` template to set `serviceAccountName`, `serviceAccount`, and `automountServiceAccountToken` for Redis pods based on the new configuration options.
* Added a helper template `redis.serviceAccountName` in `_helpers.tpl` to determine the correct service account name based on user configuration.
* Updated the chart version to `0.15.0` in `Chart.yaml` and documented the new `ServiceAccount` options in `README.md`.

### Benefits

* Explicit control over the use of a `ServiceAccount`.

### Possible drawbacks

* none known

### Applicable issues

#630

### Additional information
 
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
