### PR TITLE
[redis]: add missing label for sentinel

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.17.6
+version: 0.17.7
 appVersion: "8.4.0"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -23,6 +23,9 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- if and .Values.sentinel.enabled (eq .Values.architecture "replication") }}
+        app.kubernetes.io/component: sentinel
+        {{- end }}
       annotations:
         {{- if .Values.config.existingConfigmap }}
         checksum/config: {{ .Values.config.existingConfigmap | sha256sum }}


### PR DESCRIPTION
See https://github.com/CloudPirates-io/helm-charts/issues/772

### Description of the change
Redis: Unable to start a sentinel cluster with networkPolicy enabled.
It looks to me that the pods are missing the label "app.kubernetes.io/component: sentinel", as manually adding it to the StatefulSet allowed the sentinel cluster to start.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #772


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
