### PR TITLE
[keycloak] fix: set default values for nodePort values

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "26.5.3"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -243,8 +243,8 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | `service.httpsTargetPort`     | Keycloak HTTPS container port | `8443`      |
 | `service.annotations`         | Service annotations           | `{}`        |
 | `service.trafficDistribution` | Service traffic distribution  | `""`        |
-| `service.httpNodePort`        | Keycloak HTTP node port       | `""`        |
-| `service.httpsNodePort`       | Keycloak HTTPS node port      | `""`        |
+| `service.httpNodePort`        | Keycloak HTTP node port       | `30080`     |
+| `service.httpsNodePort`       | Keycloak HTTPS node port      | `30443"`    |
 
 ### Ingress configuration
 

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
       targetPort: {{ .Values.service.httpTargetPort }}
       protocol: TCP
       name: http
-      {{- if and (eq .Values.service.type "NodePort") (.Values.service.httpNodePort) }}
+      {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.httpNodePort }}
       {{- end }}
     {{- end }}
@@ -27,7 +27,7 @@ spec:
       targetPort: {{ .Values.service.httpsTargetPort }}
       protocol: TCP
       name: https
-      {{- if and (eq .Values.service.type "NodePort") (.Values.service.httpsNodePort) }}
+      {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.httpsNodePort }}
       {{- end }}
     {{- end }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -611,7 +611,7 @@
                     "type": "object"
                 },
                 "httpNodePort": {
-                    "type": "string"
+                    "type": "integer"
                 },
                 "httpPort": {
                     "type": "integer"
@@ -620,7 +620,7 @@
                     "type": "integer"
                 },
                 "httpsNodePort": {
-                    "type": "string"
+                    "type": "integer"
                 },
                 "httpsPort": {
                     "type": "integer"

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -266,9 +266,9 @@ service:
   ## @param service.trafficDistribution Traffic distribution preference for the keycloak service. If the field is not set, the implementation will apply its default routing strategy.
   trafficDistribution: ""
   ## @param service.nodePort Keycloak HTTP node port
-  httpNodePort: ""
+  httpNodePort: 30080
   ## @param service.nodePort Keycloak HTTPS node port
-  httpsNodePort: ""
+  httpsNodePort: 30443
 
 ## @section Ingress configuration
 ingress:


### PR DESCRIPTION
### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

This is a bug fix: due to having "" as default value for the node ports, the generated json schema expects actual values to be strings. To fix this in the schema, I added default values which are integers. Therefore I also removed the now redundant check of the variable for null in the template.

### Possible drawbacks

The users might have to change the node port values if the used ports are already occupied in their environment.

### Applicable issues

None.

### Additional information

None.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
