### PR TITLE
[redis] Increase resource limits for sentinel pods

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.26.1
+version: 0.26.2
 appVersion: "8.6.1"
 keywords:
   - redis

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -413,10 +413,10 @@ sentinel:
   ## @param sentinel.resources Resource limits and requests for Sentinel pods
   resources:
     limits:
-      cpu: 50m
+      cpu: 200m
       memory: 128Mi
     requests:
-      cpu: 25m
+      cpu: 50m
       memory: 64Mi
   ## @param sentinel.redisShutdownWaitFailover Whether Redis should wait for Sentinel failover before shutdown
   ## When true: On master termination, waits for failover to complete (zero-downtime)


### PR DESCRIPTION
### Description of the change

The default sentinel CPU limit of 50m causes CFS throttling under normal operation. The liveness probe executes /bin/sh -c "redis-cli ... ping | grep -q PONG", which requires forking three processes. In a 50m   
  cgroup, this regularly exceeds the 5-second probe timeout, leading to spurious liveness failures and potential pod restarts.

  Observed at 50m:                                                                                                                                                                                                                                            
  - ~30% of CFS scheduling periods throttled
  - ~112ms average throttle duration per event                                                                                                                                                                                                                
  - Frequent sentinel TILT mode entries due to scheduling delays  
  - Intermittent liveness probe timeouts  

### Benefits

At 200m, throttle rate drops to ~7% with zero TILT entries and zero probe timeouts.

### Possible drawbacks

Increased resource usage.

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
