### PR TITLE
[common] add new helm functions for rabbitmq-cluster-operator chart to work

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: common
 description: A library chart for common templates and helper functions
 type: library
-version: 2.0.0
-appVersion: "2.0.0"
+version: 2.1.0
+appVersion: "2.1.0"
 home: https://www.cloudpirates.io
 sources:
   - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/common

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -33,6 +33,13 @@ Useful for multi-namespace deployments in combined charts.
 {{- end }}
 
 {{/*
+Create a fully qualified app name adding the installation's namespace.
+*/}}
+{{- define "cloudpirates.fullname.namespace" -}}
+{{- printf "%s-%s" (include "cloudpirates.fullname" .) (include "cloudpirates.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cloudpirates.chart" -}}
@@ -222,6 +229,20 @@ Render a value that contains template perhaps
   {{- else }}
     {{- $value }}
   {{- end }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
+Usage:
+{{ include "cloudpirates.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "cloudpirates.tplvalues.merge" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "cloudpirates.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
 {{- end -}}
 
 {{/*

--- a/charts/common/templates/_secrets.tpl
+++ b/charts/common/templates/_secrets.tpl
@@ -1,0 +1,25 @@
+{{/*
+Reuses the value from an existing secret, otherwise sets its value to a default value.
+
+Usage:
+{{ include "cloudpirates.secrets.lookup" (dict "secret" "secret-name" "key" "keyName" "defaultValue" .Values.myValue "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - defaultValue - String - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - context - Context - Required - Parent context.
+
+*/}}
+{{- define "cloudpirates.secrets.lookup" -}}
+{{- $value := "" -}}
+{{- $secretData := (lookup "v1" "Secret" (include "cloudpirates.namespace" .context) .secret).data -}}
+{{- if and $secretData (hasKey $secretData .key) -}}
+  {{- $value = index $secretData .key -}}
+{{- else if .defaultValue -}}
+  {{- $value = .defaultValue | toString | b64enc -}}
+{{- end -}}
+{{- if $value -}}
+{{- printf "%s" $value -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION

### Description of the change

Adding extra helm functions to common chart for rabbitmq-cluster-operator chart to work (see #638)

### Benefits

More reusable functions can be used in other charts.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
