### PR TITLE
[keycloak]: Try to fix keycloak startup probe/s

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "26.5.2"
 keywords:
   - keycloak

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -101,7 +101,7 @@ keycloak:
   ## @param keycloak.httpEnabled Enable HTTP listener
   httpEnabled: true
   ## @param keycloak.httpsEnabled Enable HTTPS listener
-  httpsEnabled: true
+  httpsEnabled: false
   ## @param keycloak.httpPort HTTP port
   httpPort: 8080
   ## @param keycloak.httpsPort HTTPS port


### PR DESCRIPTION
### Description of the change

By default, disable https as it has problems with denying startup when invalid / no tls certificate is provided

### Benefits

Startup of keycloak

### Possible drawbacks

Less secure by default

### Applicable issues

- fixes #898 

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
