### PR TITLE
[mariadb]: Fixes broken healthcheck

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "12.2.2"
 keywords:
   - mariadb

--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -199,7 +199,7 @@ spec:
                     exit 1
                   fi
                 {{- else }}
-                - hhealthcheck.sh {{ if .Values.healthcheckExtraArgs }}{{ .Values.healthcheckExtraArgs }} {{ end }}--connect --innodb_initialized
+                - healthcheck.sh {{ if .Values.healthcheckExtraArgs }}{{ .Values.healthcheckExtraArgs }} {{ end }}--connect --innodb_initialized
                 {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

https://github.com/CloudPirates-io/helm-charts/commit/7b9d0236ebe42bdb4a3f8186fe3fd419806344c4

introduced a typo which breaks healthchecks of mariadb

### Benefits

Healthcheck is working again

### Possible drawbacks

None

### Applicable issues

No healthcheck, no uptime.

- fixes #

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
