### PR TITLE
[redis] Include Sentinel port in default service when enabled

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.20.1
+version: 0.20.2
 appVersion: "8.4.0"
 keywords:
   - redis

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -25,6 +25,12 @@ spec:
       targetPort: redis
       protocol: TCP
       name: redis
+    {{- if and .Values.sentinel.enabled (eq .Values.architecture "replication") }}
+    - port: {{ .Values.sentinel.port }}
+      targetPort: sentinel
+      protocol: TCP
+      name: sentinel
+    {{- end }}
     {{- range .Values.extraPorts }}
     - port: {{ .port }}
       targetPort: {{ .targetPort | default .name }}


### PR DESCRIPTION
### Description of the change

Include the sentinel port in the default redis service, it's missing when migrating from old bitnami helm charts.