### PR TITLE
[rabbitmq-cluster-operator] Add issuer and extra-list templates that were missing

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "2.18.0"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/extra-list.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/issuer.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/issuer.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.useCertManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    {{- include "rmqco.labels" . | nindent 4 }}
+  name: {{ template "cloudpirates.fullname" . }}
+  namespace: {{ include "cloudpirates.namespace" . | quote }}
+spec:
+  selfSigned: {}
+{{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add issuer.yaml and extra-list.yaml templates that were missing.

### Benefits

There were two bugs that will get fixed with this change:
- When setting useCertManager to `true` the necessary Issuer wasn't getting created, so the Certificate couldn't be created correctly.
- Adding objects to extraDeploy array didn't have any effect. This gets solved and extra objects can be created now.

### Additional information

Both issuer.yaml and extra-list.yaml have been adapted from the original bitnami

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
