### PR TITLE
[zookeeper] Add support for Bitnami Zookeeper migration with multiple replicas

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: "3.9.4"
 keywords:
   - zookeeper

--- a/charts/zookeeper/templates/_helpers.tpl
+++ b/charts/zookeeper/templates/_helpers.tpl
@@ -57,15 +57,20 @@ Return the proper Docker Image Registry Secret Names
 {{/*
 Create a server list array based on fullname, namespace, # of servers
 in a format like:
+- server.0=zkhost0:port:port
 - server.1=zkhost1:port:port
-- server.2=zkhost2:port:port
+
+serverIdOffset (default 0) allows shifting server IDs to match existing myid files.
+This is useful when migrating from Bitnami Zookeeper, which uses 1-based IDs (myid=1,2,3).
+Set serverIdOffset=1 to generate server.1, server.2, server.3 instead of server.0, server.1, server.2.
 */}}
 {{- define "zookeeper.servers" -}}
 {{- $namespace := .Release.Namespace }}
 {{- $name := include "zookeeper.fullname" . -}}
 {{- $peersPort := .Values.service.ports.quorum -}}
 {{- $leaderElectionPort := .Values.service.ports.leaderElection -}}
+{{- $offset := int (default 0 .Values.serverIdOffset) -}}
 {{- range $idx, $v := until (int .Values.replicaCount) }}
-server.{{ $idx }}={{ printf "%s-%d.%s-headless.%s.svc.cluster.local:%d:%d" $name $idx $name $namespace (int $peersPort) (int $leaderElectionPort) }}
+server.{{ add $idx $offset }}={{ printf "%s-%d.%s-headless.%s.svc.cluster.local:%d:%d" $name $idx $name $namespace (int $peersPort) (int $leaderElectionPort) }}
 {{- end }}
 {{- end -}}

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -12,6 +12,17 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override redis.fullname
 fullnameOverride: ""
+## @param serverIdOffset Offset for server IDs in zoo.cfg (set to 1 for Bitnami migration where myid starts at 1)
+## When migrating from Bitnami Zookeeper:
+##   1. Set serverIdOffset: 1 (Bitnami uses 1-based myid: 1,2,3 vs default 0-based: 0,1,2)
+##   2. Set persistence.mountPath to match Bitnami data location (e.g., /bitnami/zookeeper)
+##   3. Set persistence.dataDir to the actual data directory (e.g., /bitnami/zookeeper/data)
+##   4. Add ZOO_DATA_DIR env var via extraEnvVars to point to the data directory
+## Example extraEnvVars for Bitnami migration:
+##   extraEnvVars:
+##     - name: ZOO_DATA_DIR
+##       value: "/bitnami/zookeeper/data"
+serverIdOffset: 0
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Adds support for migrating from Bitnami Zookeeper to the official image when running multiple replicas.
#### Problem:
When migrating a multi-replica Bitnami Zookeeper cluster, the existing myid files use 1-based IDs (1, 2, 3), but the CloudPirates chart generates 0-based server IDs in zoo.cfg (server.0, server.1, server.2). This mismatch breaks quorum and prevents the cluster from starting.
#### Solution:
`serverIdOffset` parameter - Shifts server IDs in zoo.cfg to match existing Bitnami myid files. Set to `1` for Bitnami migration, default to `0`

Documentation - Added migration instructions in values.yaml.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
