### PR TITLE
[redis] Fix Redis issue with immutableFields cause by the label addition on volumeClaimTemplate

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.16.4
+version: 0.16.5
 appVersion: "8.4.0"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -647,7 +647,10 @@ spec:
       metadata:
         name: data
         labels:
-          {{- include "redis.labels" . | nindent 10 }}
+          {{- include "redis.selectorLabels" . | nindent 10 }}
+          {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         {{- with .Values.persistence.annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
The volumeClaimTemplate in STS is an immutable field. The new labels causes issues with ugprades! which is forcing us to reinstall redis on every Chart upgrade.
I am changing the labels to podLabels, used for the container templates.

<img width="2827" height="227" alt="image" src="https://github.com/user-attachments/assets/00406041-98cc-4157-9a19-e814c5959313" />

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
