### PR TITLE
[redis] return fqdn for sentinel replicas lookup (#700)

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.16.5
+version: 0.16.6
 appVersion: "8.4.0"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
 
               # Check if any sentinel is already running and knows the master
               for i in $(seq 0 {{ sub .Values.replicaCount 1 }}); do
-                SENTINEL_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless"
+                SENTINEL_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
                 MASTER_INFO=$(redis-cli -h "${SENTINEL_HOST}" -p {{ .Values.sentinel.port }} {{- if .Values.auth.sentinel }} -a "${REDIS_PASSWORD}"{{- end }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterName }} 2>/dev/null | head -1 || echo "")
                 if [ -n "$MASTER_INFO" ] && [ "$MASTER_INFO" != "Could not connect" ]; then
                   CURRENT_MASTER="$MASTER_INFO"
@@ -92,7 +92,7 @@ spec:
               if [ "$SENTINEL_FOUND" = true ] && [ -n "$CURRENT_MASTER" ]; then
                 # Sentinel knows the master - configure accordingly
                 MY_HOSTNAME=$(hostname)
-                MY_HOSTNAME_FQDN="${MY_HOSTNAME}.{{ include "redis.fullname" . }}-headless"
+                MY_HOSTNAME_FQDN="${MY_HOSTNAME}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
                 MY_IP=$(hostname -i)
 
                 # Check if I am the master by hostname or IP
@@ -110,7 +110,7 @@ spec:
                 if [ "$POD_ORDINAL" != "0" ]; then
                   echo "Bootstrap mode: configuring as replica of pod-0"
                   # Use hostname-based replication for better resilience
-                  MASTER_HOSTNAME="{{ include "redis.fullname" . }}-0.{{ include "redis.fullname" . }}-headless"
+                  MASTER_HOSTNAME="{{ include "redis.fullname" . }}-0.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
                   echo "replicaof $MASTER_HOSTNAME {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
                   echo "Bootstrap replica using pod-0 hostname: $MASTER_HOSTNAME"
                   {{- if .Values.auth.enabled }}
@@ -147,10 +147,10 @@ spec:
               echo "slave-announce-ip ${MY_IP}" >> /tmp/redis.conf
               echo "slave-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
               {{- else }}
-              echo "Using hostname: ${HOSTNAME}.{{ include "redis.fullname" . }}-headless"
-              echo "replica-announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless" >> /tmp/redis.conf
+              echo "Using hostname: ${HOSTNAME}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+              echo "replica-announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}" >> /tmp/redis.conf
               echo "replica-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
-              echo "slave-announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless" >> /tmp/redis.conf
+              echo "slave-announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}" >> /tmp/redis.conf
               echo "slave-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
               {{- end }}
 
@@ -161,7 +161,7 @@ spec:
               # Replication without Sentinel: pod-0 is always master, others are replicas
               if [ "$POD_ORDINAL" != "0" ]; then
                 echo "Configuring as replica of pod-0 (master)"
-                MASTER_HOSTNAME="{{ include "redis.fullname" . }}-0.{{ include "redis.fullname" . }}-headless"
+                MASTER_HOSTNAME="{{ include "redis.fullname" . }}-0.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
                 echo "replicaof $MASTER_HOSTNAME {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf
                 {{- if .Values.auth.enabled }}
                 echo "masterauth ${REDIS_PASSWORD}" >> /tmp/redis.conf
@@ -394,7 +394,7 @@ spec:
               echo "Checking existing Sentinels for current master..."
               for i in $(seq 0 {{ sub .Values.replicaCount 1 }}); do
                 if [ "$i" != "$POD_ORDINAL" ]; then
-                  SENTINEL_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless"
+                  SENTINEL_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
                   EXISTING_MASTER=$(redis-cli -h "${SENTINEL_HOST}" -p {{ .Values.sentinel.port }} {{- if .Values.auth.sentinel }} -a "${REDIS_PASSWORD}"{{- end }} sentinel get-master-addr-by-name {{ .Values.sentinel.masterName }} 2>/dev/null | head -1 || echo "")
                   if [ -n "$EXISTING_MASTER" ] && [ "$EXISTING_MASTER" != "Could not connect" ]; then
                     MASTER_HOST="$EXISTING_MASTER"
