### PR TITLE
[redis]: Extend redis secret connection

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.24.0
+version: 0.25.0
 appVersion: "8.4.0"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -38,10 +38,19 @@ helm install my-redis ./charts/redis
 
 ### Getting Started
 
-1. Get the Redis password:
+1. Get the Redis connection details:
 
 ```bash
+# Get password
 kubectl get secret my-redis -o jsonpath="{.data.redis-password}" | base64 -d
+
+# Get full connection URI
+kubectl get secret my-redis -o jsonpath="{.data.uri}" | base64 -d
+
+# Get individual connection fields
+kubectl get secret my-redis -o jsonpath="{.data.host}" | base64 -d
+kubectl get secret my-redis -o jsonpath="{.data.port}" | base64 -d
+kubectl get secret my-redis -o jsonpath="{.data.username}" | base64 -d
 ```
 
 2. Connect to Redis from inside the cluster:
@@ -135,6 +144,18 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/redis:<version>
 | `auth.acl.existingSecret`        | Name of existing secret containing ACL rules                 | `""`    |
 | `auth.acl.existingSecretACLKey`  | Key in existing secret containing ACL rules                  | `""`    |
 | `auth.acl.existingFilePath`      | Path to existing ACL file injected by Vault Agent Injector (mutually exclusive with existingSecret) | `""`    |
+
+#### Connection Details Secret
+
+When `auth.enabled` is `true` and no `auth.existingSecret` or `auth.acl.enabled` is set, the chart creates a Secret containing full connection details:
+
+| Key              | Description                                                                 |
+| ---------------- | --------------------------------------------------------------------------- |
+| `redis-password` | The Redis password (base64 encoded)                                         |
+| `host`           | The Redis service hostname: `<fullname>.<namespace>.svc` (base64 encoded)   |
+| `port`           | The Redis service port (base64 encoded). Uses `tls.port` when TLS is enabled |
+| `username`       | The Redis username: `default` (base64 encoded)                              |
+| `uri`            | Full connection URI: `redis://default:<password>@<host>:<port>` (base64 encoded). Uses `rediss://` scheme when TLS is enabled |
 
 #### ACL Configuration
 

--- a/charts/redis/templates/secret.yaml
+++ b/charts/redis/templates/secret.yaml
@@ -17,5 +17,14 @@ data:
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingPassword = index $existingSecret.data "redis-password" }}
   {{- end }}
-  redis-password: {{ $existingPassword | default (.Values.auth.password | default (randAlphaNum 16) | b64enc) | quote }}
+  {{- $redisPassword := $existingPassword | default (.Values.auth.password | default (randAlphaNum 16) | b64enc) }}
+  {{- $host := printf "%s.%s.svc" (include "redis.fullname" .) (include "cloudpirates.namespace" .) }}
+  {{- $port := ternary (.Values.tls.port | toString) (.Values.service.port | toString) .Values.tls.enabled }}
+  {{- $username := "default" }}
+  {{- $scheme := ternary "rediss" "redis" .Values.tls.enabled }}
+  redis-password: {{ $redisPassword | quote }}
+  host: {{ $host | b64enc | quote }}
+  port: {{ $port | b64enc | quote }}
+  username: {{ $username | b64enc | quote }}
+  uri: {{ printf "%s://%s:%s@%s:%s" $scheme $username ($redisPassword | b64dec) $host $port | b64enc | quote }}
 {{- end }}

--- a/charts/redis/tests/secret_test.yaml
+++ b/charts/redis/tests/secret_test.yaml
@@ -1,0 +1,86 @@
+suite: test redis secret connection details
+templates:
+  - secret.yaml
+tests:
+  - it: should render secret with all connection fields when auth is enabled
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - isNotEmpty:
+          path: data["redis-password"]
+      - isNotEmpty:
+          path: data.host
+      - isNotEmpty:
+          path: data.port
+      - isNotEmpty:
+          path: data.username
+      - isNotEmpty:
+          path: data.uri
+
+  - it: should set correct host, port and username
+    set:
+      auth.password: "testpassword"
+    asserts:
+      - equal:
+          path: data.host
+          value: "UkVMRUFTRS1OQU1FLXJlZGlzLk5BTUVTUEFDRS5zdmM="
+      - equal:
+          path: data.port
+          value: "NjM3OQ=="
+      - equal:
+          path: data.username
+          value: "ZGVmYXVsdA=="
+
+  - it: should use redis scheme in uri by default
+    set:
+      auth.password: "testpassword"
+    asserts:
+      - equal:
+          path: data.uri
+          value: "cmVkaXM6Ly9kZWZhdWx0OnRlc3RwYXNzd29yZEBSRUxFQVNFLU5BTUUtcmVkaXMuTkFNRVNQQUNFLnN2Yzo2Mzc5"
+
+  - it: should use custom service port in connection details
+    set:
+      auth.password: "testpassword"
+      service.port: 6380
+    asserts:
+      - equal:
+          path: data.port
+          value: "NjM4MA=="
+
+  - it: should not render secret when auth is disabled
+    set:
+      auth.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render secret when existingSecret is set
+    set:
+      auth.existingSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render secret when acl is enabled
+    set:
+      auth.acl.enabled: true
+      auth.acl.existingSecret: my-acl-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use rediss scheme and tls port when tls is enabled
+    set:
+      auth.password: "testpassword"
+      tls.enabled: true
+      tls.existingSecret: my-tls-secret
+    asserts:
+      - equal:
+          path: data.port
+          value: "NjM4MA=="
+      - equal:
+          path: data.uri
+          value: "cmVkaXNzOi8vZGVmYXVsdDp0ZXN0cGFzc3dvcmRAUkVMRUFTRS1OQU1FLXJlZGlzLk5BTUVTUEFDRS5zdmM6NjM4MA=="


### PR DESCRIPTION
### Description of the change

Optionally adds all the redis connection details to the secret

### Benefits

### Possible drawbacks

Backwards compatible

### Applicable issues

- fixes #976 

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
