### PR TITLE
[minio]: Switch to hardened image

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.15.5
+version: 0.15.4
 appVersion: "18.1.0"
 keywords:
   - postgres

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -28,7 +28,7 @@ image:
   ## @param image.repository PostgreSQL image repository
   repository: postgres
   ## @param image.tag PostgreSQL image tag (immutable tags are recommended)
-  tag: "18.1@sha256:1090bc3a8ccfb0b55f78a494d76f8d603434f7e4553543d6e807bc7bd6bbd17f"
+  tag: "18.1@sha256:3bb77a07b9ce8b8de0fe6d9b063adf20b9cca1068a1bcdc054cac71a69ce0ca6"
   ## @param image.imagePullPolicy PostgreSQL image pull policy
   imagePullPolicy: Always
   ## @param image.useHardenedImage Set to true when using hardened images (e.g., DHI) that have different PGDATA paths for Postgres <18


### PR DESCRIPTION
### Description of the change

As mini is currently only maintained for critical cve´s, I took the liberty to create a hardened image fixing all but 2 of the cve´s trivy reported to me. This is a minimally invasive change, and for people who are not a fan of this, the old, unmodified images will still be provided and will remain as-is.

### Benefits

Less trivy alerts / recommendations
Fully backwards compatible

### Possible drawbacks

As people who know what bitnami did, they could find this change invasive. But as we currently already build our own images, this is a "minimal" change that people can easy undo to use the non modified image we provide.

### Applicable issues

- fixes #

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
