### PR TITLE
[mongodb] Fix identical liveness and readiness probes on metrics sidecar

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "8.2.6"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/statefulset-configserver.yaml
+++ b/charts/mongodb/templates/statefulset-configserver.yaml
@@ -281,7 +281,7 @@ spec:
           {{- if .Values.metrics.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: http-metrics
             initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -261,7 +261,7 @@ spec:
           {{- if .Values.metrics.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: http-metrics
             initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}

--- a/charts/mongodb/templates/statefulset-shard.yaml
+++ b/charts/mongodb/templates/statefulset-shard.yaml
@@ -298,7 +298,7 @@ spec:
           {{- if $.Values.metrics.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: http-metrics
             initialDelaySeconds: {{ $.Values.metrics.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ $.Values.metrics.readinessProbe.timeoutSeconds }}

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -261,7 +261,7 @@ spec:
           {{- if .Values.metrics.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: /metrics
               port: http-metrics
             initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}

--- a/charts/mongodb/tests/metrics-probes_test.yaml
+++ b/charts/mongodb/tests/metrics-probes_test.yaml
@@ -1,0 +1,96 @@
+suite: test mongodb metrics sidecar probes
+templates:
+  - statefulset.yaml
+set:
+  image:
+    tag: 8.0.12@sha256:a6bda40d00e56682aeaa1bfc88e024b7dd755782c575c02760104fe02010f94f
+  metrics:
+    enabled: true
+    livenessProbe:
+      enabled: true
+    readinessProbe:
+      enabled: true
+tests:
+  - it: should use / for metrics liveness probe path in standalone statefulset
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.port
+          value: http-metrics
+
+  - it: should use /metrics for metrics readiness probe path in standalone statefulset
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /metrics
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.port
+          value: http-metrics
+
+  - it: should have different liveness and readiness probe paths in standalone statefulset
+    asserts:
+      - notEqual:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /metrics
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /metrics
+
+---
+suite: test mongodb metrics sidecar probes for sharded cluster
+templates:
+  - statefulset-configserver.yaml
+  - statefulset-mongos.yaml
+  - statefulset-shard.yaml
+set:
+  shardedCluster:
+    enabled: true
+    shards: 1
+    configsvr:
+      replicaCount: 1
+    mongos:
+      replicaCount: 1
+    shardsvr:
+      dataNode:
+        replicaCount: 1
+  image:
+    tag: 8.0.12@sha256:a6bda40d00e56682aeaa1bfc88e024b7dd755782c575c02760104fe02010f94f
+  metrics:
+    enabled: true
+    livenessProbe:
+      enabled: true
+    readinessProbe:
+      enabled: true
+tests:
+  - it: should use / for metrics liveness probe and /metrics for readiness probe in configserver
+    template: statefulset-configserver.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /metrics
+
+  - it: should use / for metrics liveness probe and /metrics for readiness probe in mongos
+    template: statefulset-mongos.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /metrics
+
+  - it: should use / for metrics liveness probe and /metrics for readiness probe in shard
+    template: statefulset-shard.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[1].readinessProbe.httpGet.path
+          value: /metrics


### PR DESCRIPTION
## Description

Fixes #1186

The metrics sidecar container in all statefulset templates defines identical
liveness and readiness probes (both using `path: /`), causing kube-score to
flag a `[CRITICAL] Container Probes` failure.

This PR changes the readiness probe path from `/` to `/metrics` in the metrics
sidecar across all 4 statefulset templates. The `/` endpoint remains as the
lightweight liveness check, while `/metrics` confirms the exporter can actually
scrape MongoDB and serve metrics data, making it a proper readiness signal.

## Changes

- **templates/statefulset.yaml** — readiness probe path `/` → `/metrics`
- **templates/statefulset-configserver.yaml** — readiness probe path `/` → `/metrics`
- **templates/statefulset-mongos.yaml** — readiness probe path `/` → `/metrics`
- **templates/statefulset-shard.yaml** — readiness probe path `/` → `/metrics`
- **tests/metrics-probes_test.yaml** — new test file verifying probe paths differ
- **Chart.yaml** — version bump 0.14.2 → 0.14.3

## Checklist

- [x] Chart version bumped (0.14.2 → 0.14.3, patch for bugfix)
- [x] All tests pass (`helm unittest` — 42/42 passed)
- [x] Chart passes `helm lint`
- [x] Changes are backwards compatible
- [x] Commit is signed with SSH signature