### PR TITLE
[common] Fix commonLabels propagation in common library

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: common
 description: A library chart for common templates and helper functions
 type: library
-version: 2.1.2
-appVersion: "2.1.2"
+version: 2.2.0
+appVersion: "2.2.0"
 home: https://www.cloudpirates.io
 sources:
   - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/common


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change
This PR:
- Rewrites `cloudpirates.labels` and `cloudpirates.selectorLabels` helpers to use Spring `merge/pick` instead of text concatenation, preventing duplicate YAML keys when `commonLabels` overrides standard labels (e.g. app.kubernetes.io/name)
- Removes the `selectorLabels `workaround (`.Values.selectorLabels.name` / `.Values.selectorLabels.instance`) that was previously added to allow overriding `app.kubernetes.io/name` and `app.kubernetes.io/instance` per sub-chart

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits/Motivation
When the same chart (e.g. zookeeper) is deployed multiple times as a sub-chart within an umbrella chart, each instance needs a unique `app.kubernetes.io/name` to avoid selector collisions. The standard Helm way to do this is via commonLabels:
```
zookeeper:
  commonLabels:
    app.kubernetes.io/name: zookeeper-custom
```
The previous implementation used text concatenation to append `commonLabels`, which caused duplicate YAML keys when `commonLabels` overrode an existing label like `app.kubernetes.io/name`. A custom `.Values.selectorLabels `workaround was added to work around this, but it was non-standard and didn't propagate labels consistently to all resources (e.g. selectors, services, network policies).

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
