### PR TITLE
[all]: WIP: Add gateway API for replacement of depricated ingresses

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: common
 description: A library chart for common templates and helper functions
 type: library
-version: 2.1.2
-appVersion: "2.1.2"
+version: 2.2.0
+appVersion: "2.2.0"
 home: https://www.cloudpirates.io
 sources:
   - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/common

--- a/charts/common/templates/_helpers.tpl
+++ b/charts/common/templates/_helpers.tpl
@@ -397,3 +397,18 @@ hostnames:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Resolve Gateway name - auto-generate if create=true and gatewayName not provided.
+Usage: {{ include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) }}
+Returns the gateway name to use in HTTPRoute parentRefs.
+*/}}
+{{- define "cloudpirates.gateway.resolveName" -}}
+{{- if .gateway.gatewayName -}}
+{{- .gateway.gatewayName -}}
+{{- else if .gateway.create -}}
+{{- printf "%s-gateway" .fullName -}}
+{{- else -}}
+{{- fail "gateway.gatewayName is required when gateway.enabled is true (or set gateway.create=true to auto-create)" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.12.1
+version: 0.13.0
 appVersion: "6.18.2"
 keywords:
   - ghost

--- a/charts/ghost/templates/gateway.yaml
+++ b/charts/ghost/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "ghost.fullname" . -}}
+{{- $svcPort := (first .Values.service.ports).port -}}
+{{- $labels := include "ghost.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/ghost/templates/gateway.yaml
+++ b/charts/ghost/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "ghost.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "ghost.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := (first .Values.service.ports).port -}}
 {{- $labels := include "ghost.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/ghost/templates/ingress.yaml
+++ b/charts/ghost/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ghost.fullname" . -}}
 {{- $svcPort := (first .Values.service.ports).port -}}

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -435,6 +435,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -441,8 +441,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -89,7 +89,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -85,6 +85,25 @@ ingress:
   ## @param ingress.tls An array with the tls configuration
   tls: []
 
+## @section Gateway API parameters
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: ghost.localhost
+      paths:
+        - path: /
+          pathType: PathPrefix
+    - host: admin.ghost.localhost
+      paths:
+        - path: /ghost
+          pathType: PathPrefix
+
 ## @section Service Account parameters
 serviceAccount:
   ## @param serviceAccount.create Specifies whether a service account should be created

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.14.8
+version: 0.15.0
 appVersion: "26.5.3"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/gateway.yaml
+++ b/charts/keycloak/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "keycloak.fullname" . -}}
+{{- $svcPort := .Values.keycloak.httpsEnabled | ternary .Values.service.httpsPort .Values.service.httpPort -}}
+{{- $labels := include "keycloak.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/keycloak/templates/gateway.yaml
+++ b/charts/keycloak/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "keycloak.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.keycloak.httpsEnabled | ternary .Values.service.httpsPort .Values.service.httpPort -}}
 {{- $labels := include "keycloak.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "keycloak.fullname" . -}}
 {{- $httpPort := .Values.service.httpPort -}}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -140,8 +140,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -134,6 +134,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -294,7 +294,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -289,6 +289,21 @@ ingress:
   tls: []
   #  - secretName: keycloak-tls
   #    hosts:
+
+## @section Gateway API configuration
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: keycloak.local
+      paths:
+        - path: /
+          pathType: PathPrefix
   #      - keycloak.local
 
 ## @section Resources

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.13.6
+version: 0.14.0
 appVersion: "12.2.2"
 keywords:
   - mariadb

--- a/charts/mariadb/templates/gateway.yaml
+++ b/charts/mariadb/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "mariadb.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mariadb.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.port -}}
 {{- $labels := include "mariadb.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/mariadb/templates/gateway.yaml
+++ b/charts/mariadb/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "mariadb.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $labels := include "mariadb.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/mariadb/templates/ingress.yaml
+++ b/charts/mariadb/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "mariadb.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -211,8 +211,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -205,6 +205,45 @@
                 }
             }
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -314,7 +314,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -310,6 +310,21 @@ ingress:
   ## @param ingress.tls TLS configuration for the Ingress
   tls: []
 
+## @section Gateway API parameters
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: mariadb.local
+      paths:
+        - path: /
+          pathType: PathPrefix
+
 ## @section Network Policy configuration
 networkPolicy:
   ## @param networkPolicy.enabled Specifies whether a NetworkPolicy should be created

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.9.6
+version: 0.10.0
 appVersion: "1.6.40"
 keywords:
   - memcached

--- a/charts/memcached/templates/gateway.yaml
+++ b/charts/memcached/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "memcached.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $labels := include "memcached.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/memcached/templates/gateway.yaml
+++ b/charts/memcached/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "memcached.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "memcached.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.port -}}
 {{- $labels := include "memcached.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/memcached/templates/ingress.yaml
+++ b/charts/memcached/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "memcached.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -77,8 +77,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -71,6 +71,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -65,7 +65,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -61,6 +61,21 @@ ingress:
   ## @param ingress.tls An array with the tls configuration
   tls: []
 
+## @section Gateway API parameters
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: memcached.local
+      paths:
+        - path: /
+          pathType: PathPrefix
+
 ## @section Service Account parameters
 serviceAccount:
   ## @param serviceAccount.create Specifies whether a service account should be created

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.9.2
+version: 0.10.0
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/templates/gateway-console.yaml
+++ b/charts/minio/templates/gateway-console.yaml
@@ -3,6 +3,27 @@
 {{- end -}}
 {{- if .Values.consoleGateway.enabled -}}
 {{- $fullName := include "minio.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.consoleGateway "fullName" (printf "%s-console" $fullName)) -}}
+{{- if .Values.consoleGateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "minio.labels" . | nindent 4 }}
+    app.kubernetes.io/component: console
+spec:
+  gatewayClassName: {{ .Values.consoleGateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.consolePort -}}
 {{- $labels := include "minio.labels" . -}}
 {{- $annotations := merge .Values.consoleGateway.annotations .Values.commonAnnotations }}
@@ -12,7 +33,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" (printf "%s-console" $fullName) "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "consoleGateway.gatewayName is required when consoleGateway.enabled is true" .Values.consoleGateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.consoleGateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.consoleGateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/minio/templates/gateway-console.yaml
+++ b/charts/minio/templates/gateway-console.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.consoleGateway.enabled .Values.consoleIngress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for MinIO Console. Please enable only one routing method." -}}
+{{- end -}}
+{{- if .Values.consoleGateway.enabled -}}
+{{- $fullName := include "minio.fullname" . -}}
+{{- $svcPort := .Values.service.consolePort -}}
+{{- $labels := include "minio.labels" . -}}
+{{- $annotations := merge .Values.consoleGateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" (printf "%s-console" $fullName) "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "consoleGateway.gatewayName is required when consoleGateway.enabled is true" .Values.consoleGateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.consoleGateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.consoleGateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/minio/templates/gateway.yaml
+++ b/charts/minio/templates/gateway.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for MinIO API. Please enable only one routing method." -}}
+{{- end -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "minio.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $labels := include "minio.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/minio/templates/gateway.yaml
+++ b/charts/minio/templates/gateway.yaml
@@ -3,6 +3,26 @@
 {{- end -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "minio.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "minio.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.port -}}
 {{- $labels := include "minio.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -12,7 +32,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/minio/templates/ingress-console.yaml
+++ b/charts/minio/templates/ingress-console.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.consoleGateway.enabled .Values.consoleIngress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for MinIO Console. Please enable only one routing method." -}}
+{{- end -}}
 {{- if .Values.consoleIngress.enabled -}}
 {{- $fullName := include "minio.fullname" . -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/minio/templates/ingress.yaml
+++ b/charts/minio/templates/ingress.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for MinIO API. Please enable only one routing method." -}}
+{{- end -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "minio.fullname" . -}}
 apiVersion: networking.k8s.io/v1

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -107,6 +107,45 @@
                 }
             }
         },
+        "consoleGateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "consoleIngress": {
             "type": "object",
             "properties": {
@@ -188,6 +227,45 @@
         },
         "fullnameOverride": {
             "type": "string"
+        },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "global": {
             "type": "object",

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -113,8 +113,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"
@@ -234,8 +240,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -213,7 +213,17 @@ consoleIngress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation for MinIO (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}
@@ -228,7 +238,17 @@ gateway:
 consoleGateway:
   ## @param consoleGateway.enabled Enable Gateway API HTTPRoute generation for MinIO Console (mutually exclusive with consoleIngress)
   enabled: false
-  ## @param consoleGateway.gatewayName Name of the Gateway resource to attach to
+  ## @param consoleGateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param consoleGateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param consoleGateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param consoleGateway.annotations Additional annotations for the Console HTTPRoute resource
   annotations: {}

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -209,6 +209,36 @@ consoleIngress:
   ## @param consoleIngress.tls TLS configuration for MinIO Console ingress
   tls: []
 
+## @section Gateway API configuration
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation for MinIO (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: minio.local
+      paths:
+        - path: /
+          pathType: PathPrefix
+
+## @section Console Gateway API configuration
+consoleGateway:
+  ## @param consoleGateway.enabled Enable Gateway API HTTPRoute generation for MinIO Console (mutually exclusive with consoleIngress)
+  enabled: false
+  ## @param consoleGateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param consoleGateway.annotations Additional annotations for the Console HTTPRoute resource
+  annotations: {}
+  ## @param consoleGateway.hosts An array with hosts and paths
+  hosts:
+    - host: minio-console.local
+      paths:
+        - path: /
+          pathType: PathPrefix
+
 ## @section Resources
 resources:
   {}

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.5.11
+version: 0.6.0
 appVersion: "1.29.5"
 keywords:
   - nginx

--- a/charts/nginx/templates/gateway.yaml
+++ b/charts/nginx/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "nginx.fullname" . -}}
+{{- $svcPort := (index .Values.service.ports 0).port }}
+{{- $labels := include "nginx.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/nginx/templates/gateway.yaml
+++ b/charts/nginx/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "nginx.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "nginx.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := (index .Values.service.ports 0).port }}
 {{- $labels := include "nginx.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/nginx/templates/ingress.yaml
+++ b/charts/nginx/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "nginx.fullname" . -}}
 {{- $svcPort := (index .Values.service.ports 0).port }}

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -175,8 +175,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -169,6 +169,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -89,7 +89,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -85,6 +85,21 @@ ingress:
   ## @param ingress.tls An array with the tls configuration
   tls: []
 
+## @section Gateway API parameters
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: nginx.local
+      paths:
+        - path: /
+          pathType: PathPrefix
+
 ## @section Service Account parameters
 serviceAccount:
   ## @param serviceAccount.create Specifies whether a service account should be created

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.15.6
+version: 0.16.0
 appVersion: "18.2.0"
 keywords:
   - postgres

--- a/charts/postgres/templates/gateway.yaml
+++ b/charts/postgres/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "postgres.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $labels := include "postgres.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/postgres/templates/gateway.yaml
+++ b/charts/postgres/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "postgres.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.port -}}
 {{- $labels := include "postgres.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/postgres/templates/ingress.yaml
+++ b/charts/postgres/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "postgres.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -252,8 +252,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -246,6 +246,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -221,6 +221,21 @@ ingress:
   ## @param ingress.tls TLS configuration for PostgreSQL ingress
   tls: []
   #  - secretName: postgres-tls
+
+## @section Gateway API configuration
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: postgres.local
+      paths:
+        - path: /
+          pathType: PathPrefix
   #    hosts:
   #      - postgres.local
 

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -226,7 +226,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.15.11
+version: 0.16.0
 appVersion: "4.2.3"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/gateway.yaml
+++ b/charts/rabbitmq/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "rabbitmq.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "rabbitmq.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.managementPort -}}
 {{- $labels := include "rabbitmq.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/rabbitmq/templates/gateway.yaml
+++ b/charts/rabbitmq/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "rabbitmq.fullname" . -}}
+{{- $svcPort := .Values.service.managementPort -}}
+{{- $labels := include "rabbitmq.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rabbitmq.fullname" . -}}
 {{- $svcPort := .Values.service.managementPort -}}

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -276,6 +276,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -282,8 +282,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -358,7 +358,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -354,6 +354,21 @@ ingress:
   ## @param ingress.tls Ingress TLS configuration
   tls: []
 
+## @section Gateway API configuration
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: rabbitmq.local
+      paths:
+        - path: /
+          pathType: PathPrefix
+
 ## @section Resources
 ## @param resources Resource limits and requests for RabbitMQ pods
 resources: {}

--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: (ALPHA) High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.4.1
+version: 0.5.0
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/templates/gateway.yaml
+++ b/charts/rustfs/templates/gateway.yaml
@@ -1,0 +1,50 @@
+{{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for RustFS API. Please enable only one routing method." -}}
+{{- end -}}
+{{- if and .Values.consoleGateway.enabled .Values.consoleIngress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for RustFS Console. Please enable only one routing method." -}}
+{{- end -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "rustfs.fullname" . -}}
+{{- $labels := include "rustfs.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  hostnames:
+  {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+    {{- if $.Values.gateway.enableWildcard }}
+    - {{ printf "*.%s" .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" "api") | nindent 4 }}
+{{- end }}
+
+{{- if and .Values.config.consoleEnabled .Values.consoleGateway.enabled (eq .Values.deploymentType "statefulset") }}
+---
+{{- $fullName := include "rustfs.fullname" . -}}
+{{- $labels := include "rustfs.labels" . -}}
+{{- $annotations := merge .Values.consoleGateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" (printf "%s-console" $fullName) "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "consoleGateway.gatewayName is required when consoleGateway.enabled is true" .Values.consoleGateway.gatewayName }}
+  hostnames:
+  {{- range .Values.consoleGateway.hosts }}
+    - {{ .host | quote }}
+    {{- if $.Values.consoleGateway.enableWildcard }}
+    - {{ printf "*.%s" .host | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.consoleGateway.hosts "serviceName" (printf "%s-pod0" $fullName) "servicePort" "api") | nindent 4 }}
+{{- end }}

--- a/charts/rustfs/templates/gateway.yaml
+++ b/charts/rustfs/templates/gateway.yaml
@@ -6,6 +6,26 @@
 {{- end -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "rustfs.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "rustfs.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $labels := include "rustfs.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
 apiVersion: gateway.networking.k8s.io/v1
@@ -14,7 +34,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   hostnames:
   {{- range .Values.gateway.hosts }}
     - {{ .host | quote }}
@@ -29,6 +49,27 @@ spec:
 {{- if and .Values.config.consoleEnabled .Values.consoleGateway.enabled (eq .Values.deploymentType "statefulset") }}
 ---
 {{- $fullName := include "rustfs.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.consoleGateway "fullName" (printf "%s-console" $fullName)) -}}
+{{- if .Values.consoleGateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "rustfs.labels" . | nindent 4 }}
+    app.kubernetes.io/component: console
+spec:
+  gatewayClassName: {{ .Values.consoleGateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $labels := include "rustfs.labels" . -}}
 {{- $annotations := merge .Values.consoleGateway.annotations .Values.commonAnnotations }}
 apiVersion: gateway.networking.k8s.io/v1
@@ -37,7 +78,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" (printf "%s-console" $fullName) "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "consoleGateway.gatewayName is required when consoleGateway.enabled is true" .Values.consoleGateway.gatewayName }}
+    - name: {{ $gatewayName }}
   hostnames:
   {{- range .Values.consoleGateway.hosts }}
     - {{ .host | quote }}

--- a/charts/rustfs/templates/ingress.yaml
+++ b/charts/rustfs/templates/ingress.yaml
@@ -1,3 +1,9 @@
+{{- if and .Values.gateway.enabled .Values.ingress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for RustFS API. Please enable only one routing method." -}}
+{{- end -}}
+{{- if and .Values.consoleGateway.enabled .Values.consoleIngress.enabled -}}
+{{- fail "Gateway API and Ingress cannot both be enabled for RustFS Console. Please enable only one routing method." -}}
+{{- end -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "rustfs.fullname" . -}}
 {{- $deploymentType := .Values.deploymentType -}}

--- a/charts/rustfs/values.schema.json
+++ b/charts/rustfs/values.schema.json
@@ -66,6 +66,48 @@
                 }
             }
         },
+        "consoleGateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enableWildcard": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "consoleIngress": {
             "type": "object",
             "properties": {
@@ -202,6 +244,48 @@
         },
         "fullnameOverride": {
             "type": "string"
+        },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enableWildcard": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
         "global": {
             "type": "object",

--- a/charts/rustfs/values.schema.json
+++ b/charts/rustfs/values.schema.json
@@ -72,11 +72,17 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enableWildcard": {
                     "type": "boolean"
                 },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"
@@ -251,11 +257,17 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enableWildcard": {
                     "type": "boolean"
                 },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/rustfs/values.yaml
+++ b/charts/rustfs/values.yaml
@@ -184,6 +184,40 @@ consoleIngress:
           pathType: Prefix
   ## @param consoleIngress.tls TLS configuration for Console RustFS API ingress
   tls: []
+
+## @section Gateway API configuration
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation for RustFS API (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: rustfs.localhost
+      paths:
+        - path: /
+          pathType: PathPrefix
+  ## @param gateway.enableWildcard Enable wildcard hostname support (*.host) for bucket-style S3 URLs
+  enableWildcard: true
+
+## @section Console Gateway API configuration (for StatefulSet only)
+consoleGateway:
+  ## @param consoleGateway.enabled Enable Console Gateway API HTTPRoute generation for RustFS API (mutually exclusive with consoleIngress)
+  enabled: false
+  ## @param consoleGateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param consoleGateway.annotations Additional annotations for the Console HTTPRoute resource
+  annotations: {}
+  ## @param consoleGateway.hosts An array with hosts and paths
+  hosts:
+    - host: rustfs-console.localhost
+      paths:
+        - path: /
+          pathType: PathPrefix
+  ## @param consoleGateway.enableWildcard Enable wildcard hostname support (*.host)
+  enableWildcard: true
   #  - secretName: rustfs-console-tls
   #    hosts:
   #      - rustfs-console.local

--- a/charts/rustfs/values.yaml
+++ b/charts/rustfs/values.yaml
@@ -189,7 +189,17 @@ consoleIngress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation for RustFS API (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}
@@ -206,7 +216,17 @@ gateway:
 consoleGateway:
   ## @param consoleGateway.enabled Enable Console Gateway API HTTPRoute generation for RustFS API (mutually exclusive with consoleIngress)
   enabled: false
-  ## @param consoleGateway.gatewayName Name of the Gateway resource to attach to
+  ## @param consoleGateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param consoleGateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param consoleGateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param consoleGateway.annotations Additional annotations for the Console HTTPRoute resource
   annotations: {}

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.16.0
+version: 0.17.0
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/gateway.yaml
+++ b/charts/valkey/templates/gateway.yaml
@@ -1,0 +1,17 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
+{{- if .Values.gateway.enabled -}}
+{{- $fullName := include "valkey.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $labels := include "valkey.labels" . -}}
+{{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
+spec:
+  parentRefs:
+    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+  {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
+  rules:
+    {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}
+{{- end }}

--- a/charts/valkey/templates/gateway.yaml
+++ b/charts/valkey/templates/gateway.yaml
@@ -1,6 +1,26 @@
 {{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.gateway.enabled -}}
 {{- $fullName := include "valkey.fullname" . -}}
+{{- $gatewayName := include "cloudpirates.gateway.resolveName" (dict "gateway" .Values.gateway "fullName" $fullName) -}}
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ $gatewayName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+{{- end }}
 {{- $svcPort := .Values.service.port -}}
 {{- $labels := include "valkey.labels" . -}}
 {{- $annotations := merge .Values.gateway.annotations .Values.commonAnnotations }}
@@ -10,7 +30,7 @@ metadata:
   {{- include "cloudpirates.gateway.metadata" (dict "name" $fullName "labels" $labels "annotations" $annotations "context" $) | nindent 2 }}
 spec:
   parentRefs:
-    - name: {{ required "gateway.gatewayName is required when gateway.enabled is true" .Values.gateway.gatewayName }}
+    - name: {{ $gatewayName }}
   {{- include "cloudpirates.gateway.hostnames" .Values.gateway.hosts | nindent 2 }}
   rules:
     {{- include "cloudpirates.gateway.rules" (dict "hosts" .Values.gateway.hosts "serviceName" $fullName "servicePort" $svcPort) | nindent 4 }}

--- a/charts/valkey/templates/ingress.yaml
+++ b/charts/valkey/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- include "cloudpirates.gateway.validateExclusivity" . -}}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "valkey.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -131,8 +131,14 @@
                 "annotations": {
                     "type": "object"
                 },
+                "create": {
+                    "type": "boolean"
+                },
                 "enabled": {
                     "type": "boolean"
+                },
+                "gatewayClassName": {
+                    "type": "string"
                 },
                 "gatewayName": {
                     "type": "string"

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -125,6 +125,45 @@
         "fullnameOverride": {
             "type": "string"
         },
+        "gateway": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "gatewayName": {
+                    "type": "string"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -193,7 +193,17 @@ ingress:
 gateway:
   ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
   enabled: false
-  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  ## @param gateway.create Create Gateway resource automatically (WARNING: Not recommended for production - see below)
+  create: false
+  ## WARNING: Auto-creating Gateways (create=true) is NOT RECOMMENDED for production use.
+  ## - Each app creates its own LoadBalancer (expensive in cloud environments)
+  ## - Less control for cluster admins over infrastructure
+  ## - Not the intended Gateway API pattern (separation of concerns)
+  ## - Production deployments should use a shared Gateway managed by cluster admins
+  ## - Auto-creation is convenient for development/testing only
+  ## @param gateway.gatewayClassName GatewayClass to use when creating Gateway (only used if create=true)
+  gatewayClassName: "eg"
+  ## @param gateway.gatewayName Name of existing Gateway resource to attach to (required if create=false)
   gatewayName: ""
   ## @param gateway.annotations Additional annotations for the HTTPRoute resource
   annotations: {}

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -188,6 +188,21 @@ ingress:
           pathType: Prefix
   ## @param ingress.tls TLS configuration for Valkey ingress
   tls: []
+
+## @section Gateway API configuration
+gateway:
+  ## @param gateway.enabled Enable Gateway API HTTPRoute generation (mutually exclusive with ingress)
+  enabled: false
+  ## @param gateway.gatewayName Name of the Gateway resource to attach to
+  gatewayName: ""
+  ## @param gateway.annotations Additional annotations for the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.hosts An array with hosts and paths
+  hosts:
+    - host: valkey.local
+      paths:
+        - path: /
+          pathType: PathPrefix
   #  - secretName: valkey-tls
   #    hosts:
   #      - valkey.local


### PR DESCRIPTION
### Description of the change

Add the option, similar to ingress, to define / use the new gateway api, which is mutually exclusive by design with an ingress.

### Benefits

Future proof as of the recent depreciation of Ingress nginx

### Possible drawbacks

Rework of already working systems

### Applicable issues

- fixes #

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
