### PR TITLE
[redis] add option to use ip or hostname for sentinal announce-ip

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: "8.2.3"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -269,6 +269,7 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | `sentinel.image.repository`          | Redis Sentinel image repository                                                               | `redis`            |
 | `sentinel.image.tag`                 | Redis Sentinel image tag                                                                      | `8.2.1@sha256:...` |
 | `sentinel.image.pullPolicy`          | Sentinel image pull policy                                                                    | `Always`           |
+| `sentinel.config.announceHostnames`  | Use the hostnames instead of the IP in "announce-ip" commands                                 | `true`             |
 | `sentinel.masterName`                | Name of the master server                                                                     | `mymaster`         |
 | `sentinel.quorum`                    | Number of Sentinels needed to agree on master failure                                         | `2`                |
 | `sentinel.downAfterMilliseconds`     | Time in ms after master is declared down                                                      | `30000`            |
@@ -284,12 +285,12 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 
 ### ServiceAccount
 
-| Parameter           | Description                                                             | Default |
-| ------------------- | ----------------------------------------------------------------------- | ------- |
-| `serviceAccount.annotations` | Additional custom annotations for the ServiceAccount | `{}` |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token inside the Redis pods | `false` |
-| `serviceAccount.create` | Enable the creation of a ServiceAccount | `false` |
-| `serviceAccount.name` | Name of the ServiceAccount to use. If not set and `serviceAccount.create` is `true`, a name is generated using the `fullname` template. | `""` |
+| Parameter                                     | Description                                                                                                                             | Default |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                                    | `{}`    |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token inside the Redis pods                                                                                   | `false` |
+| `serviceAccount.create`                       | Enable the creation of a ServiceAccount                                                                                                 | `false` |
+| `serviceAccount.name`                         | Name of the ServiceAccount to use. If not set and `serviceAccount.create` is `true`, a name is generated using the `fullname` template. | `""`    |
 
 ### Additional Configuration
 

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -121,11 +121,38 @@ spec:
                 fi
               fi
 
+              {{ if not .Values.sentinel.config.announceHostnames }}
+              # Configure for Sentinel discovery and force deletion tolerance
+              # Get IP address based on ipFamily setting
+              {{- if eq .Values.ipFamily "ipv4" }}
+              MY_IP=$(hostname -i | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -1)
+              if [ -z "$MY_IP" ]; then
+                echo "Warning: No IPv4 address found, falling back to first available IP"
+                MY_IP=$(hostname -i | awk '{print $1}')
+              fi
+              {{- else if eq .Values.ipFamily "ipv6" }}
+              MY_IP=$(hostname -i | grep -oE '([0-9a-f:]+:+)+[0-9a-f]+' | head -1)
+              if [ -z "$MY_IP" ]; then
+                echo "Warning: No IPv6 address found, falling back to first available IP"
+                MY_IP=$(hostname -i | awk '{print $1}')
+              fi
+              {{- else }}
+              # auto: Use the first IP address for dual-stack compatibility
+              MY_IP=$(hostname -i | awk '{print $1}')
+              {{- end }}
+              
+              echo "Using IP address: ${MY_IP}"
+              echo "replica-announce-ip ${MY_IP}" >> /tmp/redis.conf
+              echo "replica-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
+              echo "slave-announce-ip ${MY_IP}" >> /tmp/redis.conf
+              echo "slave-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
+              {{- else }}
               echo "Using hostname: ${HOSTNAME}.{{ include "redis.fullname" . }}-headless"
               echo "replica-announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless" >> /tmp/redis.conf
               echo "replica-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
               echo "slave-announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless" >> /tmp/redis.conf
               echo "slave-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
+              {{- end }}
 
               # Make slaves more eligible for promotion during force deletions
               echo "slave-priority 100" >> /tmp/redis.conf
@@ -441,7 +468,11 @@ spec:
               # CRITICAL: Track disconnected slaves for force deletion tolerance
               sentinel_link_buffer_size 32768
               # Allow sentinels to discover each other
+              {{ if .Values.sentinel.config.announceHostnames }}
               sentinel announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless
+              {{- else }}
+              sentinel announce-ip ${SENTINEL_IP}
+              {{- end }}
               sentinel announce-port {{ .Values.sentinel.port }}
               logfile ""
               loglevel notice

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -296,6 +296,9 @@ sentinel:
     repository: redis
     tag: "8.2.3@sha256:49887660cd57f34b2b3bfb73ae135e2265320c48c3d76a9294e9851265e140d6"
     pullPolicy: Always
+  ## @param sentinel.config.announceHostnames Use the hostnames instead of the IP in "announce-ip" commands
+  config:
+    announceHostnames: true
   ## @param sentinel.masterName Name of the master server (default: mymaster)
   masterName: mymaster
   ## @param sentinel.quorum Number of Sentinels that need to agree about the fact the master is not reachable


### PR DESCRIPTION
### Description of the change

This adds an option to choose to use the hostname of the pod or the ip address in the sentinel announce commands.

### Applicable issues

- fixes #628 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
