### PR TITLE
[rabbitmq] Add ServiceAccount automountServiceAccountToken configuration

### DIFF
--- a/charts/rabbitmq/Chart.lock
+++ b/charts/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.0.0
-digest: sha256:ae9378e0dcfd09a35b7f994007db99c2d6fe02ef7634f424d5233237c209a1c7
-generated: "2025-10-14T11:14:55.100361+02:00"
+  version: 2.1.0
+digest: sha256:ae6c0d8f5456d3774920c181b2548654453dabf2a20ef8fc3bf0b488959ae6e6
+generated: "2025-12-11T11:03:41.065625+01:00"

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.8.1
+version: 0.9.0
 appVersion: "4.2.0"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -304,11 +304,12 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 
 ### ServiceAccount
 
-| Parameter                    | Description                       | Default |
-| ---------------------------- | --------------------------------- | ------- |
-| `serviceAccount.create`      | Enable creation of ServiceAccount | `true`  |
-| `serviceAccount.name`        | Name of serviceAccount            | `""`    |
-| `serviceAccount.annotations` | Annotations for service account   | `{}`    |
+| Parameter                                   | Description                                              | Default |
+| ------------------------------------------- | -------------------------------------------------------- | ------- |
+| `serviceAccount.create`                     | Enable creation of ServiceAccount                        | `true`  |
+| `serviceAccount.name`                       | Name of serviceAccount                                   | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token inside the RabbitMQ pods | `false` |
+| `serviceAccount.annotations`                | Annotations for service account                          | `{}`    |
 
 ### RBAC parameters
 

--- a/charts/rabbitmq/templates/serviceaccount.yaml
+++ b/charts/rabbitmq/templates/serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if and .Values.peerDiscoveryK8sPlugin.enabled .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "rabbitmq.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -31,6 +31,7 @@ spec:
       {{- with (include "rabbitmq.imagePullSecrets" .) }}
       {{ . | nindent 6 }}
       {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       serviceAccountName: {{ include "rabbitmq.serviceAccountName" . }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
       initContainers:

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -553,6 +553,9 @@
                 "annotations": {
                     "type": "object"
                 },
+                "automountServiceAccountToken": {
+                    "type": "boolean"
+                },
                 "create": {
                     "type": "boolean"
                 },

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -382,6 +382,8 @@ serviceAccount:
   create: true
   ## @param serviceAccount.name Name of serviceAccount
   name: ""
+  ## @param serviceAccount.automountServiceAccountToken Automount service account token inside the RabbitMQ pods
+  automountServiceAccountToken: false
   ## @param serviceAccount.annotations Annotations for service account.
   annotations: {}
 


### PR DESCRIPTION
This PR adds automountServiceAccountToken configuration support to the RabbitMQ Helm chart, following the same pattern as PR #631 which added this feature to the Redis chart.

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Changes:
- Added automountServiceAccountToken field to serviceAccount section in values.yaml
- Updated StatefulSet template to use configured automountServiceAccountToken value
- Updated ServiceAccount template to respect automountServiceAccountToken setting
- Simplified serviceAccountName helper to check serviceAccount.create
- Updated values.schema.json with automountServiceAccountToken field definition
- Updated README.md documentation
- Bumped chart version to 0.8.0

### Benefits

Organizations with security policies (e.g., Kyverno policies) require explicit control over service account token mounting. This is a standard Kubernetes security best practice.

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #672

### Additional information

Testing:
- Verified template rendering with automountServiceAccountToken: true and false
- Validated with helm lint (no errors)
- Confirmed field appears in both ServiceAccount and StatefulSet pod spec

Related:
- Follows pattern from #631 (Redis chart)
- Addresses same security compliance requirements

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
