### PR TITLE
chore(redis): Bump version to 0.17.5

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.17.4
+version: 0.17.5
 appVersion: "8.4.0"
 keywords:
   - redis


### PR DESCRIPTION
## Summary
Bump Redis chart version to 0.17.5 to trigger a new release.

## Reason
PR #750 (fix for masterauth not set for pods starting as master) was merged after the 0.17.4 tag was created. The current 0.17.4 release does not include this important fix.

## Changes since 0.17.4
- fix(redis): Always set masterauth for non-standalone architectures (#750)
- chore: auto-generate values.schema.json (#757)

Bumping to 0.17.5 will trigger a new release that includes these changes.