### PR TITLE
rabbitmq-cluster-operator: Fix template error when namespaced watch is defined.

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "2.19.1"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ printf "%s-%s" (include "rmqco.clusterOperator.fullname" $) $namespace | trunc 63 | trimSuffix "-" }}
   namespace: {{ $namespace | quote }}
   labels:
-    {{- include "rmqco.labels" . | nindent 4 }}
+    {{- include "rmqco.labels" $ | nindent 4 }}
   {{- if $.Values.commonAnnotations }}
   annotations: {{- include "cloudpirates.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
@@ -27,7 +27,7 @@ metadata:
   name: {{ printf "%s-%s" (include "rmqco.msgTopologyOperator.fullname" $) $namespace | trunc 63 | trimSuffix "-" }}
   namespace: {{ $namespace | quote }}
   labels:
-    {{- include "rmqmto.labels" . | nindent 4 }}
+    {{- include "rmqmto.labels" $ | nindent 4 }}
   {{- if $.Values.commonAnnotations }}
   annotations: {{- include "cloudpirates.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
### Description of the change

This change is a fix of a template error in rabbitmq-cluster-operator regarding namespaced resource watch.

### Benefits

This change allows using the use of the below configuration in both the cluster operator and the message topology operator.
```yaml
  watchAllNamespaces: false
  watchNamespaces:
    - example
```

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #1051 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
