### PR TITLE
[rabbitmq] Add detailed metrics support (#804)

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.13.2
+version: 0.14.0
 appVersion: "4.2.3"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -247,17 +247,18 @@ kubectl edit configmap my-rabbitmq-definitions -n <namespace>
 
 ### Metrics configuration
 
-| Parameter                              | Description                                                                                                                 | Default |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `metrics.enabled`                      | Enable RabbitMQ metrics (via prometheus plugin)                                                                             | `false` |
-| `metrics.port`                         | RabbitMQ metrics port                                                                                                       | `15692` |
-| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor for Prometheus monitoring                                                                             | `false` |
-| `metrics.serviceMonitor.namespace`     | Namespace for ServiceMonitor                                                                                                | `""`    |
-| `metrics.serviceMonitor.labels`        | Labels for ServiceMonitor                                                                                                   | `{}`    |
-| `metrics.serviceMonitor.annotations`   | Annotations for ServiceMonitor                                                                                              | `{}`    |
-| `metrics.serviceMonitor.interval`      | Scrape interval                                                                                                             | `30s`   |
-| `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout                                                                                                              | `10s`   |
-| `additionalPlugins`                    | Additional RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added) | `[]`    |
+| Parameter                              | Description                                                                                                                 | Default    |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `metrics.enabled`                      | Enable RabbitMQ metrics (via prometheus plugin)                                                                             | `false`    |
+| `metrics.port`                         | RabbitMQ metrics port                                                                                                       | `15692`    |
+| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor for Prometheus monitoring                                                                             | `false`    |
+| `metrics.serviceMonitor.namespace`     | Namespace for ServiceMonitor                                                                                                | `""`       |
+| `metrics.serviceMonitor.labels`        | Labels for ServiceMonitor                                                                                                   | `{}`       |
+| `metrics.serviceMonitor.annotations`   | Annotations for ServiceMonitor                                                                                              | `{}`       |
+| `metrics.serviceMonitor.interval`      | Scrape interval                                                                                                             | `30s`      |
+| `metrics.serviceMonitor.scrapeTimeout` | Scrape timeout                                                                                                              | `10s`      |
+| `metrics.serviceMonitor.path`          | Select detail of metrics (`/metrics`, `/metrics/detailed` or `/metrics/per-object`)                                         | `/metrics` |
+| `additionalPlugins`                    | Additional RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added) | `[]`       |
 
 ### Persistence
 

--- a/charts/rabbitmq/templates/servicemonitor.yaml
+++ b/charts/rabbitmq/templates/servicemonitor.yaml
@@ -22,5 +22,5 @@ spec:
     - port: prometheus
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
-      path: /metrics
+      path: {{ .Values.metrics.serviceMonitor.path }}
 {{- end }}

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -282,6 +282,8 @@ metrics:
     interval: 30s
     ## @param metrics.serviceMonitor.scrapeTimeout Scrape timeout
     scrapeTimeout: 10s
+    ## @param metrics.serviceMonitor.path Select detail of metrics (/metrics, /metrics/detailed, /metrics/per-object)
+    path: /metrics
 
 ## @param additionalPlugins Additional default RabbitMQ plugins to enable (Prometheus Metrics, PeerDiscoveryK8s and Management plugins are automatically added)
 additionalPlugins: []


### PR DESCRIPTION
### Description of the change

Makes the `/path` paremeter for the scraping endpoint of the rabbitmq serviceMonitor configurable via `.Values.metrics.serviceMonitor.path`

### Benefits

Adds support for configuring more detailed scrape endpoints.

### Possible drawbacks

None, change is non breaking.

### Applicable issues

- fixes #804 

### Additional information

See also <https://www.rabbitmq.com/docs/prometheus#default-endpoint>

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [ ] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
