### PR TITLE
[zookeeper]: add ServiceMonitor

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.4.1
+version: 0.5.0
 appVersion: "3.9.4"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -122,11 +122,22 @@ zkCli.sh -server my-zookeeper:2181
 
 ### Metrics
 
-| Parameter                    | Description                        | Default     |
-| ---------------------------- | ---------------------------------- | ----------- |
-| `metrics.enabled`            | Enable Prometheus metrics exporter | `true`      |
-| `metrics.service.type`       | Metrics service type               | `ClusterIP` |
-| `metrics.service.ports.port` | Metrics service port               | `7000`      |
+| Parameter                                  | Description                                                                      | Default     |
+| ------------------------------------------ | -------------------------------------------------------------------------------- | ----------- |
+| `metrics.enabled`                          | Enable Prometheus metrics exporter                                               | `true`      |
+| `metrics.service.type`                     | Metrics service type                                                             | `ClusterIP` |
+| `metrics.service.ports.port`               | Metrics service port                                                             | `7000`      |
+| `metrics.service.annotations`              | Additional custom annotations for Metrics service                                | `{}`        |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor resource(s) for scraping metrics using Prometheus Operator | `false` |
+| `metrics.serviceMonitor.namespace`         | Namespace in which to create ServiceMonitor resource(s)                          | `""`    |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                      | `10s`   |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                          | `""`    |
+| `metrics.serviceMonitor.relabelings`       | Additional relabeling of metrics                                                 | `[]`    |
+| `metrics.serviceMonitor.metricRelabelings` | Additional metric relabeling of metrics                                          | `[]`    |
+| `metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                             | `false` |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                              | `{}`    |
+| `metrics.serviceMonitor.annotations`       | Additional custom annotations for the ServiceMonitor                             | `{}`    |
+| `metrics.serviceMonitor.namespaceSelector` | Namespace selector for ServiceMonitor                                            | `{}`    |
 
 ### Service Configuration
 

--- a/charts/zookeeper/templates/metrics-service.yaml
+++ b/charts/zookeeper/templates/metrics-service.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zookeeper.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "zookeeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $annotations := merge .Values.metrics.service.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - port: {{ .Values.metrics.service.port }}
+      targetPort: {{ .Values.metrics.service.port }}
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "zookeeper.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -13,14 +13,19 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/instance: release-name
-      app.kubernetes.io/name: zookeeper
+      {{- include "zookeeper.labels" . | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress
   egress:
     - {}
   ingress:
+    {{- if .Values.metrics.enabled }}
+    # Allow metrics scraping
+    - ports:
+        - port: {{ .Values.metrics.service.port }}
+          protocol: TCP
+    {{- end }}
     # Allow inbound connections to ZooKeeper
     - ports:
         - port: {{ .Values.service.ports.client | default 2181 }}
@@ -31,6 +36,5 @@ spec:
       from:
         - podSelector:
             matchLabels:
-              app.kubernetes.io/instance: release-name
-              app.kubernetes.io/name: zookeeper
+            {{- include "zookeeper.labels" . | nindent 12 }}
 {{- end }}

--- a/charts/zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/zookeeper/templates/poddisruptionbudget.yaml
@@ -19,6 +19,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/instance: release-name
-      app.kubernetes.io/name: zookeeper
+      {{- include "zookeeper.labels" . | nindent 6 }}
 {{- end }}

--- a/charts/zookeeper/templates/servicemonitor.yaml
+++ b/charts/zookeeper/templates/servicemonitor.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "zookeeper.fullname" . }}-metrics
+  namespace: {{ include "cloudpirates.namespace" . }}
+  labels:
+    {{- include "zookeeper.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- with .Values.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+{{- include "cloudpirates.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.annotations "context" .) | indent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ include "zookeeper.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "zookeeper.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -52,6 +52,11 @@ spec:
             - name: admin
               containerPort: {{ .Values.service.ports.admin | default 8080 }}
               protocol: TCP
+            {{- if .Values.metrics.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.metrics.service.port | default 7000 }}
+              protocol: TCP
+            {{- end }}
           env:
           {{- with .Values.extraEnvVars }}
 {{ toYaml . | indent 12 }}

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -136,6 +136,44 @@
                         },
                         "type": {
                             "type": "string"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "honorLabels": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "namespaceSelector": {
+                            "type": "object"
+                        },
+                        "relabelings": {
+                            "type": "array"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
+                        },
+                        "selector": {
+                            "type": "object"
                         }
                     }
                 }

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -104,6 +104,31 @@ metrics:
     type: ClusterIP
     ## @param metrics.service.ports.port Zookeeper metrics service port
     port: 7000
+    ## @param metrics.service.annotations Additional annotations for metrics service
+    annotations: {}
+  ## Prometheus ServiceMonitor configuration
+  serviceMonitor:
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    enabled: false
+    ## @param metrics.serviceMonitor.namespace Namespace in which to create ServiceMonitor resource(s)
+    namespace: ""
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
+    interval: 10s
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.relabelings Specify additional relabeling of metrics
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings Specify additional metric relabeling of metrics
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Honor metrics labels
+    honorLabels: false
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    selector: {}
+    ## @param metrics.serviceMonitor.annotations Additional custom annotations for the ServiceMonitor
+    annotations: {}
+    ## @param metrics.serviceMonitor.namespaceSelector Namespace selector for ServiceMonitor
+    namespaceSelector: {}
+
 
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @section Zookeeper Container Security Context


### PR DESCRIPTION
### Description of the change

add ServiceMonitor for zookeeper

### Benefits
Have a ServiceMonitor :)

### Possible drawbacks

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
