### PR TITLE
[rabbitmq] Fix template scope in installPlugins range block

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: "4.2.3"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
               mkdir -p {{ .Values.persistence.mountPath }}/plugins
               {{- range .Values.installPlugins }}
               echo "Downloading plugin from {{ . }}"
-              wget -O {{ .Values.persistence.mountPath }}/plugins/$(basename {{ . }}) {{ . }}
+              wget -O {{ $.Values.persistence.mountPath }}/plugins/$(basename {{ . }}) {{ . }}
               {{- end }}
               echo "Moving downloaded plugins to shared directory"
               if ls {{ .Values.persistence.mountPath }}/plugins/*.ez 1> /dev/null 2>&1; then


### PR DESCRIPTION
### Description of the change

When the template evaluates .Values.persistence.mountPath, it's trying to access .Values on the current item instead of the global scope. Code change fixes the scoping issue.

### Benefits

Fixes the issue introduced by the previous release.

### Possible drawbacks


### Applicable issues


### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
