### PR TITLE
[zookeeper] fix network policy switch

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "3.9.4"
 keywords:
   - zookeeper

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.networkPolicy.enabled }}
+{{- if .Values.networkPolicy.enabled }}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -39,7 +39,7 @@ podDisruptionBudget:
 
 networkPolicy:
   ## @param networkPolicy.enabled Enable network policies
-  enabled: true
+  enabled: false
 
 ## @section Zookeeper configuration parameters
 ## @see https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#sc_configuration


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Fixes network policy switch

### Benefits

<!-- What benefits will be realized by the code change? -->
Code works as expected

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None. 

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #688 

### Additional information

Since the default was set to true, which results to NOT create the Networkpolicy, the default was changed to "false" to keep backward compatibilty. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
