### PR TITLE
[keycloak]: Differentiate probes

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.17.0
+version: 0.18.0
 appVersion: "26.5.5"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -185,13 +185,24 @@ Return the database JDBC URL
 {{- end }}
 
 {{/*
-Return the url to use for probes
+Return the url to use for liveness probe
 */}}
-{{- define "keycloak.probeUrl" -}}
+{{- define "keycloak.livenessProbeUrl" -}}
 {{- if or (eq .Values.keycloak.httpRelativePath "") (eq .Values.keycloak.httpRelativePath "/") -}}
-{{- printf "/realms/master" -}}
+{{- printf "/health/live" -}}
 {{- else -}}
-{{- printf "%s/realms/master" .Values.keycloak.httpRelativePath -}}
+{{- printf "%s/health/live" .Values.keycloak.httpRelativePath -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return the url to use for readiness probe
+*/}}
+{{- define "keycloak.readinessProbeUrl" -}}
+{{- if or (eq .Values.keycloak.httpRelativePath "") (eq .Values.keycloak.httpRelativePath "/") -}}
+{{- printf "/health/ready" -}}
+{{- else -}}
+{{- printf "%s/health/ready" .Values.keycloak.httpRelativePath -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -131,6 +131,9 @@ spec:
             {{- if .Values.metrics.enabled }}
             - --metrics-enabled=true
             {{- end }}
+            {{- if or .Values.livenessProbe.enabled .Values.readinessProbe.enabled .Values.startupProbe.enabled }}
+            - --health-enabled=true
+            {{- end }}
             {{- with .Values.keycloak.extraArgs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -228,6 +231,9 @@ spec:
               containerPort: {{ .Values.keycloak.httpsPort }}
               protocol: TCP
             {{- end }}
+            - name: management
+              containerPort: {{ .Values.keycloak.managementPort }}
+              protocol: TCP
             {{- if .Values.metrics.enabled }}
             - name: {{ .Values.metrics.service.targetPort }}
               containerPort: {{ .Values.metrics.service.port }}
@@ -236,14 +242,9 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ include "keycloak.probeUrl" . }}
-              {{- if .Values.keycloak.httpsEnabled }}
-              port: https
-              scheme: HTTPS
-              {{- else }}
-              port: http
-              scheme: HTTP
-              {{- end }}
+              path: {{ include "keycloak.livenessProbeUrl" . }}
+              port: management
+              scheme: {{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -253,14 +254,9 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ include "keycloak.probeUrl" . }}
-              {{- if .Values.keycloak.httpsEnabled }}
-              port: https
-              scheme: HTTPS
-              {{- else }}
-              port: http
-              scheme: HTTP
-              {{- end }}
+              path: {{ include "keycloak.readinessProbeUrl" . }}
+              port: management
+              scheme: {{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -270,14 +266,9 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ include "keycloak.probeUrl" . }}
-              {{- if .Values.keycloak.httpsEnabled }}
-              port: https
-              scheme: HTTPS
-              {{- else }}
-              port: http
-              scheme: HTTP
-              {{- end }}
+              path: {{ include "keycloak.livenessProbeUrl" . }}
+              port: management
+              scheme: {{ .Values.tls.enabled | ternary "HTTPS" "HTTP" }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}

--- a/charts/keycloak/tests/statefulset-parameters_test.yaml
+++ b/charts/keycloak/tests/statefulset-parameters_test.yaml
@@ -2,11 +2,24 @@ suite: test service account
 templates:
   - templates/statefulset.yaml
 tests:
-  - it: readiness probe should be original
+  - it: liveness probe should use /health/live
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/live
+  - it: liveness probe should include the httpRelativePath
+    set:
+      keycloak:
+        httpRelativePath: /auth
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /auth/health/live
+  - it: readiness probe should use /health/ready
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /realms/master
+          value: /health/ready
   - it: readiness probe should include the httpRelativePath
     set:
       keycloak:
@@ -14,7 +27,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /auth/realms/master
+          value: /auth/health/ready
   - it: hostname explicitly set should be unchanged
     set:
       keycloak:

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -351,6 +351,9 @@
                 "httpsPort": {
                     "type": "integer"
                 },
+                "managementPort": {
+                    "type": "integer"
+                },
                 "production": {
                     "type": "boolean"
                 },

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -124,6 +124,8 @@ keycloak:
   httpPort: 8080
   ## @param keycloak.httpsPort HTTPS port
   httpsPort: 8443
+  ## @param keycloak.managementPort Management interface port (health endpoints are served here)
+  managementPort: 9000
   ## @param keycloak.proxyHeaders The proxy headers that should be accepted by the server. (forwarded, xforwarded). Must be set when running behind a reverse proxy (e.g. nginx ingress), otherwise Keycloak will not trust X-Forwarded-* headers and will generate incorrect URLs. Leave empty only when Keycloak is directly exposed without a proxy.
   proxyHeaders: ""
   ## @param keycloak.proxyProtocolEnabled  Whether the server should use the HA PROXY protocol when serving requests from behind a proxy. (true, false(default))


### PR DESCRIPTION
### Description of the change

Use the two different endpoints the management interface exposes for health and readiness

### Benefits

Kube-score does not complain anymore about identical probes

### Possible drawbacks

### Applicable issues

- fixes #1117

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
