### PR TITLE
[postgres] Introduce helm-docs generated README

### DIFF
--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -1,16 +1,21 @@
-<p align="center">
-    <a href="https://artifacthub.io/packages/helm/cloudpirates-postgres/postgres"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudpirates-postgres" /></a>
-</p>
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 18.1.0](https://img.shields.io/badge/AppVersion-18.1.0-informational?style=flat-square)
+<a href="https://artifacthub.io/packages/helm/cloudpirates-postgres/postgres"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudpirates-postgres" /></a>
 
 # PostgreSQL
 
-A Helm chart for PostgreSQL - The World's Most Advanced Open Source Relational Database. PostgreSQL is a powerful, open source object-relational database system with over 35 years of active development that has earned it a strong reputation for reliability, feature robustness, and performance.
+The World's Most Advanced Open Source Relational Database
 
 ## Prerequisites
 
 - Kubernetes 1.24+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure (if persistence is enabled)
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| oci://registry-1.docker.io/cloudpirates | common | 2.x.x |
 
 ## Installing the Chart
 
@@ -67,217 +72,159 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/postgres:<versi
 
 The following table lists the configurable parameters of the PostgreSQL chart and their default values.
 
-### Global parameters
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity settings for pod assignment |
+| args | string | `nil` | Override default container args (useful for hardened images that handle startup differently) # Leave unset or null to use default args, set to empty array [] to disable default args for hardened images like DHI |
+| auth.database | string | `""` | Alternative name for the default database to be created at initialisation |
+| auth.existingSecret | string | `""` | Name of existing secret to use for PostgreSQL credentials |
+| auth.password | string | `""` | Password for the custom user to create |
+| auth.secretKeys.adminPasswordKey | string | `"postgres-password"` | Name of key in existing secret to use for PostgreSQL admin credentials |
+| auth.username | string | `""` | Name for a custom superuser to create at initialisation. (This will also create a database with the same name) |
+| command | list | `[]` | Override default container command (useful for hardened images) |
+| commonAnnotations | object | `{}` | Annotations to add to all deployed objects |
+| commonLabels | object | `{}` | Labels to add to all deployed objects |
+| config.existingConfigmap | string | `""` | Name of existing ConfigMap with PostgreSQL configuration |
+| config.extraConfig | list | `[]` | Additional PostgreSQL configuration parameters |
+| config.mountConfigMap | bool | `true` | Enable mounting of ConfigMap with PostgreSQL configuration |
+| config.pgHbaConfig | string | `""` | Content of a custom pg_hba.conf file to be used instead of the default config |
+| config.postgresql.locale | string | `"en_US.utf8"` | Default locale setting |
+| config.postgresql.timezone | string | `"UTC"` | Default timezone setting |
+| config.postgresqlCheckpointCompletionTarget | string | `""` | Time spent flushing dirty buffers during checkpoint, as fraction of checkpoint interval |
+| config.postgresqlEffectiveCacheSize | string | `""` | Effective cache size |
+| config.postgresqlLogMinDurationStatement | string | `""` | Sets the minimum execution time above which statements will be logged |
+| config.postgresqlLogStatement | string | `""` | Sets the type of statements logged |
+| config.postgresqlMaintenanceWorkMem | string | `""` | Maximum amount of memory to be used by maintenance operations |
+| config.postgresqlMaxConnections | int | `100` | Maximum number of connections |
+| config.postgresqlRandomPageCost | string | `""` | Sets the planner's estimate of the cost of a non-sequentially-fetched disk page |
+| config.postgresqlSharedBuffers | string | `""` | Amount of memory the database server uses for shared memory buffers |
+| config.postgresqlSharedPreloadLibraries | string | `""` | Shared preload libraries (comma-separated list) |
+| config.postgresqlWalBuffers | string | `""` | Amount of memory used in shared memory for WAL data (deprecated, see postgresql.wal.buffers) |
+| config.postgresqlWorkMem | string | `""` | Amount of memory to be used by internal sort operations and hash tables |
+| containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Enable container privilege escalation |
+| containerSecurityContext.capabilities | object | `{"drop":["ALL"]}` | Linux capabilities to be dropped |
+| containerSecurityContext.readOnlyRootFilesystem | bool | `false` | Mount container root filesystem as read-only |
+| containerSecurityContext.runAsGroup | int | `999` | Group ID for the PostgreSQL container |
+| containerSecurityContext.runAsNonRoot | bool | `true` | Configure the container to run as a non-root user |
+| containerSecurityContext.runAsUser | int | `999` | User ID for the PostgreSQL container |
+| customUser.database | string | `""` | Name of the database to be created |
+| customUser.existingSecret | string | `""` | Existing secret, in which username, password and database name are saved |
+| customUser.name | string | `""` | Name of the custom user to be created |
+| customUser.password | string | `""` | Password to be used for the custom user |
+| customUser.secretKeys.database | string | `"CUSTOM_DB"` | Custom user database secret reference (set empty to fallback to customUser.database) |
+| customUser.secretKeys.name | string | `"CUSTOM_USER"` | Custom user name secret reference (set empty to fallback to customUser.name) |
+| customUser.secretKeys.password | string | `"CUSTOM_PASSWORD"` |  |
+| extraEnvVars | list | `[]` | Additional environment variables to set |
+| extraEnvVarsSecret | string | `""` | Name of a secret containing additional environment variables |
+| extraObjects | list | `[]` | Array of extra objects to deploy with the release |
+| extraVolumeMounts | list | `[]` | Additional volume mounts to add to the MongoDB container |
+| extraVolumes | list | `[]` | Additional volumes to add to the pod |
+| fullnameOverride | string | `""` | String to fully override postgres.fullname |
+| global.enableServiceLinks | bool | `true` | Whether to add service links env variables to pods |
+| global.imagePullSecrets | list | `[]` | Global Docker registry secret names as an array |
+| global.imageRegistry | string | `""` | Global Docker Image registry |
+| image.imagePullPolicy | string | `"Always"` | PostgreSQL image pull policy |
+| image.registry | string | `"docker.io"` | PostgreSQL image registry |
+| image.repository | string | `"postgres"` | PostgreSQL image repository |
+| image.tag | string | `"18.1@sha256:5773fe724c49c42a7a9ca70202e11e1dff21fb7235b335a73f39297d200b73a2"` | PostgreSQL image tag (immutable tags are recommended) |
+| image.useHardenedImage | bool | `false` | Set to true when using hardened images (e.g., DHI) that have different PGDATA paths for Postgres <18 |
+| ingress.annotations | object | `{}` | Additional annotations for the Ingress resource |
+| ingress.className | string | `""` | IngressClass that will be used to implement the Ingress |
+| ingress.enabled | bool | `false` | Enable ingress record generation for PostgreSQL |
+| ingress.hosts[0].host | string | `"postgres.local"` | Hostname |
+| ingress.hosts[0].paths[0].path | string | `"/"` | Base path |
+| ingress.hosts[0].paths[0].pathType | string | `"Prefix"` | Path type |
+| ingress.tls | list | `[]` | TLS configuration for PostgreSQL ingress |
+| initContainers | list | `[]` | Init containers to add to the PostgreSQL pods. Useful for tasks like pgautoupgrade for major version upgrades |
+| initdb.args | string | `""` | Send arguments to postgres initdb. This is a space separated string of arguments |
+| initdb.directory | string | `"/docker-entrypoint-initdb.d/"` | Directory where to load initScripts |
+| initdb.scripts | object | `{}` | Dictionary of initdb scripts |
+| initdb.scriptsConfigMap | string | `""` | ConfigMap with scripts to be run at first boot |
+| livenessProbe.enabled | bool | `true` | Enable livenessProbe on PostgreSQL containers |
+| livenessProbe.failureThreshold | int | `3` | Failure threshold for livenessProbe |
+| livenessProbe.initialDelaySeconds | int | `30` | Initial delay seconds for livenessProbe |
+| livenessProbe.periodSeconds | int | `10` | Period seconds for livenessProbe |
+| livenessProbe.successThreshold | int | `1` | Success threshold for livenessProbe |
+| livenessProbe.timeoutSeconds | int | `5` | Timeout seconds for livenessProbe |
+| metrics.enabled | bool | `false` | Start a sidecar prometheus exporter to expose PostgreSQL metrics |
+| metrics.image.pullPolicy | string | `"Always"` | PostgreSQL exporter image pull policy |
+| metrics.image.registry | string | `"quay.io"` | PostgreSQL exporter image registry |
+| metrics.image.repository | string | `"prometheuscommunity/postgres-exporter"` | PostgreSQL exporter image repository |
+| metrics.image.tag | string | `"v0.18.1@sha256:fb96c4413985d4b23ab02b19022b3d70a86c8e0a62f41ab15ebb6f4673781a5d"` | PostgreSQL exporter image tag |
+| metrics.resources | object | `{}` | Resource limits and requests for metrics container |
+| metrics.service.annotations | object | `{}` | Additional custom annotations for Metrics service |
+| metrics.service.labels | object | `{}` | Additional custom labels for Metrics service |
+| metrics.service.port | int | `9187` | Metrics service port |
+| metrics.serviceMonitor.annotations | object | `{}` | ServiceMonitor annotations |
+| metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator |
+| metrics.serviceMonitor.honorLabels | bool | `false` | honorLabels chooses the metric's labels on collisions with target labels |
+| metrics.serviceMonitor.interval | string | `"30s"` | The interval at which metrics should be scraped |
+| metrics.serviceMonitor.metricRelabelings | list | `[]` | ServiceMonitor metricRelabelings configs to apply to samples before ingestion |
+| metrics.serviceMonitor.namespace | string | `""` | The namespace in which the ServiceMonitor will be created |
+| metrics.serviceMonitor.namespaceSelector | object | `{}` | ServiceMonitor namespace selector |
+| metrics.serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabel configs to apply to samples before scraping |
+| metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | The timeout after which the scrape is ended |
+| metrics.serviceMonitor.selector | object | `{}` | Additional labels for ServiceMonitor resource |
+| nameOverride | string | `""` | String to partially override postgres.fullname |
+| nodeSelector | object | `{}` | Node labels for pod assignment |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Persistent Volume access modes |
+| persistence.annotations | object | `{}` | Persistent Volume Claim annotations |
+| persistence.enabled | bool | `true` | Enable persistence using Persistent Volume Claims |
+| persistence.existingClaim | string | `""` | The name of an existing PVC to use for persistence |
+| persistence.labels | object | `{}` | Labels for persistent volume claims |
+| persistence.size | string | `"8Gi"` | Persistent Volume size |
+| persistence.storageClass | string | `""` | Persistent Volume storage class |
+| persistence.subPath | string | `""` | The subdirectory of the volume to mount to # Useful in dev environments and one PV for multiple services |
+| persistence.volumeName | string | `"data"` | Container volume name and volume claim prefix |
+| persistentVolumeClaimRetentionPolicy.enabled | bool | `false` | Enable Persistent volume retention policy for the Statefulset |
+| persistentVolumeClaimRetentionPolicy.whenDeleted | string | `"Retain"` | Volume retention behavior that applies when the StatefulSet is deleted |
+| persistentVolumeClaimRetentionPolicy.whenScaled | string | `"Retain"` | Volume retention behavior when the replica count of the StatefulSet is reduced |
+| podAnnotations | object | `{}` | Map of annotations to add to the pods |
+| podLabels | object | `{}` | Map of labels to add to the pods |
+| podSecurityContext.fsGroup | int | `999` | Group ID for the volumes of the pod |
+| priorityClassName | string | `""` | Priority class name to be used for the pods |
+| readinessProbe.enabled | bool | `true` | Enable readinessProbe on PostgreSQL containers |
+| readinessProbe.failureThreshold | int | `3` | Failure threshold for readinessProbe |
+| readinessProbe.initialDelaySeconds | int | `5` | Initial delay seconds for readinessProbe |
+| readinessProbe.periodSeconds | int | `5` | Period seconds for readinessProbe |
+| readinessProbe.successThreshold | int | `1` | Success threshold for readinessProbe |
+| readinessProbe.timeoutSeconds | int | `5` | Timeout seconds for readinessProbe |
+| replicaCount | int | `1` | Number of PostgreSQL replicas to deploy (Note: PostgreSQL doesn't support multi-master replication by default) |
+| replication.allowFrom.ipv4 | string | `"0.0.0.0/0"` | Allowed IPv4 network (set empty to disable that feature) |
+| replication.allowFrom.ipv6 | string | `"::/0"` | Allowed IPv6 network (set empty to disable that feature) |
+| replication.auth.existingSecret | string | `""` | Use existing secret reference instead of password |
+| replication.auth.password | string | `""` | Password for replication user (cannot be empty) |
+| replication.auth.secretKeys.password | string | `"replication-password"` | Secret key for replication password |
+| replication.auth.username | string | `"replication"` | Username for replication user |
+| replication.enabled | bool | `false` | Enables the WAL replication feature for both sides (primary and standby) |
+| replication.primary.host | string | `""` | Hostname of the primary server |
+| replication.primary.port | int | `5432` | Port of the primary server |
+| resources | object | `{}` |  |
+| service.annotations | object | `{}` | Service annotations |
+| service.nodePort | int | `30432` | PostgreSQL NodePort port |
+| service.port | int | `5432` | PostgreSQL service port |
+| service.targetPort | int | `5432` | PostgreSQL container port |
+| service.type | string | `"ClusterIP"` | PostgreSQL service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Whether to automount the SA token inside the pod |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. |
+| startupProbe.enabled | bool | `true` | Enable startupProbe on PostgreSQL containers |
+| startupProbe.failureThreshold | int | `30` | Failure threshold for startupProbe |
+| startupProbe.initialDelaySeconds | int | `30` | Initial delay seconds for startupProbe |
+| startupProbe.periodSeconds | int | `10` | Period seconds for startupProbe |
+| startupProbe.successThreshold | int | `1` | Success threshold for startupProbe |
+| startupProbe.timeoutSeconds | int | `5` | Timeout seconds for startupProbe |
+| terminationGracePeriodSeconds | int | `30` | Time for Kubernetes to wait for the pod to gracefully terminate |
+| tolerations | list | `[]` | Toleration labels for pod assignment |
 
-| Parameter                 | Description                                     | Default |
-| ------------------------- | ----------------------------------------------- | ------- |
-| `global.imageRegistry`    | Global Docker image registry                    | `""`    |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`    |
+## Examples
 
-### PostgreSQL image configuration
-
-| Parameter                  | Description                                                                                              | Default                                                                          |
-| -------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `image.registry`           | PostgreSQL image registry                                                                                | `docker.io`                                                                      |
-| `image.repository`         | PostgreSQL image repository                                                                              | `postgres`                                                                       |
-| `image.tag`                | PostgreSQL image tag (immutable tags are recommended)                                                    | `"18.1@sha256:28bda6d50590658221007b10573830c941b483e9d1a5bc2713a3f60477df8389"` |
-| `image.imagePullPolicy`    | PostgreSQL image pull policy                                                                             | `Always`                                                                         |
-| `image.useHardenedImage`   | Set to `true` when using hardened images (e.g., DHI) that have different PGDATA paths for Postgres <18   | `false`                                                                          |
-
-### Deployment configuration
-
-| Parameter           | Description                                                                                                    | Default |
-| ------------------- | -------------------------------------------------------------------------------------------------------------- | ------- |
-| `replicaCount`      | Number of PostgreSQL replicas to deploy (Note: PostgreSQL doesn't support multi-master replication by default) | `1`     |
-| `nameOverride`      | String to partially override postgres.fullname                                                                 | `""`    |
-| `fullnameOverride`  | String to fully override postgres.fullname                                                                     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects                                                                          | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects                                                                     | `{}`    |
-| `priorityClassName` | Priority class name to be used for the pods                                                                    | ``      |
-| `terminationGracePeriodSeconds` | Time for Kubernetes to wait for the pod to gracefully terminate                                    | `30`    |
-
-### Pod annotations and labels
-
-| Parameter        | Description                           | Default |
-| ---------------- | ------------------------------------- | ------- |
-| `podAnnotations` | Map of annotations to add to the pods | `{}`    |
-| `podLabels`      | Map of labels to add to the pods      | `{}`    |
-
-### Security Context
-
-| Parameter                                           | Description                                       | Default   |
-| --------------------------------------------------- | ------------------------------------------------- | --------- |
-| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod               | `999`     |
-| `containerSecurityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
-| `containerSecurityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
-| `containerSecurityContext.runAsUser`                | User ID for the PostgreSQL container              | `999`     |
-| `containerSecurityContext.runAsGroup`               | Group ID for the PostgreSQL container             | `999`     |
-| `containerSecurityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `false`   |
-| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
-
-### PostgreSQL Authentication
-
-| Parameter                          | Description                                                                                                    | Default               |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `auth.username`                    | Name for a custom superuser to create at initialisation. (This will also create a database with the same name) | `"openfga"`           |
-| `auth.password`                    | Password for the custom user to create                                                                         | `""`                  |
-| `auth.database`                    | Alternative name for the default database to be created at initialisation                                      | `""`                  |
-| `auth.existingSecret`              | Name of existing secret to use for PostgreSQL credentials                                                      | `""`                  |
-| `auth.secretKeys.adminPasswordKey` | Name of key in existing secret to use for PostgreSQL admin credentials                                         | `"postgres-password"` |
-
-### PostgreSQL Configuration
-
-| Parameter                                     | Description                                                                             | Default |
-| --------------------------------------------- | --------------------------------------------------------------------------------------- | ------- |
-| `config.mountConfigMap`                       | Enable mounting of ConfigMap with PostgreSQL configuration                              | `true`  |
-| `config.postgresqlSharedPreloadLibraries`     | Shared preload libraries (comma-separated list)                                         | `""`    |
-| `config.postgresqlMaxConnections`             | Maximum number of connections                                                           | `100`   |
-| `config.postgresqlSharedBuffers`              | Amount of memory the database server uses for shared memory buffers                     | `""`    |
-| `config.postgresqlEffectiveCacheSize`         | Effective cache size                                                                    | `""`    |
-| `config.postgresqlWorkMem`                    | Amount of memory to be used by internal sort operations and hash tables                 | `""`    |
-| `config.postgresqlMaintenanceWorkMem`         | Maximum amount of memory to be used by maintenance operations                           | `""`    |
-| `config.postgresqlWalBuffers`                 | Amount of memory used in shared memory for WAL data                                     | `""`    |
-| `config.postgresqlCheckpointCompletionTarget` | Time spent flushing dirty buffers during checkpoint, as fraction of checkpoint interval | `""`    |
-| `config.postgresqlRandomPageCost`             | Sets the planner's estimate of the cost of a non-sequentially-fetched disk page         | `""`    |
-| `config.postgresqlLogStatement`               | Sets the type of statements logged                                                      | `""`    |
-| `config.postgresqlLogMinDurationStatement`    | Sets the minimum execution time above which statements will be logged                   | `""`    |
-| `config.extraConfig`                          | Additional PostgreSQL configuration parameters                                          | `[]`    |
-| `config.existingConfigmap`                    | Name of existing ConfigMap with PostgreSQL configuration                                | `""`    |
-| `config.pgHbaConfig`                          | Content of a custom pg_hba.conf file to be used instead of the default config           | `""`    |
-
-### Custom User Configuration
-| Parameter                   | Description                                                                        | Default                                  |
-| --------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------- |
-| `customUser`                | Optional user to be created at initialisation with a custom password and database  | `{}`                                     |
-| `customUser.name`           | Name of the custom user to be created                                              | `""`                                     |
-| `customUser.database`       | Name of the database to be created                                                 | `""`                                     |
-| `customUser.password`       | Password to be used for the custom user                                            | `""`                                     |
-| `customUser.existingSecret` | Existing secret, in which username, password and database name are saved           | `""`                                     |
-| `customUser.secretKeys`     | Name of keys in existing secret to use the custom user name, password and database | `{name: "", database: "", password: ""}` |
-
-### Container Command/Args Override
-
-| Parameter | Description                                                                                                                                       | Default |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `command` | Override default container command (useful for hardened images)                                                                                   | `[]`    |
-| `args`    | Override default container args (useful for hardened images that handle startup differently). Set to `null` to use defaults, `[]` to disable args | `null`  |
-
-These parameters are useful when using hardened PostgreSQL images (such as from DHI or other security-focused registries) that have different entrypoint behaviors than the standard Docker Hub postgres image. When using such images, you may need to set `args: []` to prevent passing the default `postgres` binary name and configuration arguments.
-
-### PostgreSQL Initdb Configuration
-
-| Parameter                 | Description                                                                      | Default |
-| ------------------------- | -------------------------------------------------------------------------------- | ------- |
-| `initdb.args`             | Send arguments to postgres initdb. This is a space separated string of arguments | `""`    |
-| `initdb.scripts`          | Dictionary of initdb scripts                                                     | `{}`    |
-| `initdb.scriptsConfigMap` | ConfigMap with scripts to be run at first boot                                   | `""`    |
-
-### Service configuration
-
-| Parameter                       | Description                                                                       | Default     |
-| ------------------------------- | --------------------------------------------------------------------------------- | ----------- |
-| `service.type`                  | PostgreSQL service type                                                           | `ClusterIP` |
-| `service.port`                  | PostgreSQL service port                                                           | `5432`      |
-| `service.targetPort`            | PostgreSQL container port                                                         | `5432`      |
-| `service.nodePort`              | PostgreSQL NodePort port                                                          | `30432`     |
-| `service.annotations`           | Service annotations                                                               | `{}`        |
-| `service.loadBalancerIP`        | Load balancer IP (applies if service type is `LoadBalancer`)                      | `""`        |
-| `service.externalTrafficPolicy` | External traffic policy (applies if service type is `LoadBalancer` or `NodePort`) | `Cluster`   |
-
-### Ingress configuration
-
-| Parameter                            | Description                                             | Default          |
-| ------------------------------------ | ------------------------------------------------------- | ---------------- |
-| `ingress.enabled`                    | Enable ingress record generation for PostgreSQL         | `false`          |
-| `ingress.className`                  | IngressClass that will be used to implement the Ingress | `""`             |
-| `ingress.annotations`                | Additional annotations for the Ingress resource         | `{}`             |
-| `ingress.hosts[0].host`              | Hostname for PostgreSQL ingress                         | `postgres.local` |
-| `ingress.hosts[0].paths[0].path`     | Path for PostgreSQL ingress                             | `/`              |
-| `ingress.hosts[0].paths[0].pathType` | Path type for PostgreSQL ingress                        | `Prefix`         |
-| `ingress.tls`                        | TLS configuration for PostgreSQL ingress                | `[]`             |
-
-### Resources
-
-| Parameter   | Description                                 | Default |
-| ----------- | ------------------------------------------- | ------- |
-| `resources` | The resources to allocate for the container | `{}`    |
-
-### Persistence
-
-| Parameter                   | Description                                        | Default             |
-| --------------------------- | -------------------------------------------------- | ------------------- |
-| `persistence.enabled`       | Enable persistence using Persistent Volume Claims  | `true`              |
-| `persistence.storageClass`  | Persistent Volume storage class                    | `""`                |
-| `persistence.annotations`   | Persistent Volume Claim annotations                | `{}`                |
-| `persistence.labels`        | Labels for persistent volume claims                | `{}`                |
-| `persistence.size`          | Persistent Volume size                             | `8Gi`               |
-| `persistence.accessModes`   | Persistent Volume access modes                     | `["ReadWriteOnce"]` |
-| `persistence.existingClaim` | The name of an existing PVC to use for persistence | `""`                |
-| `persistence.subPath`       | The subdirectory of the volume to mount to         | `""`                |
-
-### Persistent Volume Claim Retention Policy
-
-| Parameter                                          | Description                                                                    | Default    |
-| -------------------------------------------------- | ------------------------------------------------------------------------------ | ---------- |
-| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for the Statefulset                  | `false`    |
-| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `"Retain"` |
-| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `"Retain"` |
-
-### Liveness and readiness probes
-
-| Parameter                            | Description                                    | Default |
-| ------------------------------------ | ---------------------------------------------- | ------- |
-| `livenessProbe.enabled`              | Enable livenessProbe on PostgreSQL containers  | `true`  |
-| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe        | `30`    |
-| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe               | `10`    |
-| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe              | `5`     |
-| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe            | `3`     |
-| `livenessProbe.successThreshold`     | Success threshold for livenessProbe            | `1`     |
-| `readinessProbe.enabled`             | Enable readinessProbe on PostgreSQL containers | `true`  |
-| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe       | `5`     |
-| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe              | `5`     |
-| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe             | `5`     |
-| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe           | `3`     |
-| `readinessProbe.successThreshold`    | Success threshold for readinessProbe           | `1`     |
-| `startupProbe.enabled`               | Enable startupProbe on PostgreSQL containers   | `true`  |
-| `startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe         | `30`    |
-| `startupProbe.periodSeconds`         | Period seconds for startupProbe                | `10`    |
-| `startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe               | `5`     |
-| `startupProbe.failureThreshold`      | Failure threshold for startupProbe             | `30`    |
-| `startupProbe.successThreshold`      | Success threshold for startupProbe             | `1`     |
-
-### Node Selection
-
-| Parameter      | Description                          | Default |
-| -------------- | ------------------------------------ | ------- |
-| `nodeSelector` | Node labels for pod assignment       | `{}`    |
-| `tolerations`  | Toleration labels for pod assignment | `[]`    |
-| `affinity`     | Affinity settings for pod assignment | `{}`    |
-
-### Service Account
-
-| Parameter                                     | Description                                                                                                               | Default |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `serviceAccount.create`                       | Specifies whether a service account should be created                                                                     | `false` |
-| `serviceAccount.annotations`                  | Annotations to add to the service account                                                                                 | `{}`    |
-| `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template. | `""`    |
-| `serviceAccount.automountServiceAccountToken` | Whether to automount the SA token inside the pod                                                                          | `false` |
-
-### Extra Configuration Parameters
-
-| Parameter            | Description                                                            | Default |
-| -------------------- | ---------------------------------------------------------------------- | ------- |
-| `extraEnvVars`       | Additional environment variables to set                                | `[]`    |
-| `extraVolumes`       | Additional volumes to add to the pod                                   | `[]`    |
-| `extraVolumeMounts`  | Additional volume mounts to add to the MongoDB container               | `[]`    |
-| `extraObjects`       | Array of extra objects to deploy with the release                      | `[]`    |
-| `extraEnvVarsSecret` | Name of an existing Secret containing additional environment variables | ``      |
-
-#### Extra Objects
+### Extra Objects
 
 You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
 
-**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ .Release.Namespace }}"`.
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{  .Release.Namespace }}"`.
 
 **Example: Deploy a NetworkPolicy with templating**
 
@@ -287,7 +234,7 @@ extraObjects:
     kind: NetworkPolicy
     metadata:
       name: allow-dns
-      namespace: "{{ .Release.Namespace }}"
+      namespace: "{{  .Release.Namespace }}"
     spec:
       podSelector: {}
       policyTypes:
@@ -308,32 +255,6 @@ extraObjects:
 ```
 
 All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
-
-### Metrics Configuration
-
-| Parameter                                  | Description                                                                     | Default                                 |
-| ------------------------------------------ | ------------------------------------------------------------------------------- | --------------------------------------- |
-| `metrics.enabled`                          | Start a sidecar prometheus exporter to expose PostgreSQL metrics                | `false`                                 |
-| `metrics.image.registry`                   | PostgreSQL exporter image registry                                              | `quay.io`                               |
-| `metrics.image.repository`                 | PostgreSQL exporter image repository                                            | `prometheuscommunity/postgres-exporter` |
-| `metrics.image.tag`                        | PostgreSQL exporter image tag                                                   | `v0.18.1`                               |
-| `metrics.image.pullPolicy`                 | PostgreSQL exporter image pull policy                                           | `Always`                                |
-| `metrics.resources`                        | Resource limits and requests for metrics container                              | `{}`                                    |
-| `metrics.service.annotations`              | Additional custom annotations for Metrics service                               | `{}`                                    |
-| `metrics.service.labels`                   | Additional custom labels for Metrics service                                    | `{}`                                    |
-| `metrics.service.port`                     | Metrics service port                                                            | `9187`                                  |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator | `false`                                 |
-| `metrics.serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created                       | `""`                                    |
-| `metrics.serviceMonitor.interval`          | The interval at which metrics should be scraped                                 | `30s`                                   |
-| `metrics.serviceMonitor.scrapeTimeout`     | The timeout after which the scrape is ended                                     | `10s`                                   |
-| `metrics.serviceMonitor.selector`          | Additional labels for ServiceMonitor resource                                   | `{}`                                    |
-| `metrics.serviceMonitor.annotations`       | ServiceMonitor annotations                                                      | `{}`                                    |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels        | `false`                                 |
-| `metrics.serviceMonitor.relabelings`       | ServiceMonitor relabel configs to apply to samples before scraping              | `[]`                                    |
-| `metrics.serviceMonitor.metricRelabelings` | ServiceMonitor metricRelabelings configs to apply to samples before ingestion   | `[]`                                    |
-| `metrics.serviceMonitor.namespaceSelector` | ServiceMonitor namespace selector                                               | `{}`                                    |
-
-## Examples
 
 ### Basic Deployment
 

--- a/charts/postgres/README.tmpl.md
+++ b/charts/postgres/README.tmpl.md
@@ -1,0 +1,530 @@
+{{ template "chart.badgesSection" . }}
+<a href="https://artifacthub.io/packages/helm/cloudpirates-postgres/postgres"><img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudpirates-postgres" /></a>
+
+# PostgreSQL
+
+{{ template "chart.description" . }}
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure (if persistence is enabled)
+
+{{ template "chart.requirementsSection" . }}
+
+## Installing the Chart
+
+To install the chart with the release name `my-postgres`:
+
+```bash
+helm install my-postgres oci://registry-1.docker.io/cloudpirates/postgres
+```
+
+To install with custom values:
+
+```bash
+helm install my-postgres oci://registry-1.docker.io/cloudpirates/postgres -f my-values.yaml
+```
+
+Or install directly from the local chart:
+
+```bash
+helm install my-postgres ./charts/postgres
+```
+
+The command deploys PostgreSQL on the Kubernetes cluster in the default configuration. The [Configuration](#configuration) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-postgres` deployment:
+
+```bash
+helm uninstall my-postgres
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Security & Signature Verification
+
+This Helm chart is cryptographically signed with Cosign to ensure authenticity and prevent tampering.
+
+**Public Key:**
+
+```
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7BgqFgKdPtHdXz6OfYBklYwJgGWQ
+mZzYz8qJ9r6QhF3NxK8rD2oG7Bk6nHJz7qWXhQoU2JvJdI3Zx9HGpLfKvw==
+-----END PUBLIC KEY-----
+```
+
+To verify the helm chart before installation, copy the public key to the file `cosign.pub` and run cosign:
+
+```bash
+cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/postgres:<version>
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the PostgreSQL chart and their default values.
+
+{{ template "chart.valuesTable" . }}
+
+## Examples
+
+### Extra Objects
+
+You can use the `extraObjects` array to deploy additional Kubernetes resources (such as NetworkPolicies, ConfigMaps, etc.) alongside the release. This is useful for customizing your deployment with extra manifests that are not covered by the default chart options.
+
+**Helm templating is supported in any field, but all template expressions must be quoted.** For example, to use the release namespace, write `namespace: "{{ "{{" }}  .Release.Namespace {{ "}}" }}"`.
+
+**Example: Deploy a NetworkPolicy with templating**
+
+```yaml
+extraObjects:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-dns
+      namespace: "{{ "{{" }}  .Release.Namespace {{ "}}" }}"
+    spec:
+      podSelector: {}
+      policyTypes:
+        - Egress
+      egress:
+        - to:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: kube-system
+              podSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+        - ports:
+            - port: 53
+              protocol: UDP
+            - port: 53
+              protocol: TCP
+```
+
+All objects in `extraObjects` will be rendered and deployed with the release. You can use any valid Kubernetes manifest, and reference Helm values or built-in objects as needed (just remember to quote template expressions).
+
+### Basic Deployment
+
+Deploy PostgreSQL with default configuration:
+
+```bash
+helm install my-postgres ./charts/postgres
+```
+
+### Production Setup with Persistence and custom user
+
+```yaml
+# values-production.yaml
+persistence:
+  enabled: true
+  storageClass: "fast-ssd"
+  size: 100Gi
+
+resources:
+  requests:
+    memory: "1Gi"
+    cpu: "500m"
+  limits:
+    memory: "2Gi"
+    cpu: "1000m"
+
+auth:
+  username: "myapp"
+  password: "your-secure-app-password"
+
+config:
+  postgresqlMaxConnections: 200
+  postgresqlSharedBuffers: "256MB"
+  postgresqlEffectiveCacheSize: "1GB"
+  postgresqlWorkMem: "8MB"
+  postgresqlMaintenanceWorkMem: "128MB"
+
+customUser:
+  existingSecret: "postgres-custom-user"
+  secretKeys:
+    name: "username"
+    password: "password"
+    database: "mydatabase"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: postgres.yourdomain.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: postgres-tls
+      hosts:
+        - postgres.yourdomain.com
+```
+
+Deploy with production values:
+
+```bash
+helm install my-postgres ./charts/postgres -f values-production.yaml
+```
+
+### High Performance Configuration
+
+```yaml
+# values-performance.yaml
+resources:
+  requests:
+    memory: "4Gi"
+    cpu: "2000m"
+  limits:
+    memory: "8Gi"
+    cpu: "4000m"
+
+config:
+  postgresqlMaxConnections: 500
+  postgresqlSharedBuffers: "2GB"
+  postgresqlEffectiveCacheSize: "6GB"
+  postgresqlWorkMem: "16MB"
+  postgresqlMaintenanceWorkMem: "512MB"
+  postgresqlWalBuffers: "32MB"
+  postgresqlCheckpointCompletionTarget: "0.9"
+  postgresqlRandomPageCost: "1.0"
+  extraConfig:
+    - "wal_level = replica"
+    - "max_wal_senders = 3"
+    - "archive_mode = on"
+    - "archive_command = 'test ! -f /backup/%f && cp %p /backup/%f'"
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - postgres
+          topologyKey: kubernetes.io/hostname
+```
+
+### Using Existing Secret for Authentication
+
+```yaml
+# values-external-secret.yaml
+auth:
+  existingSecret: "postgres-credentials"
+  secretKeys:
+    adminPasswordKey: "postgres-password"
+
+# For custom users, use the customUser section
+customUser:
+  existingSecret: "postgres-custom-user"
+  secretKeys:
+    name: "username"  # Set empty for fallback to customUser.name
+    database: "database"  # Set empty for fallback to customUser.database
+    password: "password"
+```
+
+Create the secrets first:
+
+```bash
+# Admin/superuser credentials
+kubectl create secret generic postgres-credentials \
+  --from-literal=postgres-password=your-admin-password
+
+# Custom user credentials (optional)
+kubectl create secret generic postgres-custom-user \
+  --from-literal=username=myuser \
+  --from-literal=password=myuserpassword \
+  --from-literal=database=mydb
+```
+
+### Custom Configuration with ConfigMap
+
+```yaml
+# values-custom-config.yaml
+config:
+  existingConfigmap: "postgres-custom-config"
+```
+
+### Monitoring with Prometheus
+
+Enable metrics collection with Prometheus:
+
+```yaml
+# values-monitoring.yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+```
+
+The PostgreSQL exporter will expose metrics on port 9187, and if you have Prometheus Operator installed, the ServiceMonitor will automatically configure Prometheus to scrape the metrics.
+
+You can access metrics directly via port-forward:
+
+```bash
+kubectl port-forward service/my-postgres-metrics 9187:9187
+curl http://localhost:9187/metrics
+```
+
+### Replication setup
+
+Replication setup only works for instances without an initialized database and `$PGDATA` directory.
+
+#### Primary setup
+
+This will create a replication user as init script. If you want to set up replication for an already initialized database, you need to create this user afterwards on your own.
+
+```yaml
+replication:
+  enabled: true
+  auth:
+    password: "secret"
+```
+
+#### Standby setup
+
+As soon as a primary host is configured, this instance is considered to be a standby server.
+
+This will also create an `initContainer` name `replication-standby-init`, which:
+- Creates/updates the `replication.pgpass` credentials file in the transient run directory
+- Initializes the database using `pg_basebackup` if not already done using the credentials file above
+
+```yaml
+replication:
+  enabled: true
+  auth:
+    password: "secret"  # Password must match primary
+  primary:
+    host: "your-database.namespace.svc.cluster.local"
+```
+
+### Using Hardened Images
+
+When using hardened PostgreSQL images (such as from DHI or other security-focused registries), you need to configure several settings:
+
+```yaml
+# values-hardened-image.yaml
+image:
+  registry: dhi.io
+  repository: postgres
+  tag: "18.1"
+  imagePullPolicy: IfNotPresent
+  # Enable hardened image mode for correct PGDATA paths (required for Postgres <18)
+  useHardenedImage: true
+
+# Disable default args for hardened images
+args: []
+
+# Adjust security context to match hardened image requirements
+podSecurityContext:
+  fsGroup: 70
+
+containerSecurityContext:
+  runAsUser: 70
+  runAsGroup: 70
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+```
+
+**Important Notes:**
+
+1. **PGDATA Paths:** The `image.useHardenedImage` parameter is particularly important for PostgreSQL versions below 18, as hardened images use different PGDATA paths (`/var/lib/postgresql/<version>/data`) compared to standard images (`/var/lib/postgresql/data/pgdata`). For PostgreSQL 18+, both image types use the same path structure.
+
+2. **Persistent Storage:** When using hardened images with persistent storage, you **must** add an initContainer to fix directory permissions. Hardened images enforce strict permission checks (0700 or 0750) and will fail to start if the Kubernetes-managed volumes have incorrect permissions (typically 2770 with setgid bit).
+
+```yaml
+# values-hardened-image-with-persistence.yaml
+image:
+  registry: dhi.io
+  repository: postgres
+  tag: "17.7"
+  imagePullPolicy: IfNotPresent
+  useHardenedImage: true
+
+args: []
+
+podSecurityContext:
+  fsGroup: 70
+
+containerSecurityContext:
+  runAsUser: 70
+  runAsGroup: 70
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop:
+      - ALL
+
+# Enable persistence
+persistence:
+  enabled: true
+  size: 10Gi
+
+# REQUIRED: Init container to fix permissions for hardened images with persistence
+initContainers:
+  - name: fix-permissions
+    image: busybox:1.36
+    command:
+      - sh
+      - -c
+      - |
+        chown -R 70:70 /var/lib/postgresql
+        find /var/lib/postgresql -type d -exec chmod 750 {} \;
+    securityContext:
+      runAsUser: 0
+      runAsNonRoot: false
+    volumeMounts:
+      - name: data
+        mountPath: /var/lib/postgresql
+```
+
+**Why is the initContainer needed?**
+
+Hardened PostgreSQL images have strict security requirements and will not automatically fix directory permissions. When Kubernetes creates persistent volumes with `fsGroup`, it sets permissions to 2770 (including the setgid bit), which PostgreSQL's hardened images reject. The initContainer runs once before PostgreSQL starts to correct these permissions.
+
+## Access PostgreSQL
+
+### Via kubectl port-forward
+
+```bash
+kubectl port-forward service/my-postgres 5432:5432
+```
+
+### Connect using psql
+
+```bash
+# Connect as postgres user
+PGPASSWORD=your-password psql -h localhost -U postgres -d postgres
+
+# Connect as custom user
+PGPASSWORD=your-password psql -h localhost -U myapp -d myappdb
+```
+
+### Default Credentials
+
+- **Admin User**: `postgres` (if enabled)
+- **Admin Password**: Auto-generated (check secret) or configured value
+- **Custom User**: Configured username
+- **Custom Password**: Auto-generated or configured value
+
+Get the auto-generated passwords:
+
+```bash
+# Admin password
+kubectl get secret my-postgres -o jsonpath="{.data.postgres-password}" | base64 --decode
+
+# Custom user password
+kubectl get secret my-postgres -o jsonpath="{.data.password}" | base64 --decode
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Pod fails to start with permission errors**
+
+   - Ensure your storage class supports the required access modes
+   - Check if security contexts are compatible with your cluster policies
+   - Verify the PostgreSQL data directory permissions
+
+2. **Cannot connect to PostgreSQL**
+
+   - Verify the service is running: `kubectl get svc`
+   - Check if authentication is properly configured
+   - Ensure firewall rules allow access to port 5432
+   - Check PostgreSQL logs: `kubectl logs <pod-name>`
+
+3. **Database initialization fails**
+
+   - Check if persistent volume has enough space
+   - Verify environment variables are set correctly
+   - Review pod events: `kubectl describe pod <pod-name>`
+
+4. **Hardened image fails with "invalid argument: postgres"**
+
+   - This occurs when using hardened images with different entrypoint behavior
+   - Solution: Set `args: []` in your values file to disable default args
+   - See [Using Hardened Images](#using-hardened-images) example
+
+5. **Permission denied errors with hardened images**
+
+   - Occurs when switching from standard postgres image (UID 999) to hardened image (e.g., UID 70)
+   - Existing data directory has wrong ownership
+   - Solution: Add init container to fix permissions
+   - After successful startup, remove the init container
+
+6. **Performance issues**
+   - Check configured memory settings
+   - Monitor resource usage with `kubectl top pod`
+   - Adjust PostgreSQL configuration parameters
+   - Consider increasing resources
+
+### Performance Tuning
+
+1. **Memory Configuration**
+
+   ```yaml
+   config:
+     postgresqlSharedBuffers: "256MB" # 25% of RAM
+     postgresqlEffectiveCacheSize: "1GB" # 75% of RAM
+     postgresqlWorkMem: "8MB" # RAM / max_connections
+     postgresqlMaintenanceWorkMem: "128MB"
+   ```
+
+2. **Connection Settings**
+
+   ```yaml
+   config:
+     postgresqlMaxConnections: 200
+   ```
+
+3. **WAL and Checkpoints**
+
+   ```yaml
+   config:
+     postgresqlWalBuffers: "16MB"
+     postgresqlCheckpointCompletionTarget: "0.7"
+     extraConfig:
+       - "wal_level = replica"
+       - "max_wal_size = 2GB"
+       - "min_wal_size = 1GB"
+   ```
+
+4. **Resource Limits**
+   ```yaml
+   resources:
+     requests:
+       memory: "2Gi"
+       cpu: "1000m"
+     limits:
+       memory: "4Gi"
+       cpu: "2000m"
+   ```
+
+### Backup and Recovery
+
+**Manual Backup**
+
+```bash
+kubectl exec -it <pod-name> -- pg_dump -U postgres -d mydb > backup.sql
+```
+
+### Getting Support
+
+For issues related to this Helm chart, please check:
+
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+- [Kubernetes Documentation](https://kubernetes.io/docs/)
+- [Create an issue](https://github.com/CloudPirates-io/helm-charts/issues)

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -68,23 +68,6 @@
                         },
                         "timezone": {
                             "type": "string"
-                        },
-                        "wal": {
-                            "type": "object",
-                            "properties": {
-                                "buffers": {
-                                    "type": "string"
-                                },
-                                "keepSize": {
-                                    "type": "integer"
-                                },
-                                "level": {
-                                    "type": "string"
-                                },
-                                "maxSenders": {
-                                    "type": "integer"
-                                }
-                            }
                         }
                     }
                 },

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -1,194 +1,184 @@
 ## @section Global parameters
 global:
-  ## @param global.imageRegistry Global Docker Image registry
+  # -- Global Docker Image registry
   imageRegistry: ""
-  ## @param global.imagePullSecrets Global Docker registry secret names as an array
+  # -- Global Docker registry secret names as an array
   imagePullSecrets: []
+  # -- Whether to add service links env variables to pods
   enableServiceLinks: true
 
 ## @section Common parameters
-## @param nameOverride String to partially override postgres.fullname
+# -- String to partially override postgres.fullname
 nameOverride: ""
-## @param fullnameOverride String to fully override postgres.fullname
+# -- String to fully override postgres.fullname
 fullnameOverride: ""
-## @param commonLabels Labels to add to all deployed objects
+# -- Labels to add to all deployed objects
 commonLabels: {}
-## @param commonAnnotations Annotations to add to all deployed objects
+# -- Annotations to add to all deployed objects
 commonAnnotations: {}
-## @param priorityClassName Priority class name to be used for the pods
+# -- Priority class name to be used for the pods
 priorityClassName: ""
 
-## @param terminationGracePeriodSeconds Time for Kubernetes to wait for the pod to gracefully terminate
+# -- Time for Kubernetes to wait for the pod to gracefully terminate
 terminationGracePeriodSeconds: 30
 
 ## @section PostgreSQL image configuration
 image:
-  ## @param image.registry PostgreSQL image registry
+  # -- PostgreSQL image registry
   registry: docker.io
-  ## @param image.repository PostgreSQL image repository
+  # -- PostgreSQL image repository
   repository: postgres
-  ## @param image.tag PostgreSQL image tag (immutable tags are recommended)
+  # -- PostgreSQL image tag (immutable tags are recommended)
   tag: "18.1@sha256:5773fe724c49c42a7a9ca70202e11e1dff21fb7235b335a73f39297d200b73a2"
-  ## @param image.imagePullPolicy PostgreSQL image pull policy
+  # -- PostgreSQL image pull policy
   imagePullPolicy: Always
-  ## @param image.useHardenedImage Set to true when using hardened images (e.g., DHI) that have different PGDATA paths for Postgres <18
+  # -- Set to true when using hardened images (e.g., DHI) that have different PGDATA paths for Postgres <18
   useHardenedImage: false
 
 ## @section Deployment configuration
-## @param replicaCount Number of PostgreSQL replicas to deploy (Note: PostgreSQL doesn't support multi-master replication by default)
+# -- Number of PostgreSQL replicas to deploy (Note: PostgreSQL doesn't support multi-master replication by default)
 replicaCount: 1
 
 ## @section Pod annotations and labels
-## @param podAnnotations Map of annotations to add to the pods
+# -- Map of annotations to add to the pods
 podAnnotations: {}
-## @param podLabels Map of labels to add to the pods
+# -- Map of labels to add to the pods
 podLabels: {}
 
 ## @section Security Context
 podSecurityContext:
-  ## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
+  # -- Group ID for the volumes of the pod
   fsGroup: 999
 
 containerSecurityContext:
-  ## @param containerSecurityContext.allowPrivilegeEscalation Enable container privilege escalation
+  # -- Enable container privilege escalation
   allowPrivilegeEscalation: false
-  ## @param containerSecurityContext.runAsNonRoot Configure the container to run as a non-root user
+  # -- Configure the container to run as a non-root user
   runAsNonRoot: true
-  ## @param containerSecurityContext.runAsUser User ID for the PostgreSQL container
+  # -- User ID for the PostgreSQL container
   runAsUser: 999
-  ## @param containerSecurityContext.runAsGroup Group ID for the PostgreSQL container
+  # -- Group ID for the PostgreSQL container
   runAsGroup: 999
-  ## @param containerSecurityContext.readOnlyRootFilesystem Mount container root filesystem as read-only
+  # -- Mount container root filesystem as read-only
   readOnlyRootFilesystem: false
-  ## @param containerSecurityContext.capabilities.drop Linux capabilities to be dropped
+  # -- Linux capabilities to be dropped
   capabilities:
     drop:
       - ALL
 
 ## @section PostgreSQL Authentication
 auth:
-  ## @param auth.username Name for a custom superuser to create at initialisation. (This will also create a database with the same name)
+  # -- Name for a custom superuser to create at initialisation. (This will also create a database with the same name)
   username: ""
-  ## @param auth.password Password for the custom user to create
+  # -- Password for the custom user to create
   password: ""
-  ## @param auth.database Alternative name for the default database to be created at initialisation
+  # -- Alternative name for the default database to be created at initialisation
   database: ""
-  ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+  # -- Name of existing secret to use for PostgreSQL credentials
   existingSecret: ""
   secretKeys:
-    ## @param auth.secretKeys.adminPasswordKey Name of key in existing secret to use for PostgreSQL admin credentials
+    # -- Name of key in existing secret to use for PostgreSQL admin credentials
     adminPasswordKey: "postgres-password"
 
 ## @section PostgreSQL Configuration
 config:
-  ## @param config.mountConfigMap Enable mounting of ConfigMap with PostgreSQL configuration
+  # -- Enable mounting of ConfigMap with PostgreSQL configuration
   mountConfigMap: true
-  ## @param config.postgresqlSharedPreloadLibraries Shared preload libraries (comma-separated list)
+  # -- Shared preload libraries (comma-separated list)
   postgresqlSharedPreloadLibraries: ""
-  ## @param config.postgresqlMaxConnections Maximum number of connections
+  # -- Maximum number of connections
   postgresqlMaxConnections: 100
-  ## @param config.postgresqlSharedBuffers Amount of memory the database server uses for shared memory buffers
+  # -- Amount of memory the database server uses for shared memory buffers
   postgresqlSharedBuffers: ""
-  ## @param config.postgresqlEffectiveCacheSize Effective cache size
+  # -- Effective cache size
   postgresqlEffectiveCacheSize: ""
-  ## @param config.postgresqlWorkMem Amount of memory to be used by internal sort operations and hash tables
+  # -- Amount of memory to be used by internal sort operations and hash tables
   postgresqlWorkMem: ""
-  ## @param config.postgresqlMaintenanceWorkMem Maximum amount of memory to be used by maintenance operations
+  # -- Maximum amount of memory to be used by maintenance operations
   postgresqlMaintenanceWorkMem: ""
-  ## @param config.postgresqlWalBuffers Amount of memory used in shared memory for WAL data (deprecated, see postgresql.wal.buffers)
+  # -- Amount of memory used in shared memory for WAL data (deprecated, see postgresql.wal.buffers)
   postgresqlWalBuffers: ""
-  ## @param config.postgresqlCheckpointCompletionTarget Time spent flushing dirty buffers during checkpoint, as fraction of checkpoint interval
+  # -- Time spent flushing dirty buffers during checkpoint, as fraction of checkpoint interval
   postgresqlCheckpointCompletionTarget: ""
-  ## @param config.postgresqlRandomPageCost Sets the planner's estimate of the cost of a non-sequentially-fetched disk page
+  # -- Sets the planner's estimate of the cost of a non-sequentially-fetched disk page
   postgresqlRandomPageCost: ""
-  ## @param config.postgresqlLogStatement Sets the type of statements logged
+  # -- Sets the type of statements logged
   postgresqlLogStatement: ""
-  ## @param config.postgresqlLogMinDurationStatement Sets the minimum execution time above which statements will be logged
+  # -- Sets the minimum execution time above which statements will be logged
   postgresqlLogMinDurationStatement: ""
-  ## @param config.extraConfig Additional PostgreSQL configuration parameters
+  # -- Additional PostgreSQL configuration parameters
   extraConfig: []
-  ## @param config.existingConfigmap Name of existing ConfigMap with PostgreSQL configuration
+  # -- Name of existing ConfigMap with PostgreSQL configuration
   existingConfigmap: ""
-  ## @param config.pgHbaConfig Content of a custom pg_hba.conf file to be used instead of the default config
+  # -- Content of a custom pg_hba.conf file to be used instead of the default config
   pgHbaConfig: ""
-  # -- New postgresql configuration block
   postgresql:
     # -- Default timezone setting
     timezone: "UTC"
     # -- Default locale setting
     locale: "en_US.utf8"
     # -- WAL settings
-    wal:
-      # -- Amount of memory used in shared memory for WAL data - https://postgresqlco.nf/doc/en/param/wal_buffers/
-      buffers: "16MB"
-      # -- Determines how much information is written to the WAL - https://postgresqlco.nf/doc/en/param/wal_level/
-      level: replica
-      # -- Specifies the maximum number of concurrent connections from standby servers or streaming base backup clients - https://postgresqlco.nf/doc/en/param/max_wal_senders/
-      maxSenders: 5
-      # -- Specifies the minimum size of past WAL files kept in the pg_wal directory (in MB) - https://postgresqlco.nf/doc/en/param/wal_keep_size/
-      keepSize: 1024
 
 ## @section customUser Optional user to be created at initialisation with a custom password and database
 customUser:
-  ## @param customUser.name Name of the custom user to be created
+  # -- Name of the custom user to be created
   name: ""
-  ## @param customUser.database Name of the database to be created
+  # -- Name of the database to be created
   database: ""
-  ## @param customUser.password Password to be used for the custom user
+  # -- Password to be used for the custom user
   password: ""
-  ## @param customUser.existingSecret Existing secret, in which username, password and database name are saved
+  # -- Existing secret, in which username, password and database name are saved
   existingSecret: ""
-  ## @param customUser.secretKeys Name of keys in existing secret to use the custom user name, password and database
   secretKeys:
-    ## @param customUser.secretKeys.name Custom user name secret reference (set empty to fallback to customUser.name)
+    # -- Custom user name secret reference (set empty to fallback to customUser.name)
     name: "CUSTOM_USER"
-    ## @param customUser.secretKeys.database Custom user database secret reference (set empty to fallback to customUser.database)
+    # -- Custom user database secret reference (set empty to fallback to customUser.database)
     database: "CUSTOM_DB"
     password: "CUSTOM_PASSWORD"
 
 ## @section PostgreSQL Initdb configuration
 initdb:
-  ## @param initdb.args Send arguments to postgres initdb. This is a space separated string of arguments
+  # -- Send arguments to postgres initdb. This is a space separated string of arguments
   args: ""
-  ## @param initdb.scripts Dictionary of initdb scripts
+  # -- Dictionary of initdb scripts
   scripts: {}
-  ## @param initdb.scriptsConfigMap ConfigMap with scripts to be run at first boot
+  # -- ConfigMap with scripts to be run at first boot
   scriptsConfigMap: ""
-  ## @param initdb.directory Directory where to load initScripts
+  # -- Directory where to load initScripts
   directory: "/docker-entrypoint-initdb.d/"
 
 ## @section Service configuration
 service:
-  ## @param service.type PostgreSQL service type
+  # -- PostgreSQL service type
   type: ClusterIP
-  ## @param service.port PostgreSQL service port
+  # -- PostgreSQL service port
   port: 5432
-  ## @param service.targetPort PostgreSQL container port
+  # -- PostgreSQL container port
   targetPort: 5432
-  ## @param service.nodePort PostgreSQL NodePort port
+  # -- PostgreSQL NodePort port
   nodePort: 30432
-  ## @param service.annotations Service annotations
+  # -- Service annotations
   annotations: {}
 
 ## @section Ingress configuration
 ingress:
-  ## @param ingress.enabled Enable ingress record generation for PostgreSQL
+  # -- Enable ingress record generation for PostgreSQL
   enabled: false
-  ## @param ingress.className IngressClass that will be used to implement the Ingress
+  # -- IngressClass that will be used to implement the Ingress
   className: ""
-  ## @param ingress.annotations Additional annotations for the Ingress resource
+  # -- Additional annotations for the Ingress resource
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  ## @param ingress.hosts[0].host Hostname for PostgreSQL ingress
-  ## @param ingress.hosts[0].paths[0].path Path for PostgreSQL ingress
-  ## @param ingress.hosts[0].paths[0].pathType Path type for PostgreSQL ingress
   hosts:
-    - host: postgres.local
+    -
+      # -- Hostname
+      host: postgres.local
       paths:
-        - path: /
+        -
+          # -- Base path
+          path: /
+          # -- Path type
           pathType: Prefix
-  ## @param ingress.tls TLS configuration for PostgreSQL ingress
+  # -- TLS configuration for PostgreSQL ingress
   tls: []
   #  - secretName: postgres-tls
   #    hosts:
@@ -209,101 +199,100 @@ resources: {}
 
 ## @section Persistence
 persistence:
-  ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+  # -- Enable persistence using Persistent Volume Claims
   enabled: true
-  ## @param persistence.storageClass Persistent Volume storage class
+  # -- Persistent Volume storage class
   storageClass: ""
-  ## @param persistence.annotations Persistent Volume Claim annotations
+  # -- Persistent Volume Claim annotations
   annotations: {}
-  ## @param persistence.size Persistent Volume size
+  # -- Persistent Volume size
   size: 8Gi
-  ## @param persistence.accessModes Persistent Volume access modes
+  # -- Persistent Volume access modes
   accessModes:
     - ReadWriteOnce
-  ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+  # -- The name of an existing PVC to use for persistence
   existingClaim: ""
-  ## @param persistence.subPath The subdirectory of the volume to mount to
+  # -- The subdirectory of the volume to mount to
   ## Useful in dev environments and one PV for multiple services
   subPath: ""
-  ## @param persistence.labels Labels for persistent volume claims
+  # -- Labels for persistent volume claims
   labels: {}
-  ## @param persistence.volumeName Container volume name and volume claim prefix
+  # -- Container volume name and volume claim prefix
   volumeName: "data"
 
 ## @section Persistent Volume Claim Retention Policy
 persistentVolumeClaimRetentionPolicy:
-  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for the Statefulset
+  # -- Enable Persistent volume retention policy for the Statefulset
   enabled: false
-  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  # -- Volume retention behavior when the replica count of the StatefulSet is reduced
   whenScaled: Retain
-  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  # -- Volume retention behavior that applies when the StatefulSet is deleted
   whenDeleted: Retain
 
 ## @section Liveness and readiness probes
 livenessProbe:
-  ## @param livenessProbe.enabled Enable livenessProbe on PostgreSQL containers
+  # -- Enable livenessProbe on PostgreSQL containers
   enabled: true
-  ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  # -- Initial delay seconds for livenessProbe
   initialDelaySeconds: 30
-  ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+  # -- Period seconds for livenessProbe
   periodSeconds: 10
-  ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  # -- Timeout seconds for livenessProbe
   timeoutSeconds: 5
-  ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+  # -- Failure threshold for livenessProbe
   failureThreshold: 3
-  ## @param livenessProbe.successThreshold Success threshold for livenessProbe
+  # -- Success threshold for livenessProbe
   successThreshold: 1
 
 readinessProbe:
-  ## @param readinessProbe.enabled Enable readinessProbe on PostgreSQL containers
+  # -- Enable readinessProbe on PostgreSQL containers
   enabled: true
-  ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  # -- Initial delay seconds for readinessProbe
   initialDelaySeconds: 5
-  ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+  # -- Period seconds for readinessProbe
   periodSeconds: 5
-  ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  # -- Timeout seconds for readinessProbe
   timeoutSeconds: 5
-  ## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+  # -- Failure threshold for readinessProbe
   failureThreshold: 3
-  ## @param readinessProbe.successThreshold Success threshold for readinessProbe
+  # -- Success threshold for readinessProbe
   successThreshold: 1
 
 startupProbe:
-  ## @param startupProbe.enabled Enable startupProbe on PostgreSQL containers
+  # -- Enable startupProbe on PostgreSQL containers
   enabled: true
-  ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  # -- Initial delay seconds for startupProbe
   initialDelaySeconds: 30
-  ## @param startupProbe.periodSeconds Period seconds for startupProbe
+  # -- Period seconds for startupProbe
   periodSeconds: 10
-  ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  # -- Timeout seconds for startupProbe
   timeoutSeconds: 5
-  ## @param startupProbe.failureThreshold Failure threshold for startupProbe
+  # -- Failure threshold for startupProbe
   failureThreshold: 30
-  ## @param startupProbe.successThreshold Success threshold for startupProbe
+  # -- Success threshold for startupProbe
   successThreshold: 1
 
 ## @section Node Selection
-## @param nodeSelector Node labels for pod assignment
+# -- Node labels for pod assignment
 nodeSelector: {}
 
-## @param tolerations Toleration labels for pod assignment
+# -- Toleration labels for pod assignment
 tolerations: []
 
-## @param affinity Affinity settings for pod assignment
+# -- Affinity settings for pod assignment
 affinity: {}
 
-## @section Service Account
 serviceAccount:
-  ## @param serviceAccount.create Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: false
-  ## @param serviceAccount.annotations Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  ## @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template.
+  # -- The name of the service account to use. If not set and create is true, a name is generated using the `fullname` template.
   name: ""
-  ## @param serviceAccount.automountServiceAccountToken whether to automount the SA token inside the pod
+  # -- Whether to automount the SA token inside the pod
   automountServiceAccountToken: false
 
-## @param extraEnvVars Additional environment variables to set
+# -- Additional environment variables to set
 extraEnvVars: []
   # - name: CUSTOM_VAR
   #   value: "custom-value"
@@ -313,16 +302,16 @@ extraEnvVars: []
   #       name: my-secret
   #       key: secret-key
 
-## @param extraEnvVarsSecret Name of a secret containing additional environment variables
+# -- Name of a secret containing additional environment variables
 extraEnvVarsSecret: ""
 
-## @param extraVolumes Additional volumes to add to the pod
+# -- Additional volumes to add to the pod
 extraVolumes: []
 
-## @param extraVolumeMounts Additional volume mounts to add to the MongoDB container
+# -- Additional volume mounts to add to the MongoDB container
 extraVolumeMounts: []
 
-## @param initContainers Init containers to add to the PostgreSQL pods. Useful for tasks like pgautoupgrade for major version upgrades
+# -- Init containers to add to the PostgreSQL pods. Useful for tasks like pgautoupgrade for major version upgrades
 initContainers: []
 # Example with pgautoupgrade for major version upgrades:
 # - name: pgautoupgrade
@@ -332,72 +321,69 @@ initContainers: []
 #       mountPath: /var/lib/postgresql/data
 
 ## @section Container command/args override
-## @param command Override default container command (useful for hardened images)
+# -- Override default container command (useful for hardened images)
 command: []
-## @param args Override default container args (useful for hardened images that handle startup differently)
+# -- Override default container args (useful for hardened images that handle startup differently)
 ## Leave unset or null to use default args, set to empty array [] to disable default args for hardened images like DHI
 args: null  # @schema type:[array, null]
 
-## @param extraObjects Array of extra objects to deploy with the release
+# -- Array of extra objects to deploy with the release
 extraObjects: []
 
 ## @section Metrics configuration
 metrics:
-  ## @param metrics.enabled Start a sidecar prometheus exporter to expose PostgreSQL metrics
+  # -- Start a sidecar prometheus exporter to expose PostgreSQL metrics
   enabled: false
   image:
-    ## @param metrics.image.registry PostgreSQL exporter image registry
+    # -- PostgreSQL exporter image registry
     registry: quay.io
-    ## @param metrics.image.repository PostgreSQL exporter image repository
+    # -- PostgreSQL exporter image repository
     repository: prometheuscommunity/postgres-exporter
-    ## @param metrics.image.tag PostgreSQL exporter image tag
+    # -- PostgreSQL exporter image tag
     tag: "v0.18.1@sha256:fb96c4413985d4b23ab02b19022b3d70a86c8e0a62f41ab15ebb6f4673781a5d"
-    ## @param metrics.image.pullPolicy PostgreSQL exporter image pull policy
+    # -- PostgreSQL exporter image pull policy
     pullPolicy: Always
-  ## @param metrics.resources Resource limits and requests for metrics container
+  # -- Resource limits and requests for metrics container
   resources: {}
   ## Metrics service configuration
   service:
-    ## @param metrics.service.annotations Additional custom annotations for Metrics service
+    # -- Additional custom annotations for Metrics service
     annotations: {}
-    ## @param metrics.service.labels Additional custom labels for Metrics service
+    # -- Additional custom labels for Metrics service
     labels: {}
-    ## @param metrics.service.port Metrics service port
+    # -- Metrics service port
     port: 9187
   ## Prometheus Operator ServiceMonitor configuration
   serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    # -- Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
     enabled: false
-    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
+    # -- The namespace in which the ServiceMonitor will be created
     namespace: ""
-    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
+    # -- The interval at which metrics should be scraped
     interval: 30s
-    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
+    # -- The timeout after which the scrape is ended
     scrapeTimeout: 10s
-    ## @param metrics.serviceMonitor.selector Additional labels for ServiceMonitor resource
+    # -- Additional labels for ServiceMonitor resource
     selector: {}
-    ## @param metrics.serviceMonitor.annotations ServiceMonitor annotations
+    # -- ServiceMonitor annotations
     annotations: {}
-    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    # -- honorLabels chooses the metric's labels on collisions with target labels
     honorLabels: false
-    ## @param metrics.serviceMonitor.relabelings ServiceMonitor relabel configs to apply to samples before scraping
+    # -- ServiceMonitor relabel configs to apply to samples before scraping
     relabelings: []
-    ## @param metrics.serviceMonitor.metricRelabelings ServiceMonitor metricRelabelings configs to apply to samples before ingestion
+    # -- ServiceMonitor metricRelabelings configs to apply to samples before ingestion
     metricRelabelings: []
-    ## @param metrics.serviceMonitor.namespaceSelector ServiceMonitor namespace selector
+    # -- ServiceMonitor namespace selector
     namespaceSelector: {}
 
-# -- Physical WAL replication configuration
 replication:
   # -- Enables the WAL replication feature for both sides (primary and standby)
   enabled: false
-  # -- Standby server configuration
   primary:
     # -- Hostname of the primary server
     host: ""
     # -- Port of the primary server
     port: 5432
-  # -- Replication authentication configuration
   auth:
     # -- Username for replication user
     username: "replication"
@@ -405,10 +391,9 @@ replication:
     password: ""
     # -- Use existing secret reference instead of password
     existingSecret: ""
-    # -- Keys configuration for .existingSecret
     secretKeys:
+      # -- Secret key for replication password
       password: "replication-password"
-  # -- Allow from IP ranges configuration for the primary server
   allowFrom:
     # -- Allowed IPv4 network (set empty to disable that feature)
     ipv4: "0.0.0.0/0"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add support for generating the `README.md` based on `values.yaml` by running
```shell
helm-docs -t README.tmpl.md
```

Helm-Docs: https://github.com/norwoodj/helm-docs

### Benefits

- Variables are always up to date
- No manual update necessary
- Less documentation overhead by removing these `@param section.block.value` prefixes

### Possible drawbacks

- Section separation is gone

### Applicable issues

- None

### Additional information

- Should be integrated into pipeline

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [ ] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [ ] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
