### PR TITLE
[keycloak]: Allow prepending arguments to keycloak

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.13.5
+version: 0.13.6
 appVersion: "26.5.2"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -152,6 +152,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `keycloak.proxyTrustedAddresses`       | A comma separated list of trusted proxy addresses                                                            | `""`               |
 | `keycloak.production`                  | Enable production mode                                                                                       | `false`            |
 | `keycloak.httpRelativePath`            | Set relative path for serving resources; must start with a /                                                 | `""`               |
+| `keycloak.extraArgsPrefix`             | Additional arguments to pass before the start command (e.g., for --config-file)                              | `[]`               |
 | `keycloak.extraArgs`                   | Additional arguments to pass to the Keycloak startup command                                                 | `[]`               |
 
 ### TLS Configuration

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -71,6 +71,9 @@ spec:
           command:
             - {{ .Values.image.command }}
           args:
+            {{- with .Values.keycloak.extraArgsPrefix }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if .Values.keycloak.production }}
             - start
             {{- else }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -240,6 +240,9 @@
                 "extraArgs": {
                     "type": "array"
                 },
+                "extraArgsPrefix": {
+                    "type": "array"
+                },
                 "hostname": {
                     "type": "string"
                 },

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -116,6 +116,8 @@ keycloak:
   production: false
   ## @param keycloak.httpRelativePath Set relative path for serving resources; must start with a /
   httpRelativePath: /
+  ## @param keycloak.extraArgsPrefix Additional arguments to pass before the start command (e.g., for --config-file)
+  extraArgsPrefix: []
   ## @param keycloak.extraArgs Additional arguments to pass to the Keycloak startup command
   extraArgs: []
 


### PR DESCRIPTION
### Description of the change

Allows prepending arguments to the keycloak startup command

### Benefits

Stated above

### Possible drawbacks

None, by default, its empty

### Applicable issues

- fixes #906

### Additional information


### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
