### PR TITLE
[redis]: allow changing revisionHistoryLimit

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.16.7
+version: 0.17.0
 appVersion: "8.4.0"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -94,17 +94,18 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/redis:<version>
 
 ### Common Parameters
 
-| Parameter             | Description                                                                                                                                                                             | Default         |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `nameOverride`        | String to partially override redis.fullname                                                                                                                                             | `""`            |
-| `fullnameOverride`    | String to fully override redis.fullname                                                                                                                                                 | `""`            |
-| `namespaceOverride`   | String to override the namespace for all resources                                                                                                                                      | `""`            |
-| `clusterDomain`       | Kubernetes cluster domain                                                                                                                                                               | `cluster.local` |
-| `commonLabels`        | Labels to add to all deployed objects                                                                                                                                                   | `{}`            |
-| `commonAnnotations`   | Annotations to add to all deployed objects                                                                                                                                              | `{}`            |
-| `architecture`        | Redis architecture. `standalone`: Single instance, `cluster`: Multi-master cluster, `replication`: Master-replica (use `sentinel.enabled` to control automatic failover)                | `standalone`    |
-| `replicaCount`        | Number of Redis instances (when `architecture=replication\|cluster`). As cluster or replication with Sentinel: total instances. Replication without Sentinel: 1 master + (n-1) replicas | `3`             |
-| `clusterReplicaCount` | Number of replicas to be created for each master when `architecture=cluster`.                                                                                                           | `0`             |
+| Parameter              | Description                                                                                                                                                                             | Default         |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `nameOverride`         | String to partially override redis.fullname                                                                                                                                             | `""`            |
+| `fullnameOverride`     | String to fully override redis.fullname                                                                                                                                                 | `""`            |
+| `namespaceOverride`    | String to override the namespace for all resources                                                                                                                                      | `""`            |
+| `clusterDomain`        | Kubernetes cluster domain                                                                                                                                                               | `cluster.local` |
+| `commonLabels`         | Labels to add to all deployed objects                                                                                                                                                   | `{}`            |
+| `commonAnnotations`    | Annotations to add to all deployed objects                                                                                                                                              | `{}`            |
+| `architecture`         | Redis architecture. `standalone`: Single instance, `cluster`: Multi-master cluster, `replication`: Master-replica (use `sentinel.enabled` to control automatic failover)                | `standalone`    |
+| `replicaCount`         | Number of Redis instances (when `architecture=replication\|cluster`). As cluster or replication with Sentinel: total instances. Replication without Sentinel: 1 master + (n-1) replicas | `3`             |
+| `clusterReplicaCount`  | Number of replicas to be created for each master when `architecture=cluster`.                                                                                                           | `0`             |
+| `revisionHistoryLimit` | Number of revisions to keep in history for rollback (set to 0 for unlimited)                                                                                                            | `10`            |
 
 ### Pod labels and annotations
 

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
 spec:
   serviceName: {{ include "redis.fullname" . }}-headless
   replicas: {{ if eq .Values.architecture "standalone" }}1{{ else }}{{ .Values.replicaCount }}{{ end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit | default 10 }}
   selector:
     matchLabels:
       {{- include "redis.selectorLabels" . | nindent 6 }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -496,6 +496,9 @@
                 }
             }
         },
+        "revisionHistoryLimit": {
+            "type": "integer"
+        },
         "sentinel": {
             "type": "object",
             "properties": {

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -51,6 +51,9 @@ replicaCount: 3
 ## For example: replicaCount: 6 and clusterReplicaCount: 1 creates 3 masters + 3 replicas (1 per master)
 clusterReplicaCount: 0
 
+## @param revisionHistoryLimit Number of revisions to keep in history for rollback (set to 0 for unlimited)
+revisionHistoryLimit: 10
+
 ## @section Pod labels and annotations
 ## @param podLabels Map of labels to add to the pods
 podLabels: {}


### PR DESCRIPTION
### Description of the change
allow changing revisionHistoryLimit
We keep 10 as the default value to make the change transparent and avoid creating a breaking change.

### Benefits

Allow changing the value of revisionHistoryLimit

### Possible drawbacks
Not known yet.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