@@ -469,7 +469,7 @@ spec:
               sentinel_link_buffer_size 32768
               # Allow sentinels to discover each other
               {{ if .Values.sentinel.config.announceHostnames }}
-              sentinel announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless
+              sentinel announce-ip ${HOSTNAME}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}
               {{- else }}
               sentinel announce-ip ${SENTINEL_IP}
               {{- end }}
@@ -481,7 +481,7 @@ spec:
               # Add known sentinels to help with discovery (using hostnames for resilience)
               for i in $(seq 0 {{ sub .Values.replicaCount 1 }}); do
                 if [ "$i" != "$POD_ORDINAL" ]; then
-                  SENTINEL_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless"
+                  SENTINEL_HOST="{{ include "redis.fullname" . }}-${i}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
                   # Test if the host is resolvable before adding
                   if getent hosts "$SENTINEL_HOST" >/dev/null 2>&1; then
                     SENTINEL_IP=$(getent hosts "$SENTINEL_HOST" | awk '{print $1}' | head -1)


### PR DESCRIPTION
* [redis] use fqdn for sentinel redis replicas, to avoid problems when calling it cross namespaces
recognized replicas fqdn
```
$ redis-cli -p 26379 -h redis-cloud-pirates-headless.redis
redis-cloud-pirates-headless.redis:26379> sentinel replicas redis-master
1)  1) "name"
    2) "redis-cloud-pirates-2.redis-cloud-pirates-headless.redis.svc.cluster.local:6379"
    3) "ip"
    4) "redis-cloud-pirates-2.redis-cloud-pirates-headless.redis.svc.cluster.local"
    5) "port"
    6) "6379"
    7) "runid"
    8) "f352db09cc6a2bae2f13a9d6c397bfe47f9d1db9"
    9) "flags"
   10) "slave"
   11) "link-pending-commands"
   12) "0"
   13) "link-refcount"
   14) "1"
   15) "last-ping-sent"
   16) "0"
   17) "last-ok-ping-reply"
   18) "640"
   19) "last-ping-reply"
   20) "640"
   21) "down-after-milliseconds"
   22) "5000"
   23) "info-refresh"
   24) "6860"
   25) "role-reported"
   26) "slave"
   27) "role-reported-time"
   28) "14213"
   29) "master-link-down-time"
   30) "0"
   31) "master-link-status"
   32) "ok"
   33) "master-host"
   34) "redis-cloud-pirates-0.redis-cloud-pirates-headless.redis.svc.cluster.local"
   35) "master-port"
   36) "6379"
   37) "slave-priority"
   38) "100"
   39) "slave-repl-offset"
   40) "12411"
   41) "replica-announced"
   42) "1"
2)  1) "name"
    2) "redis-cloud-pirates-1.redis-cloud-pirates-headless.redis.svc.cluster.local:6379"
    3) "ip"
    4) "redis-cloud-pirates-1.redis-cloud-pirates-headless.redis.svc.cluster.local"
    5) "port"
    6) "6379"
    7) "runid"
    8) "aa47a57e2d5758bee67ee8bdb271cff3870e3341"
    9) "flags"
   10) "slave"
   11) "link-pending-commands"
   12) "0"
   13) "link-refcount"
   14) "1"
   15) "last-ping-sent"
   16) "0"
   17) "last-ok-ping-reply"
   18) "757"
   19) "last-ping-reply"
   20) "757"
   21) "down-after-milliseconds"
   22) "5000"
   23) "info-refresh"
   24) "78"
   25) "role-reported"
   26) "slave"
   27) "role-reported-time"
   28) "44372"
   29) "master-link-down-time"
   30) "0"
   31) "master-link-status"
   32) "ok"
   33) "master-host"
   34) "redis-cloud-pirates-0.redis-cloud-pirates-headless.redis.svc.cluster.local"
   35) "master-port"
   36) "6379"
   37) "slave-priority"
   38) "100"
   39) "slave-repl-offset"
   40) "15091"
   41) "replica-announced"
   42) "1"

```