### PR TITLE
[keycloak] Make resources apply to initContainers

### DIFF
--- a/charts/keycloak/CHANGELOG.md
+++ b/charts/keycloak/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 0.8.6
+* chore: make resource apply also to initContainers
+
 
 ## 0.8.5 (2025-11-13)
 

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.8.6
+version: 0.8.7
 appVersion: "26.4.5"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -242,9 +242,9 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Resources
 
-| Parameter   | Description                                 | Default |
-| ----------- | ------------------------------------------- | ------- |
-| `resources` | The resources to allocate for the container | `{}`    |
+| Parameter   | Description                                                                 | Default |
+| ----------- |-----------------------------------------------------------------------------| ------- |
+| `resources` | The resources to allocate for each container (including the InitContainers) | `{}`    |
 
 ### Persistence
 

--- a/charts/keycloak/templates/deployment.yaml
+++ b/charts/keycloak/templates/deployment.yaml
@@ -41,16 +41,22 @@ spec:
           volumeMounts:
             - name: keycloak-lib-quarkus
               mountPath: /shared-quarkus
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.postgres.enabled }}
         - name: wait-for-postgres
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ .Values.initContainers.waitForPostgres.image }}
           command: ["sh", "-c", "until pg_isready -h {{ .Release.Name }}-postgres -p 5432 -U postgres; do echo waiting for database; sleep 2; done;"]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         {{- else if .Values.mariadb.enabled }}
         - name: wait-for-mariadb
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ .Values.initContainers.waitForMariadb.image }}
           command: ["sh", "-c", "until mariadb-admin ping -h {{ .Release.Name }}-mariadb -P 3306 --silent; do echo waiting for database; sleep 2; done;"]
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
         {{- end }}
         {{- if .Values.extraInitContainers }}
           {{- toYaml .Values.extraInitContainers | nindent 8 }}

--- a/charts/keycloak/tests/deployment-parameters_test.yaml
+++ b/charts/keycloak/tests/deployment-parameters_test.yaml
@@ -49,3 +49,44 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].args[2]
           value: --hostname-admin=keycloak.mydomain.com
+  - it: resources should be set
+    set:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.initContainers[0].resources.requests.memory
+          value: 128Mi
+  - it: resources should be set when postgres is enabled
+    set:
+      resources:
+        requests:
+          cpu: 100m
+      postgres:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].resources.requests.cpu
+          value: 100m
+  - it: resources should be set when mariadb is enabled
+    set:
+      resources:
+        requests:
+          cpu: 100m
+      mariadb:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[1].resources.requests.cpu
+          value: 100m


### PR DESCRIPTION
### Description of the change
We cant deploy the Keycloack Helm chart in our OpenShift cluster because there is a Policy that demands every pod to have resource-limits. This PR adds resource Limits to the initContainers for the KeyCloak Helm chart. [keycloak]

### Benefits
deployment on restricted namespaces is possible

### Possible drawbacks
maybe inconsitencies to other helmcharts in this repo?

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] changes are tested 
