### PR TITLE
[minio] add post-job helm-hook annotation, update readme

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.5.6
+version: 0.5.7
 appVersion: "2025.09.07"
 keywords:
   - minio

--- a/charts/minio/README.md
+++ b/charts/minio/README.md
@@ -183,6 +183,18 @@ The following table lists the configurable parameters of the MinIO chart and the
 | ----------- | ------------------------------------------- | ------- |
 | `resources` | The resources to allocate for the container | `{}`    |
 
+### Bucket provisioning
+
+| Parameter        | Description                                                                    | Default |
+| ---------------- | ------------------------------------------------------------------------------ | ------- |
+| `defaultBuckets` | Comma, semi-colon or space separated list of buckets to create at installation | `""`    |
+
+### Configuration for the Job '{{ .Release.Name }}-post-job'
+
+| Parameter             | Description                        | Default                                   |
+| --------------------- | ---------------------------------- | ----------------------------------------- |
+| `postJob.annotations` | Additional annotations for the Job | `helm.sh/hook: post-install,post-upgrade` |
+
 ### Persistence
 
 | Parameter                   | Description                                        | Default             |

--- a/charts/minio/templates/post-job.yaml
+++ b/charts/minio/templates/post-job.yaml
@@ -6,9 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
-  {{- with (include "minio.annotations" .) }}
+  {{- $annotations := merge (include "minio.annotations" . | fromYaml) .Values.postJob.annotations }}
+  {{- with $annotations }}
   annotations: 
-{{- . | indent 4 }}
+{{ toYaml . | indent 4 }}
   {{- end }}
 spec:
   ttlSecondsAfterFinished: 600

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -77,7 +77,13 @@ config:
 ## @param defaultBuckets Comma, semi-colon or space separated list of buckets to create at initialization
 ## Format: "bucket-name" or "bucket-name:policy" where policy can be: none, download, upload, or public
 ## e.g: "my-bucket, my-second-bucket:download, my-public-bucket:public"
-defaultBuckets: ""
+defaultBuckets: "test"
+
+## @section postJob Configuration for the Job '{{ .Release.Name }}-post-job'
+postJob:
+  ## postJob.annotations Additional annotations for the Job
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
 
 ## @section Deployment configuration
 replicaCount: 1


### PR DESCRIPTION
### Description of the change

Adds an Helm-Sync-Hook annotation for the Job. 

### Benefits

The Post Job will be treated as an post-sync job. 

### Applicable issues

- fixes #705 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
