### PR TITLE
[zookeeper]: fix NetPol and PDB to use correct selectorLabels template

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: "3.9.4"
 keywords:
   - zookeeper

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "zookeeper.labels" . | nindent 6 }}
+      {{- include "zookeeper.selectorLabels" . | nindent 6 }}
   policyTypes:
     - Ingress
     - Egress
@@ -36,5 +36,5 @@ spec:
       from:
         - podSelector:
             matchLabels:
-            {{- include "zookeeper.labels" . | nindent 12 }}
+              {{- include "zookeeper.selectorLabels" . | nindent 14 }}
 {{- end }}

--- a/charts/zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/zookeeper/templates/poddisruptionbudget.yaml
@@ -19,5 +19,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "zookeeper.labels" . | nindent 6 }}
+      {{- include "zookeeper.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
### Description of the change
fix NetPol and PDB to use correct selectorLabels template

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
