### PR TITLE
mariadb: dont enable metrics-exporter by default

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.10.0
+version: 0.10.1
 appVersion: "12.1.2"
 keywords:
   - mariadb

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -322,7 +322,7 @@ extraObjects: []
 ## @section Metrics
 metrics:
   ## @param metrics.enabled Enable metrics exporter sidecar
-  enabled: true
+  enabled: false
   ## @param metrics.image.registry Metrics exporter image registry
   ## @param metrics.image.repository Metrics exporter image repository
   ## @param metrics.image.tag Metrics exporter image tag (immutable tags are recommended)


### PR DESCRIPTION
### Description of the change

the newly added metrics-exporter should not be enabled by default (as mentioned in the readme).
Another reason for disable by default - it requires some password in the secret, so enabling it by default breaks existing deployments.

### Benefits

Does no longer break existing deployments.

### Possible drawbacks

Someone may have to explicitly enable the feature.

### Applicable issues

- fixes #742

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
