### PR TITLE
[common] Fix YAML parse error caused by whitespace control in selectorLabels

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: common
 description: A library chart for common templates and helper functions
 type: library
-version: 2.1.1
-appVersion: "2.1.1"
+version: 2.1.2
+appVersion: "2.1.2"
 home: https://www.cloudpirates.io
 sources:
   - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/common
@@ -14,8 +14,5 @@ maintainers:
 annotations:
   license: Apache-2.0
   artifacthub.io/changes: |2
-        - kind: changed
-          description: "rename templates from common.* to cloudpirates.* to prevent collisions (#377)"
-          links:
-            - name: "Commit 07c6560"
-              url: "https://github.com/CloudPirates-io/helm-charts/commit/07c6560"
+        - kind: fixed
+          description: "Fix YAML parse error caused by whitespace control in selectorLabels broken in #914"

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Common labels
 */}}
 {{- define "cloudpirates.labels" -}}
 helm.sh/chart: {{ include "cloudpirates.chart" . }}
-{{- include "cloudpirates.selectorLabels" . }}
+{{ include "cloudpirates.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -69,7 +69,7 @@ Selector labels
 app.kubernetes.io/name: {{ .Values.selectorLabels.name }}
 {{- else -}}
 app.kubernetes.io/name: {{ include "cloudpirates.name" . }}
-{{- end -}}
+{{ end -}}
 {{- if and .Values.selectorLabels .Values.selectorLabels.instance }}
 app.kubernetes.io/instance: {{ .Values.selectorLabels.instance }}
 {{- else -}}


### PR DESCRIPTION
Commit 67b1f4f ("[common] Add support for overriding selector labels (#914)") introduced incorrect Go template whitespace control that causes labels to concatenate on single lines, producing invalid YAML.

Any chart depending on common (etcd, mariadb, valkey, etc.) fails with:

    Error: YAML parse error on etcd/templates/service.yaml: error converting
    YAML to JSON: yaml: line 7: mapping values are not allowed in this context

    helm template my-release oci://registry-1.docker.io/cloudpirates/etcd \
      --version 0.5.0

With --debug, the rendered output shows concatenated labels:

    labels:
      helm.sh/chart: etcd-0.5.0app.kubernetes.io/name: etcdapp.kubernetes.io/instance: my-release

Two uses of `{{-` (leading dash) incorrectly strip newlines:

1. Line 54: `{{- include "cloudpirates.selectorLabels"` strips the newline after `helm.sh/chart`, concatenating it with the first selector label

2. Line 72: `{{- end -}}` strips the newline after `app.kubernetes.io/name`, concatenating it with `app.kubernetes.io/instance`

Remove the leading dash from both locations to preserve the newlines:

- Line 54: `{{- include` -> `{{ include`
- Line 72: `{{- end -}}` -> `{{ end -}}`

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
