### PR TITLE
[all] scoped per-chart changelogs in GitHub Releases

### DIFF
--- a/.github/actions/generate-changelog/action.yaml
+++ b/.github/actions/generate-changelog/action.yaml
@@ -1,0 +1,142 @@
+name: Generate Per-Chart Changelog
+description: |
+  Generate scoped changelog for Helm charts in a monorepo.
+  Supports two modes:
+    - generate: write CHANGELOG.md files per chart
+    - release-notes: output release notes for a single chart version (for GitHub Releases)
+
+inputs:
+  mode:
+    description: "'generate' for CHANGELOG.md files, 'release-notes' for single-version output"
+    required: false
+    default: "release-notes"
+  charts:
+    description: "Space-separated list of charts to process (default: all)"
+    required: false
+    default: ""
+  chart:
+    description: "Single chart name (for release-notes mode)"
+    required: false
+    default: ""
+  max-versions:
+    description: "Maximum number of versions per chart (generate mode)"
+    required: false
+    default: "20"
+  max-commits:
+    description: "Maximum commits to scan per chart"
+    required: false
+    default: "500"
+  repo-url:
+    description: "GitHub repository URL (auto-detected if empty)"
+    required: false
+    default: ""
+  config-file:
+    description: "Path to optional YAML config file"
+    required: false
+    default: ".changelog-config.yml"
+  output-file:
+    description: "Output file path (release-notes mode)"
+    required: false
+    default: "/tmp/release-notes.md"
+  dry-run:
+    description: "Print to stdout instead of writing files (generate mode)"
+    required: false
+    default: "false"
+  python-version:
+    description: "Python version to use"
+    required: false
+    default: "3.12"
+
+outputs:
+  changed-charts:
+    description: "Comma-separated list of charts whose CHANGELOG.md was updated (generate mode)"
+    value: ${{ steps.generate.outputs.changed-charts }}
+  release-notes-file:
+    description: "Path to the generated release notes file (release-notes mode)"
+    value: ${{ steps.release-notes.outputs.file }}
+  version:
+    description: "Chart version detected (release-notes mode)"
+    value: ${{ steps.release-notes.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install dependencies
+      shell: bash
+      run: pip install gitpython pyyaml click
+
+    - name: Fetch full git history
+      shell: bash
+      run: |
+        if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+          echo "Shallow clone detected — fetching full history..."
+          git fetch --unshallow
+        fi
+        git fetch --tags
+
+    - name: Determine repo URL
+      id: repo-url
+      shell: bash
+      env:
+        INPUT_REPO_URL: ${{ inputs.repo-url }}
+        GITHUB_REPO: ${{ github.repository }}
+      run: |
+        if [ -n "$INPUT_REPO_URL" ]; then
+          echo "url=$INPUT_REPO_URL" >> "$GITHUB_OUTPUT"
+        else
+          echo "url=https://github.com/${GITHUB_REPO}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Generate changelogs (file mode)
+      id: generate
+      if: inputs.mode == 'generate'
+      shell: bash
+      env:
+        REPO_URL: ${{ steps.repo-url.outputs.url }}
+        MAX_VERSIONS: ${{ inputs.max-versions }}
+        MAX_COMMITS: ${{ inputs.max-commits }}
+        CONFIG_FILE: ${{ inputs.config-file }}
+        DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_CHARTS: ${{ inputs.charts }}
+      run: |
+        ARGS="generate --repo-url $REPO_URL --max-versions $MAX_VERSIONS --max-commits $MAX_COMMITS --config $CONFIG_FILE"
+
+        if [ "$DRY_RUN" = "true" ]; then
+          ARGS="$ARGS --dry-run"
+        fi
+
+        for chart in $INPUT_CHARTS; do
+          ARGS="$ARGS -c $chart"
+        done
+
+        python scripts/generate-changelog.py $ARGS
+
+        CHANGED=$(git diff --name-only -- 'charts/*/CHANGELOG.md' | sed 's|charts/||;s|/CHANGELOG.md||' | paste -sd,)
+        echo "changed-charts=$CHANGED" >> "$GITHUB_OUTPUT"
+
+    - name: Generate release notes (single version)
+      id: release-notes
+      if: inputs.mode == 'release-notes'
+      shell: bash
+      env:
+        REPO_URL: ${{ steps.repo-url.outputs.url }}
+        MAX_COMMITS: ${{ inputs.max-commits }}
+        CONFIG_FILE: ${{ inputs.config-file }}
+        CHART_NAME: ${{ inputs.chart }}
+        OUTPUT_FILE: ${{ inputs.output-file }}
+      run: |
+        python scripts/generate-changelog.py release-notes "$CHART_NAME" \
+          --repo-url "$REPO_URL" \
+          --max-commits "$MAX_COMMITS" \
+          --config "$CONFIG_FILE" \
+          -o "$OUTPUT_FILE"
+
+        echo "file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
+
+        VERSION=$(yq eval '.version' "charts/${CHART_NAME}/Chart.yaml")
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/changelog-and-release.yaml
+++ b/.github/workflows/changelog-and-release.yaml
@@ -12,23 +12,8 @@ on:
         description: 'Specific chart to process (e.g., "nginx"). Leave empty to process all changed charts.'
         required: false
         type: string
-      regenerate_changelog:
-        description: 'Delete and regenerate the changelog for the specified chart'
-        required: false
-        type: boolean
-        default: false
       force_release:
         description: 'Force re-release of the specified chart (deletes existing tag)'
-        required: false
-        type: boolean
-        default: false
-      reset_all_changelogs:
-        description: '⚠️ Delete and regenerate ALL changelogs (ignores chart_name)'
-        required: false
-        type: boolean
-        default: false
-      skip_changelog:
-        description: 'Skip changelog generation completely'
         required: false
         type: boolean
         default: false
@@ -43,412 +28,10 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  changelog-update:
-    name: Update Changelogs
-    if: |
-      github.event.inputs.skip_changelog != 'true' &&
-      (github.event_name == 'workflow_dispatch' ||
-       (github.event.head_commit.author.name != 'cloudpirates-bot' &&
-        github.event.head_commit.committer.name != 'cloudpirates-bot'))
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: write
-    outputs:
-      has_changes: ${{ steps.generate-changelog.outputs.has_changes }}
-    steps:
-      - name: Checkout main branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.CHANGELOG_PAT || secrets.GITHUB_TOKEN }}
-
-      - name: Fetch all tags
-        run: git fetch --tags --force
-
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod +x /usr/local/bin/yq
-
-      - name: Determine charts to update
-        id: charts-to-update
-        run: |
-          # For manual workflow_dispatch with reset_all_changelogs
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.reset_all_changelogs }}" = "true" ]; then
-            echo "⚠️ Reset all changelogs enabled: processing ALL charts"
-            all_charts=$(find charts -mindepth 1 -maxdepth 1 -type d ! -name 'common' -exec basename {} \; | tr '\n' ',' | sed 's/,$//')
-            echo "Found charts: $all_charts"
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "changedCharts=$all_charts" >> $GITHUB_OUTPUT
-            echo "manual_chart=false" >> $GITHUB_OUTPUT
-            echo "reset_all=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # For manual workflow_dispatch with specific chart
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.chart_name }}" ]; then
-            CHART_NAME="${{ github.event.inputs.chart_name }}"
-            echo "Manual trigger for specific chart: $CHART_NAME"
-
-            if [ ! -d "charts/$CHART_NAME" ]; then
-              echo "❌ Error: Chart 'charts/$CHART_NAME' not found"
-              exit 1
-            fi
-
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "changedCharts=$CHART_NAME" >> $GITHUB_OUTPUT
-            echo "manual_chart=true" >> $GITHUB_OUTPUT
-            echo "reset_all=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # For manual workflow_dispatch without specific options - process ALL charts
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Manual trigger without specific chart: processing ALL charts"
-            all_charts=$(find charts -mindepth 1 -maxdepth 1 -type d ! -name 'common' -exec basename {} \; | tr '\n' ',' | sed 's/,$//')
-            echo "Found charts: $all_charts"
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "changedCharts=$all_charts" >> $GITHUB_OUTPUT
-            echo "manual_chart=false" >> $GITHUB_OUTPUT
-            echo "reset_all=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # For automatic push events, check what changed
-          BEFORE_SHA="${{ github.event.before }}"
-
-          # If BEFORE_SHA is still empty, use HEAD~1 as fallback
-          if [ -z "$BEFORE_SHA" ]; then
-            echo "No before SHA found, using HEAD~1"
-            BEFORE_SHA=$(git rev-parse HEAD~1 2>/dev/null || echo "")
-          fi
-
-          # If still no BEFORE_SHA, get all charts
-          if [ -z "$BEFORE_SHA" ]; then
-            echo "Cannot determine previous commit, processing all charts"
-            all_charts=$(find charts -mindepth 1 -maxdepth 1 -type d ! -name 'common' -exec basename {} \; | tr '\n' ',' | sed 's/,$//')
-            echo "Found charts: $all_charts"
-            echo "changed=true" >> $GITHUB_OUTPUT
-            echo "changedCharts=$all_charts" >> $GITHUB_OUTPUT
-            echo "manual_chart=false" >> $GITHUB_OUTPUT
-            echo "reset_all=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          changed_files=$(git diff --name-only "${BEFORE_SHA}" HEAD -- 'charts/**' 2>/dev/null || echo "")
-
-          if [[ -n "$changed_files" ]]; then
-            changed_charts=$(echo "$changed_files" | grep '^charts/' | cut -d/ -f2 | sort -u | grep -v '^common$' | tr '\n' ',')
-            if [[ -n "$changed_charts" ]]; then
-              echo "Changed charts: $changed_charts"
-              echo "changed=true" >> $GITHUB_OUTPUT
-              echo "changedCharts=${changed_charts}" >> $GITHUB_OUTPUT
-              echo "manual_chart=false" >> $GITHUB_OUTPUT
-              echo "reset_all=false" >> $GITHUB_OUTPUT
-            else
-              echo "No chart changes detected"
-              echo "changed=false" >> $GITHUB_OUTPUT
-              echo "manual_chart=false" >> $GITHUB_OUTPUT
-              echo "reset_all=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No chart changes detected"
-            echo "changed=false" >> $GITHUB_OUTPUT
-            echo "manual_chart=false" >> $GITHUB_OUTPUT
-            echo "reset_all=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Generate changelogs
-        id: generate-changelog
-        if: steps.charts-to-update.outputs.changed == 'true'
-        env:
-          REGENERATE: ${{ github.event.inputs.regenerate_changelog == 'true' || github.event.inputs.reset_all_changelogs == 'true' }}
-        run: |
-          set -e
-
-          IFS=',' read -ra CHARTS <<< "${{ steps.charts-to-update.outputs.changedCharts }}"
-
-          for CHART_NAME in "${CHARTS[@]}"; do
-            CHART_NAME=$(echo "$CHART_NAME" | xargs) # trim whitespace
-            [ -z "$CHART_NAME" ] && continue
-
-            echo "Processing changelog for: $CHART_NAME"
-            CHART_DIR="charts/$CHART_NAME"
-            CHANGELOG_FILE="$CHART_DIR/CHANGELOG.md"
-            CHART_VERSION=$(yq eval '.version' "$CHART_DIR/Chart.yaml")
-
-            # Delete existing changelog if regenerate is enabled
-            if [ "$REGENERATE" = "true" ] && [ -f "$CHANGELOG_FILE" ]; then
-              echo "Deleting existing $CHANGELOG_FILE for regeneration"
-              rm "$CHANGELOG_FILE"
-            fi
-
-            # Create or append to changelog
-            if [ ! -f "$CHANGELOG_FILE" ]; then
-              echo "# Changelog" > "$CHANGELOG_FILE"
-              echo "" >> "$CHANGELOG_FILE"
-              echo "All notable changes to this chart will be documented in this file." >> "$CHANGELOG_FILE"
-              echo "" >> "$CHANGELOG_FILE"
-            fi
-
-            # Get all tags for this chart
-            TAGS=$(git tag -l "${CHART_NAME}-*" | sort -V -r || echo "")
-
-            if [ -z "$TAGS" ]; then
-              echo "No tags found for $CHART_NAME, skipping historical generation"
-              continue
-            fi
-
-            # Create temp file for new content
-            TEMP_FILE=$(mktemp)
-            echo "# Changelog" > "$TEMP_FILE"
-            echo "" >> "$TEMP_FILE"
-            echo "All notable changes to this chart will be documented in this file." >> "$TEMP_FILE"
-            echo "" >> "$TEMP_FILE"
-
-            # Process each tag (use process substitution to avoid subshell)
-            while IFS= read -r TAG; do
-              [ -z "$TAG" ] && continue
-
-              VERSION="${TAG#${CHART_NAME}-}"
-              TAG_DATE=$(git log -1 --format=%ai "$TAG" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
-
-              # Get previous tag
-              PREV_TAG=$(git tag -l "${CHART_NAME}-*" | sort -V -r | grep -A1 "^${TAG}$" | tail -1)
-
-              echo "## [$VERSION] - $TAG_DATE" >> "$TEMP_FILE"
-              echo "" >> "$TEMP_FILE"
-
-              # Get commits between tags
-              if [ -n "$PREV_TAG" ] && [ "$PREV_TAG" != "$TAG" ]; then
-                COMMIT_RANGE="${PREV_TAG}..${TAG}"
-
-                # Get commits for this chart
-                while IFS= read -r COMMIT_LINE; do
-                  [ -z "$COMMIT_LINE" ] && continue
-
-                  COMMIT_HASH=$(echo "$COMMIT_LINE" | awk '{print $1}')
-                  COMMIT_MSG=$(echo "$COMMIT_LINE" | cut -d' ' -f2-)
-
-                  # Skip maintenance/bot commits that shouldn't be in changelog
-                  if echo "$COMMIT_MSG" | grep -qiE '(chore:.*CHANGELOG|chore:.*changelog|auto-generate.*schema|regenerate.*CHANGELOG|reset.*CHANGELOG)'; then
-                    continue
-                  fi
-
-                  # Clean up commit message
-                  COMMIT_MSG=$(echo "$COMMIT_MSG" | sed -E "s/^\[${CHART_NAME}\] //i" | sed -E 's/^\[all\] //i')
-
-                  echo "- $COMMIT_MSG ([${COMMIT_HASH}](https://github.com/${{ github.repository }}/commit/${COMMIT_HASH}))" >> "$TEMP_FILE"
-                done < <(git log "$COMMIT_RANGE" --oneline --no-merges -- "$CHART_DIR" 2>/dev/null || true)
-              else
-                echo "- Initial release" >> "$TEMP_FILE"
-              fi
-
-              echo "" >> "$TEMP_FILE"
-            done < <(echo "$TAGS")
-
-            # Replace old changelog
-            mv "$TEMP_FILE" "$CHANGELOG_FILE"
-            echo "✅ Generated changelog for $CHART_NAME"
-          done
-
-          # Check if there are changes
-          echo "Checking for changelog changes..."
-          git status --porcelain
-
-          # If regenerate mode is enabled, always commit (even if content is identical)
-          if [ "$REGENERATE" = "true" ]; then
-            echo "✅ Regenerate mode enabled - forcing commit"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          elif git status --porcelain | grep -q 'CHANGELOG.md'; then
-            echo "✅ Changelog changes detected"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️ No changelog changes detected"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Update ArtifactHub changes annotations
-        id: update-ah-changes
-        if: steps.charts-to-update.outputs.changed == 'true'
-        env:
-          GH_REPO: ${{ github.repository }}
-          AH_PYTHON_SCRIPT: |
-            import subprocess, re, os, sys
-
-            chart_name = os.environ['AH_CHART_NAME']
-            chart_dir = os.environ['AH_CHART_DIR']
-            commit_range = os.environ['AH_COMMIT_RANGE']
-            repo = os.environ['AH_REPO']
-
-            result = subprocess.run(
-                ["git", "log", commit_range, "--oneline", "--no-merges", "--", chart_dir],
-                capture_output=True, text=True
-            )
-
-            # Find the first (most recent) non-maintenance commit — this is the PR title
-            title = None
-            for line in result.stdout.strip().split('\n'):
-                if not line.strip():
-                    continue
-                parts = line.split(' ', 1)
-                if len(parts) < 2:
-                    continue
-                _, msg = parts
-                if re.search(r'(chore:.*changelog|auto-generate.*schema|regenerate.*changelog|reset.*changelog)', msg, re.I):
-                    continue
-                msg = re.sub(rf'^\[{re.escape(chart_name)}\][:\s]+', '', msg, flags=re.I)
-                msg = re.sub(r'^\[all\][:\s]+', '', msg, flags=re.I)
-                msg = msg.strip()
-                if msg:
-                    title = msg
-                    break
-
-            if not title:
-                sys.exit(0)
-
-            # Extract PR number from title if present (e.g. "Fix something (#123)")
-            pr_match = re.search(r'\(#(\d+)\)$', title)
-            pr_num = pr_match.group(1) if pr_match else None
-            title = re.sub(r'\s*\(#\d+\)$', '', title).strip()
-
-            kind = 'changed'
-            if re.search(r'\b(fix(es|ed)?|bugfix)\b', title, re.I):
-                kind = 'fixed'
-            elif re.search(r'\b(add(s|ed)?|new|feat(ure)?)\b', title, re.I):
-                kind = 'added'
-            elif re.search(r'\bsecurity\b', title, re.I):
-                kind = 'security'
-            elif re.search(r'\b(remov(es|ed)?|delet(es|ed)?)\b', title, re.I):
-                kind = 'removed'
-            elif re.search(r'\bdeprecate(s|d)?\b', title, re.I):
-                kind = 'deprecated'
-
-            lines = []
-            lines.append(f'- kind: {kind}')
-            lines.append(f'  description: "{title.replace(chr(34), chr(92)+chr(34))}"')
-            lines.append(f'  links:')
-            if pr_num:
-                lines.append(f'    - name: "Pull Request"')
-                lines.append(f'      url: "https://github.com/{repo}/pull/{pr_num}"')
-            lines.append(f'    - name: "Changelog"')
-            lines.append(f'      url: "https://github.com/{repo}/blob/main/charts/{chart_name}/CHANGELOG.md"')
-
-            print('\n'.join(lines))
-        run: |
-          set -e
-          IFS=',' read -ra CHARTS <<< "${{ steps.charts-to-update.outputs.changedCharts }}"
-
-          for CHART_NAME in "${CHARTS[@]}"; do
-            CHART_NAME=$(echo "$CHART_NAME" | xargs)
-            [ -z "$CHART_NAME" ] && continue
-
-            CHART_DIR="charts/$CHART_NAME"
-            [ ! -f "$CHART_DIR/Chart.yaml" ] && continue
-
-            CHART_VERSION=$(yq eval '.version' "$CHART_DIR/Chart.yaml")
-            CURRENT_TAG="${CHART_NAME}-${CHART_VERSION}"
-
-            if git tag -l | grep -q "^${CURRENT_TAG}$"; then
-              PREV_TAG=$(git tag -l "${CHART_NAME}-*" | sort -V | grep -B1 "^${CURRENT_TAG}$" | head -1)
-              if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$CURRENT_TAG" ]; then
-                echo "⚠️ No previous tag for $CHART_NAME, skipping"
-                continue
-              fi
-              COMMIT_RANGE="${PREV_TAG}..${CURRENT_TAG}"
-            else
-              LATEST_TAG=$(git tag -l "${CHART_NAME}-*" | sort -V | tail -1)
-              if [ -z "$LATEST_TAG" ]; then
-                echo "⚠️ No tags found for $CHART_NAME, skipping"
-                continue
-              fi
-              COMMIT_RANGE="${LATEST_TAG}..HEAD"
-            fi
-
-            echo "Updating ArtifactHub annotation for $CHART_NAME ($COMMIT_RANGE)"
-
-            export AH_CHART_NAME="$CHART_NAME"
-            export AH_CHART_DIR="$CHART_DIR"
-            export AH_COMMIT_RANGE="$COMMIT_RANGE"
-            export AH_REPO="$GH_REPO"
-
-            CHANGES_YAML=$(echo "$AH_PYTHON_SCRIPT" | python3 -)
-
-            if [ -n "$CHANGES_YAML" ]; then
-              export CHANGES_YAML
-              yq eval '.annotations["artifacthub.io/changes"] = strenv(CHANGES_YAML)' -i "$CHART_DIR/Chart.yaml"
-              echo "✅ Updated artifacthub.io/changes for $CHART_NAME"
-            else
-              echo "⚠️ No relevant commits found for $CHART_NAME annotation"
-            fi
-          done
-
-          if git status --porcelain | grep -q 'Chart.yaml'; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit and push changelog updates
-        if: steps.generate-changelog.outputs.has_changes == 'true' || steps.update-ah-changes.outputs.has_changes == 'true'
-        run: |
-          # Setup SSH key for signing
-          mkdir -p ~/.ssh
-          echo "${{ secrets.BOT_SSH_SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
-
-          # Configure git with SSH signing
-          git config user.name 'cloudpirates-bot'
-          git config user.email 'cloudpirates-bot@users.noreply.github.com'
-          git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
-          git config commit.gpgsign true
-
-          # Add changelog files (use -f to force add even if no changes detected)
-          find charts -name "CHANGELOG.md" -type f -exec git add {} \;
-          find charts -name "Chart.yaml" -type f -exec git add {} \;
-
-          # Check if there's actually something to commit
-          if git diff --cached --quiet; then
-            echo "⚠️ No changes to commit after git add"
-            rm -f ~/.ssh/signing_key
-            exit 0
-          fi
-
-          # Determine commit message
-          if [ "${{ github.event.inputs.reset_all_changelogs }}" = "true" ]; then
-            COMMIT_MSG="chore: reset and regenerate ALL CHANGELOG.md files"
-          elif [ "${{ github.event.inputs.regenerate_changelog }}" = "true" ]; then
-            if [ -n "${{ github.event.inputs.chart_name }}" ]; then
-              COMMIT_MSG="chore: regenerate CHANGELOG.md for ${{ github.event.inputs.chart_name }}"
-            else
-              COMMIT_MSG="chore: regenerate CHANGELOG.md"
-            fi
-          elif [ "${{ steps.charts-to-update.outputs.manual_chart }}" = "true" ]; then
-            COMMIT_MSG="chore: update CHANGELOG.md for ${{ github.event.inputs.chart_name }}"
-          else
-            COMMIT_MSG="chore: update CHANGELOG.md for merged changes"
-          fi
-
-          git commit -m "$COMMIT_MSG" \
-            -m "Signed-off-by: cloudpirates-bot <cloudpirates-bot@users.noreply.github.com>"
-
-          # Pull and push
-          git pull --rebase origin main
-          git push origin main
-
-          # Cleanup
-          rm -f ~/.ssh/signing_key
-
   release:
     name: Release Charts
-    needs: changelog-update
     if: |
-      always() &&
-      !cancelled() &&
       github.event.inputs.skip_release != 'true' &&
-      (needs.changelog-update.result == 'success' || needs.changelog-update.result == 'skipped') &&
       (github.event_name == 'workflow_dispatch' ||
        (github.event.head_commit.author.name != 'cloudpirates-bot' &&
         github.event.head_commit.committer.name != 'cloudpirates-bot'))
@@ -465,18 +48,19 @@ jobs:
           ref: main
 
       - name: Configure Git
+        env:
+          SSH_SIGNING_KEY: ${{ secrets.BOT_SSH_SIGNING_KEY }}
         run: |
-          # Setup SSH key for signing
-          mkdir -p ~/.ssh
-          echo "${{ secrets.BOT_SSH_SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
-
-          # Configure git with SSH signing
           git config user.name 'cloudpirates-bot'
           git config user.email 'cloudpirates-bot@users.noreply.github.com'
-          git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
-          git config commit.gpgsign true
+          if [ -n "$SSH_SIGNING_KEY" ]; then
+            mkdir -p ~/.ssh
+            echo "$SSH_SIGNING_KEY" > ~/.ssh/signing_key
+            chmod 600 ~/.ssh/signing_key
+            git config gpg.format ssh
+            git config user.signingkey ~/.ssh/signing_key
+            git config commit.gpgsign true
+          fi
 
       - name: Login to Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -492,10 +76,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install yq
+      - name: Install tools
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
+          pip install gitpython pyyaml click
 
       - name: Update chart dependencies
         run: |
@@ -511,46 +96,42 @@ jobs:
 
       - name: Detect changed charts
         id: detect-changed-charts
+        env:
+          INPUT_CHART_NAME: ${{ github.event.inputs.chart_name || '' }}
+          INPUT_FORCE_RELEASE: ${{ github.event.inputs.force_release || 'false' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           CHANGED_CHARTS=""
 
-          # Check if force_release is enabled for a specific chart
-          if [ "${{ github.event.inputs.force_release }}" = "true" ] && [ -n "${{ github.event.inputs.chart_name }}" ]; then
-            FORCE_CHART="${{ github.event.inputs.chart_name }}"
-            echo "Force release enabled for chart: $FORCE_CHART"
+          # Force release a specific chart
+          if [ "$INPUT_FORCE_RELEASE" = "true" ] && [ -n "$INPUT_CHART_NAME" ]; then
+            echo "Force release enabled for chart: $INPUT_CHART_NAME"
 
-            if [ ! -d "charts/$FORCE_CHART" ]; then
-              echo "❌ Error: Chart 'charts/$FORCE_CHART' not found"
+            if [ ! -d "charts/$INPUT_CHART_NAME" ]; then
+              echo "❌ Error: Chart 'charts/$INPUT_CHART_NAME' not found"
               exit 1
             fi
 
-            if [ ! -f "charts/$FORCE_CHART/Chart.yaml" ]; then
-              echo "❌ Error: Chart.yaml not found in 'charts/$FORCE_CHART'"
-              exit 1
+            CHART_VERSION=$(yq eval '.version' "charts/$INPUT_CHART_NAME/Chart.yaml")
+            echo "🚀 Force releasing: $INPUT_CHART_NAME-$CHART_VERSION"
+
+            if git tag -l | grep -q "^${INPUT_CHART_NAME}-${CHART_VERSION}$"; then
+              echo "Deleting existing tag: ${INPUT_CHART_NAME}-${CHART_VERSION}"
+              git tag -d "${INPUT_CHART_NAME}-${CHART_VERSION}" || true
+              git push origin ":refs/tags/${INPUT_CHART_NAME}-${CHART_VERSION}" || true
             fi
 
-            CHART_VERSION=$(yq eval '.version' "charts/$FORCE_CHART/Chart.yaml")
-            echo "🚀 Force releasing: $FORCE_CHART-$CHART_VERSION"
-
-            # Delete the existing tag if it exists to allow re-release
-            if git tag -l | grep -q "^${FORCE_CHART}-${CHART_VERSION}$"; then
-              echo "Deleting existing tag: ${FORCE_CHART}-${CHART_VERSION}"
-              git tag -d "${FORCE_CHART}-${CHART_VERSION}" || true
-              git push origin ":refs/tags/${FORCE_CHART}-${CHART_VERSION}" || true
-            fi
-
-            CHANGED_CHARTS="$FORCE_CHART"
-            echo "changed_charts=$CHANGED_CHARTS" >> $GITHUB_OUTPUT
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "force_release=true" >> $GITHUB_OUTPUT
+            CHANGED_CHARTS="$INPUT_CHART_NAME"
+            echo "changed_charts=$CHANGED_CHARTS" >> "$GITHUB_OUTPUT"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "force_release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Normal detection logic
-          # If a specific chart was requested via workflow_dispatch, only process that chart
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.chart_name }}" ]; then
-            CHART_DIRS="charts/${{ github.event.inputs.chart_name }}"
+          # Manual trigger for a specific chart
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_CHART_NAME" ]; then
+            CHART_DIRS="charts/$INPUT_CHART_NAME"
           else
             CHART_DIRS="charts/*"
           fi
@@ -561,27 +142,89 @@ jobs:
             CHART_NAME=$(basename "$chart_dir")
             CHART_VERSION=$(yq eval '.version' "$chart_dir/Chart.yaml")
 
-            # Check if already released
             if git tag -l | grep -q "^${CHART_NAME}-${CHART_VERSION}$"; then
               echo "✓ $CHART_NAME-$CHART_VERSION already released"
               continue
             fi
 
-            # Check for changes since last release
             LAST_CHART_TAG=$(git tag -l "${CHART_NAME}-*" | sort -V | tail -1)
             if [ -n "$LAST_CHART_TAG" ]; then
               CHART_CHANGES=$(git diff --name-only "$LAST_CHART_TAG" HEAD -- "$chart_dir/" 2>/dev/null || echo "")
               [ -z "$CHART_CHANGES" ] && continue
             fi
 
-            # Add to release list
             [ -z "$CHANGED_CHARTS" ] && CHANGED_CHARTS="$CHART_NAME" || CHANGED_CHARTS="$CHANGED_CHARTS,$CHART_NAME"
             echo "🚀 Will release: $CHART_NAME-$CHART_VERSION"
           done
 
-          echo "changed_charts=$CHANGED_CHARTS" >> $GITHUB_OUTPUT
-          [ -n "$CHANGED_CHARTS" ] && echo "has_changes=true" >> $GITHUB_OUTPUT || echo "has_changes=false" >> $GITHUB_OUTPUT
-          echo "force_release=false" >> $GITHUB_OUTPUT
+          echo "changed_charts=$CHANGED_CHARTS" >> "$GITHUB_OUTPUT"
+          [ -n "$CHANGED_CHARTS" ] && echo "has_changes=true" >> "$GITHUB_OUTPUT" || echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          echo "force_release=false" >> "$GITHUB_OUTPUT"
+
+      - name: Update artifacthub.io/changes annotations
+        if: steps.detect-changed-charts.outputs.has_changes == 'true'
+        env:
+          CHANGED_CHARTS: ${{ steps.detect-changed-charts.outputs.changed_charts }}
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          for CHART_NAME in ${CHANGED_CHARTS//,/ }; do
+            CHART_DIR="charts/$CHART_NAME"
+            [ ! -f "$CHART_DIR/Chart.yaml" ] && continue
+
+            CHART_VERSION=$(yq eval '.version' "$CHART_DIR/Chart.yaml")
+            CURRENT_TAG="${CHART_NAME}-${CHART_VERSION}"
+
+            # Determine commit range
+            if git tag -l | grep -q "^${CURRENT_TAG}$"; then
+              PREV_TAG=$(git tag -l "${CHART_NAME}-*" | sort -V | grep -B1 "^${CURRENT_TAG}$" | head -1)
+              if [ -z "$PREV_TAG" ] || [ "$PREV_TAG" = "$CURRENT_TAG" ]; then
+                echo "⚠️ No previous tag for $CHART_NAME, skipping ArtifactHub annotation"
+                continue
+              fi
+              COMMIT_RANGE="${PREV_TAG}..${CURRENT_TAG}"
+            else
+              LATEST_TAG=$(git tag -l "${CHART_NAME}-*" | sort -V | tail -1)
+              if [ -z "$LATEST_TAG" ]; then
+                echo "⚠️ No tags found for $CHART_NAME, skipping ArtifactHub annotation"
+                continue
+              fi
+              COMMIT_RANGE="${LATEST_TAG}..HEAD"
+            fi
+
+            echo "Generating ArtifactHub annotation for $CHART_NAME ($COMMIT_RANGE)"
+
+            # Generate changes YAML from commit messages
+            CHANGES_YAML=$(git log --pretty=format:"%s" "$COMMIT_RANGE" -- "$CHART_DIR/" | \
+              grep -v "^Merge " | grep -v "^chore: update CHANGELOG" | \
+              python3 -c "
+          import sys, re
+          kinds = {'feat': 'added', 'fix': 'fixed', 'chore': 'changed', 'refactor': 'changed', 'docs': 'changed', 'sec': 'security'}
+          lines = []
+          for msg in sys.stdin:
+              msg = msg.strip()
+              if not msg:
+                  continue
+              m = re.match(r'^(\w+)(?:\([^)]*\))?!?:\s*(.+)', msg)
+              kind = kinds.get(m.group(1), 'changed') if m else 'changed'
+              desc = m.group(2) if m else msg
+              pr = re.search(r'\(#(\d+)\)', desc)
+              links = ''
+              if pr:
+                  links = f'\n    links:\n      - name: \"Pull Request\"\n        url: \"$REPO_URL/pull/{pr.group(1)}\"'
+              lines.append(f'- kind: {kind}\n  description: \"{desc}\"{links}')
+          print('\n'.join(lines))
+          ")
+
+            if [ -n "$CHANGES_YAML" ]; then
+              export CHANGES_YAML
+              yq eval '.annotations["artifacthub.io/changes"] = strenv(CHANGES_YAML)' -i "$CHART_DIR/Chart.yaml"
+              echo "✅ Updated artifacthub.io/changes for $CHART_NAME"
+            else
+              echo "⚠️ No relevant commits found for $CHART_NAME annotation"
+            fi
+          done
 
       - name: Run chart-releaser
         if: steps.detect-changed-charts.outputs.has_changes == 'true'
@@ -604,18 +247,18 @@ jobs:
           string: ${{ github.repository_owner }}
 
       - name: Upload charts to OCI registries
+        id: upload-charts
         if: steps.detect-changed-charts.outputs.has_changes == 'true'
         env:
           COSIGN_KEY: ${{ secrets.COSIGN_KEY }}
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          CHANGED_CHARTS: ${{ steps.detect-changed-charts.outputs.changed_charts }}
         run: |
           set -euo pipefail
 
-          CHANGED_CHARTS="${{ steps.detect-changed-charts.outputs.changed_charts }}"
           [ -z "$CHANGED_CHARTS" ] && exit 0
 
-          # Retry function
           retry() {
             local max_attempts=3
             local attempt=1
@@ -630,7 +273,7 @@ jobs:
             return 1
           }
 
-          retry helm registry login --username $REGISTRY_USER --password ${{ secrets.REGISTRY_PASSWORD }} https://${{ vars.REGISTRY }}
+          retry helm registry login --username "$REGISTRY_USER" --password ${{ secrets.REGISTRY_PASSWORD }} https://${{ vars.REGISTRY }}
           retry helm registry login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} https://ghcr.io
 
           RELEASED_CHARTS=""
@@ -640,45 +283,82 @@ jobs:
 
             CHART_VERSION=$(yq eval '.version' "Chart.yaml")
 
-            # Push to primary registry
             echo "Pushing $CHART_NAME-$CHART_VERSION to primary registry..."
-            if retry helm push ${{ github.workspace }}/.cr-release-packages/${CHART_NAME}-${CHART_VERSION}.tgz oci://${{ vars.REGISTRY }}/${{ vars.REPOSITORY }} 2>&1 | tee output.log; then
+            if retry helm push "${{ github.workspace }}/.cr-release-packages/${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}" 2>&1 | tee output.log; then
               DIGEST=$(grep -oP 'Digest:\s*\K(sha256:[a-f0-9]+)' output.log || echo "")
               if [ -n "$DIGEST" ]; then
-                cosign sign -y --upload=true --key env://COSIGN_KEY ${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/${CHART_NAME}:${CHART_VERSION}@$DIGEST
+                cosign sign -y --upload=true --key env://COSIGN_KEY "${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}/${CHART_NAME}:${CHART_VERSION}@$DIGEST"
                 RELEASED_CHARTS="$RELEASED_CHARTS ${CHART_NAME}"
               fi
             fi
 
-            # Push to GHCR
             echo "Pushing $CHART_NAME-$CHART_VERSION to GHCR..."
-            if retry helm push ${{ github.workspace }}/.cr-release-packages/${CHART_NAME}-${CHART_VERSION}.tgz oci://ghcr.io/${{ steps.github-repo-owner-name.outputs.lowercase }}/helm-charts 2>&1 | tee ghcr-output.log; then
+            if retry helm push "${{ github.workspace }}/.cr-release-packages/${CHART_NAME}-${CHART_VERSION}.tgz" "oci://ghcr.io/${{ steps.github-repo-owner-name.outputs.lowercase }}/helm-charts" 2>&1 | tee ghcr-output.log; then
               GHCR_DIGEST=$(grep -oP 'Digest:\s*\K(sha256:[a-f0-9]+)' ghcr-output.log || echo "")
-              [ -n "$GHCR_DIGEST" ] && cosign sign -y --upload=true --key env://COSIGN_KEY ghcr.io/${{ steps.github-repo-owner-name.outputs.lowercase }}/helm-charts/${CHART_NAME}:${CHART_VERSION}@$GHCR_DIGEST
+              [ -n "$GHCR_DIGEST" ] && cosign sign -y --upload=true --key env://COSIGN_KEY "ghcr.io/${{ steps.github-repo-owner-name.outputs.lowercase }}/helm-charts/${CHART_NAME}:${CHART_VERSION}@$GHCR_DIGEST"
             fi
 
-            cd ${{ github.workspace }}
+            cd "${{ github.workspace }}"
           done
 
           echo "released_charts=$RELEASED_CHARTS" >> "$GITHUB_OUTPUT"
 
-          if [ -n "$RELEASED_CHARTS" ]; then
-            echo "## 📦 Helm Charts Released" >> $GITHUB_STEP_SUMMARY
+      # ---------------------------------------------------------------
+      # Update GitHub Release notes with scoped per-chart changelogs.
+      # chart-releaser creates the release with default notes;
+      # this step replaces them with rich, classified release notes
+      # generated by scripts/generate-changelog.py.
+      # ---------------------------------------------------------------
+      - name: Update release notes with scoped changelog
+        if: steps.detect-changed-charts.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGED_CHARTS: ${{ steps.detect-changed-charts.outputs.changed_charts }}
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          set -euo pipefail
 
-            if [ "${{ steps.detect-changed-charts.outputs.force_release }}" = "true" ]; then
-              echo "**⚠️ Force Release Mode** - Chart: \`${{ github.event.inputs.chart_name }}\`" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-            elif [ -n "${{ github.event.inputs.chart_name }}" ]; then
-              echo "**Manual Release** - Chart: \`${{ github.event.inputs.chart_name }}\`" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
+          for CHART_NAME in ${CHANGED_CHARTS//,/ }; do
+            CHART_VERSION=$(yq eval '.version' "charts/$CHART_NAME/Chart.yaml")
+            TAG="${CHART_NAME}-${CHART_VERSION}"
+
+            echo "Generating release notes for $TAG..."
+            python scripts/generate-changelog.py release-notes "$CHART_NAME" \
+              --repo-url "$REPO_URL" \
+              -o "/tmp/release-notes-${CHART_NAME}.md"
+
+            if gh release view "$TAG" > /dev/null 2>&1; then
+              gh release edit "$TAG" --notes-file "/tmp/release-notes-${CHART_NAME}.md"
+              echo "✅ Updated release notes for $TAG"
+            else
+              echo "⚠️ Release $TAG not found — skipping notes update"
+            fi
+          done
+
+      - name: Job summary
+        if: steps.detect-changed-charts.outputs.has_changes == 'true'
+        env:
+          RELEASED_CHARTS: ${{ steps.upload-charts.outputs.released_charts }}
+          FORCE_RELEASE: ${{ steps.detect-changed-charts.outputs.force_release }}
+          INPUT_CHART_NAME: ${{ github.event.inputs.chart_name || '' }}
+        run: |
+          if [ -n "$RELEASED_CHARTS" ]; then
+            echo "## 📦 Helm Charts Released" >> "$GITHUB_STEP_SUMMARY"
+
+            if [ "$FORCE_RELEASE" = "true" ]; then
+              echo "**⚠️ Force Release Mode** - Chart: \`${INPUT_CHART_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            elif [ -n "$INPUT_CHART_NAME" ]; then
+              echo "**Manual Release** - Chart: \`${INPUT_CHART_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
             fi
 
             for chart in $RELEASED_CHARTS; do
-              echo "- ✅ **$chart**" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ **$chart**" >> "$GITHUB_STEP_SUMMARY"
             done
-            echo "### 📍 Registries" >> $GITHUB_STEP_SUMMARY
-            echo "- Primary: \`${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}\`" >> $GITHUB_STEP_SUMMARY
-            echo "- GHCR: \`ghcr.io/${{ steps.github-repo-owner-name.outputs.lowercase }}/helm-charts\`" >> $GITHUB_STEP_SUMMARY
+            echo "### 📍 Registries" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Primary: \`${{ vars.REGISTRY }}/${{ vars.REPOSITORY }}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- GHCR: \`ghcr.io/${{ steps.github-repo-owner-name.outputs.lowercase }}/helm-charts\`" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Cleanup

--- a/scripts/generate-changelog.py
+++ b/scripts/generate-changelog.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+Per-chart changelog generator for CloudPirates helm-charts monorepo.
+
+Generates scoped CHANGELOG.md files for each chart by:
+1. Detecting all charts in charts/
+2. For each chart, finding commits that touched its directory
+3. Grouping commits by chart version (detected from Chart.yaml changes)
+4. Classifying commits using conventional commit patterns
+5. Writing a scoped CHANGELOG.md in each chart directory
+
+Adapted from https://github.com/ixxeL-DevOps/gha-templates/blob/main/changelog.py
+"""
+
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+import click
+import yaml
+
+try:
+    import git
+except ImportError:
+    click.echo("ERROR: gitpython is required. Install with: pip install gitpython", err=True)
+    sys.exit(1)
+
+DEFAULT_GROUPS = [
+    {
+        "title": "💥 Breaking changes",
+        "regexp": r"^.*?(feat|chore|fix)!(?:\(\w+\))?!?: .+$",
+    },
+    {
+        "title": "🚀 New Features",
+        "regexp": r"^.*?feat(?:\(\w+\))?!?: .+$",
+    },
+    {
+        "title": "📦 Dependency updates",
+        "regexp": r"^.*?(?:chore|build|ci)(?:\(\w+\))?!?: .+$",
+    },
+    {
+        "title": "⚠️ Security updates",
+        "regexp": r"^.*?sec(?:\(\w+\))?!?: .+$",
+    },
+    {
+        "title": "🐛 Bug fixes",
+        "regexp": r"^.*?(fix|refactor)(?:\(\w+\))?!?: .+$",
+    },
+    {
+        "title": "📚 Documentation updates",
+        "regexp": r"^.*?docs(?:\(\w+\))?!?: .+$",
+    },
+    {
+        "title": "🔄 Image updates",
+        "regexp": r"^.*(?:Update image\.?\w*|update.*image).*$",
+    },
+]
+
+NOISE_PATTERNS = [
+    r"^chore: update CHANGELOG\.md",
+    r"^Merge branch ",
+    r"^chore: update CHANGELOG",
+]
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def discover_charts(repo_root: str) -> list[str]:
+    """Find all chart directories under charts/."""
+    charts_dir = os.path.join(repo_root, "charts")
+    if not os.path.isdir(charts_dir):
+        return []
+    return sorted(
+        d
+        for d in os.listdir(charts_dir)
+        if os.path.isfile(os.path.join(charts_dir, d, "Chart.yaml"))
+    )
+
+
+def get_chart_commits(repo: git.Repo, chart_path: str, max_commits: int = 500) -> list[git.Commit]:
+    """Get all commits that touched a specific chart directory."""
+    return list(repo.iter_commits(paths=chart_path, max_count=max_commits))
+
+
+def get_version_at_commit(repo: git.Repo, commit: git.Commit, chart_yaml_path: str) -> Optional[str]:
+    """Get the chart version from Chart.yaml at a specific commit."""
+    try:
+        blob = commit.tree / chart_yaml_path
+        content = yaml.safe_load(blob.data_stream.read().decode("utf-8"))
+        return content.get("version")
+    except (KeyError, yaml.YAMLError, UnicodeDecodeError):
+        return None
+
+
+def group_commits_by_version(
+    repo: git.Repo, commits: list[git.Commit], chart_name: str
+) -> dict[str, list[git.Commit]]:
+    """Group commits by the chart version they belong to.
+
+    Walks commits chronologically (newest first). When the version in
+    Chart.yaml changes between two consecutive commits, that marks a
+    version boundary.
+    """
+    chart_yaml_path = f"charts/{chart_name}/Chart.yaml"
+    versioned: dict[str, list[git.Commit]] = {}
+    current_version = None
+
+    for commit in commits:
+        version = get_version_at_commit(repo, commit, chart_yaml_path)
+        if version is None:
+            continue
+        if current_version is None:
+            current_version = version
+        if version != current_version:
+            current_version = version
+        versioned.setdefault(current_version, []).append(commit)
+
+    return versioned
+
+
+def is_noise_commit(message: str) -> bool:
+    """Filter out automated/noise commits (changelog updates, merges)."""
+    first_line = message.split("\n", 1)[0].strip()
+    return any(re.match(p, first_line) for p in NOISE_PATTERNS)
+
+
+def is_commit_relevant(commit: git.Commit, chart_name: str) -> bool:
+    """Check if a commit has meaningful changes beyond just a version bump.
+
+    A commit is considered irrelevant if:
+    - It ONLY changes the version field in Chart.yaml
+    - It is an automated noise commit (changelog update, merge)
+    """
+    if is_noise_commit(commit.message):
+        return False
+
+    chart_path = f"charts/{chart_name}/"
+    chart_files_changed = []
+
+    for parent in commit.parents:
+        diff = parent.diff(commit)
+        for d in diff:
+            path = d.b_path or d.a_path
+            if path and path.startswith(chart_path):
+                chart_files_changed.append(path)
+
+    if not chart_files_changed:
+        return False
+
+    if chart_files_changed == [f"charts/{chart_name}/Chart.yaml"]:
+        return False
+
+    return True
+
+
+def classify_commit(message: str, groups: list[dict]) -> Optional[str]:
+    """Classify a commit message into a group."""
+    first_line = message.split("\n", 1)[0].strip()
+    for group in groups:
+        if group.get("regexp") and re.match(group["regexp"], first_line):
+            return group["title"]
+    return None
+
+
+def format_author(name: str, email: str, repo_url: str) -> str:
+    """Format author as a GitHub-linkable mention.
+
+    Resolution order:
+    1. GitHub noreply email → extract username → @username
+    2. Bot accounts → @name[bot]
+    3. No spaces in name → assume username → @username
+    4. Fallback → link to GitHub commits by author email
+    """
+    # GitHub noreply pattern: username@users.noreply.github.com
+    # or: 12345+username@users.noreply.github.com
+    noreply_match = re.match(r"(?:\d+\+)?([^@]+)@users\.noreply\.github\.com", email)
+    if noreply_match:
+        return f"@{noreply_match.group(1)}"
+
+    # Bot accounts (already formatted as username[bot])
+    if "[bot]" in name:
+        return f"@{name}"
+
+    # No spaces = likely a username
+    if " " not in name:
+        return f"@{name}"
+
+    # Fallback: link to commits by this author in the repo
+    return f"[{name}]({repo_url}/commits?author={email})"
+
+
+def format_commit_message(commit: git.Commit, repo_url: str) -> str:
+    """Format a single commit as a markdown list item."""
+    msg = commit.message.split("\n", 1)[0].strip()
+    sha_short = commit.hexsha[:8]
+
+    pr_match = re.search(r"\(#(\d+)\)", msg)
+    if pr_match:
+        pr_num = pr_match.group(1)
+        msg = re.sub(
+            r"\(#(\d+)\)",
+            f"([#{pr_num}]({repo_url}/pull/{pr_num}))",
+            msg,
+        )
+
+    author = format_author(commit.author.name, commit.author.email, repo_url)
+
+    return f"- {msg} ([{sha_short}]({repo_url}/commit/{commit.hexsha})) — {author}"
+
+
+def generate_chart_changelog(
+    repo: git.Repo,
+    chart_name: str,
+    repo_url: str,
+    groups: list[dict],
+    max_versions: int = 20,
+    max_commits: int = 500,
+) -> str:
+    """Generate a scoped CHANGELOG.md content for a single chart."""
+    chart_path = f"charts/{chart_name}"
+    commits = get_chart_commits(repo, chart_path, max_commits)
+
+    if not commits:
+        return f"# Changelog — {chart_name}\n\nNo changes recorded.\n"
+
+    versioned = group_commits_by_version(repo, commits, chart_name)
+
+    markdown = f"# Changelog — {chart_name}\n\n"
+    markdown += "All notable changes to this chart will be documented in this file.\n"
+    markdown += "Only commits that directly affect this chart are listed.\n\n"
+
+    version_count = 0
+    for version, version_commits in versioned.items():
+        if version_count >= max_versions:
+            break
+
+        relevant_commits = [c for c in version_commits if is_commit_relevant(c, chart_name)]
+
+        if not relevant_commits and not version_commits:
+            continue
+
+        date = datetime.fromtimestamp(
+            version_commits[0].committed_date, tz=timezone.utc
+        ).strftime("%Y-%m-%d")
+
+        markdown += f"## [{chart_name}-{version}] - {date}\n\n"
+
+        if not relevant_commits:
+            markdown += "_Version bump only — no user-facing changes._\n\n"
+            version_count += 1
+            continue
+
+        classified: dict[str, list[git.Commit]] = {g["title"]: [] for g in groups}
+        classified["🧰 Other work"] = []
+
+        for commit in relevant_commits:
+            group_title = classify_commit(commit.message, groups)
+            if group_title:
+                classified[group_title].append(commit)
+            else:
+                classified["🧰 Other work"].append(commit)
+
+        for title, group_commits in classified.items():
+            if group_commits:
+                markdown += f"### {title}\n\n"
+                for commit in group_commits:
+                    markdown += format_commit_message(commit, repo_url) + "\n"
+                markdown += "\n"
+
+        version_count += 1
+
+    return markdown
+
+
+def generate_release_notes(
+    repo: git.Repo,
+    chart_name: str,
+    repo_url: str,
+    groups: list[dict],
+    max_commits: int = 500,
+) -> tuple[str, str]:
+    """Generate release notes for the latest version of a chart.
+
+    Returns (version, markdown) tuple. The markdown is suitable for
+    injection into a GitHub Release body.
+    """
+    chart_path = f"charts/{chart_name}"
+    commits = get_chart_commits(repo, chart_path, max_commits)
+
+    if not commits:
+        return ("unknown", "No changes recorded.")
+
+    versioned = group_commits_by_version(repo, commits, chart_name)
+
+    if not versioned:
+        return ("unknown", "No versioned changes found.")
+
+    version = next(iter(versioned))
+    version_commits = versioned[version]
+    relevant_commits = [c for c in version_commits if is_commit_relevant(c, chart_name)]
+
+    if not relevant_commits:
+        return (version, "_Version bump only — no user-facing changes._")
+
+    markdown = ""
+    classified: dict[str, list[git.Commit]] = {g["title"]: [] for g in groups}
+    classified["🧰 Other work"] = []
+
+    for commit in relevant_commits:
+        group_title = classify_commit(commit.message, groups)
+        if group_title:
+            classified[group_title].append(commit)
+        else:
+            classified["🧰 Other work"].append(commit)
+
+    for title, group_commits in classified.items():
+        if group_commits:
+            markdown += f"## {title}\n\n"
+            for commit in group_commits:
+                markdown += format_commit_message(commit, repo_url) + "\n"
+            markdown += "\n"
+
+    return (version, markdown.strip())
+
+
+def load_config(config_path: str) -> dict:
+    """Load optional YAML config file."""
+    if os.path.isfile(config_path):
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f) or {}
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Per-chart changelog generator for Helm monorepos."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
+@click.option("--repo-url", default="https://github.com/CloudPirates-io/helm-charts", show_default=True, help="GitHub repository URL.")
+@click.option("--charts", "-c", multiple=True, help="Specific chart(s) to process. Repeat for multiple. Default: all.")
+@click.option("--max-versions", default=20, show_default=True, type=int, help="Maximum versions per chart.")
+@click.option("--max-commits", default=500, show_default=True, type=int, help="Maximum commits to scan per chart.")
+@click.option("--config", "config_path", default=".changelog-config.yml", show_default=True, help="Path to optional YAML config file.")
+@click.option("--dry-run", is_flag=True, help="Print to stdout instead of writing files.")
+def generate(
+    repo_url: str,
+    charts: tuple[str, ...],
+    max_versions: int,
+    max_commits: int,
+    config_path: str,
+    dry_run: bool,
+) -> None:
+    """Generate scoped CHANGELOG.md for each chart."""
+    repo_root = os.getcwd()
+    repo = git.Repo(repo_root)
+
+    config = load_config(config_path)
+    groups = config.get("groups", DEFAULT_GROUPS)
+
+    chart_list = list(charts) or discover_charts(repo_root)
+
+    if not chart_list:
+        raise click.ClickException("No charts found in charts/ directory")
+
+    click.echo(f"Processing {len(chart_list)} chart(s): {', '.join(chart_list)}")
+
+    for chart_name in chart_list:
+        chart_dir = os.path.join(repo_root, "charts", chart_name)
+        if not os.path.isdir(chart_dir):
+            click.secho(f"  SKIP {chart_name} — directory not found", fg="yellow")
+            continue
+
+        click.echo(f"\n{'='*60}")
+        click.secho(f"  Generating changelog for: {chart_name}", fg="cyan", bold=True)
+        click.echo(f"{'='*60}")
+
+        changelog = generate_chart_changelog(
+            repo=repo,
+            chart_name=chart_name,
+            repo_url=repo_url,
+            groups=groups,
+            max_versions=max_versions,
+            max_commits=max_commits,
+        )
+
+        if dry_run:
+            click.echo(changelog)
+        else:
+            output_path = os.path.join(chart_dir, "CHANGELOG.md")
+            with open(output_path, "w") as f:
+                f.write(changelog)
+            click.secho(f"  ✓ Wrote {output_path}", fg="green")
+
+    click.echo("\nDone.")
+
+
+@cli.command("list")
+def list_charts() -> None:
+    """List all discovered charts."""
+    repo_root = os.getcwd()
+    charts = discover_charts(repo_root)
+
+    if not charts:
+        raise click.ClickException("No charts found in charts/ directory")
+
+    click.echo(f"Found {len(charts)} chart(s):\n")
+    for chart in charts:
+        chart_yaml = os.path.join(repo_root, "charts", chart, "Chart.yaml")
+        with open(chart_yaml) as f:
+            data = yaml.safe_load(f)
+        version = data.get("version", "?")
+        click.echo(f"  {chart:<30} v{version}")
+
+
+@cli.command()
+@click.argument("chart_name")
+@click.option("--max-commits", default=100, show_default=True, type=int, help="Maximum commits to scan.")
+def inspect(chart_name: str, max_commits: int) -> None:
+    """Show recent commits for a specific chart (debug helper)."""
+    repo_root = os.getcwd()
+    repo = git.Repo(repo_root)
+    chart_path = f"charts/{chart_name}"
+
+    if not os.path.isdir(os.path.join(repo_root, chart_path)):
+        raise click.ClickException(f"Chart not found: {chart_name}")
+
+    commits = get_chart_commits(repo, chart_path, max_commits)
+    chart_yaml_path = f"charts/{chart_name}/Chart.yaml"
+
+    click.echo(f"Last {len(commits)} commits touching {chart_path}/:\n")
+    for commit in commits[:30]:
+        version = get_version_at_commit(repo, commit, chart_yaml_path) or "?"
+        msg = commit.message.split("\n", 1)[0].strip()[:80]
+        relevant = "✓" if is_commit_relevant(commit, chart_name) else "✗"
+        noise = " (noise)" if is_noise_commit(commit.message) else ""
+        sha = commit.hexsha[:8]
+        click.echo(f"  [{relevant}] {sha}  v{version:<10}  {msg}{noise}")
+
+
+@cli.command("release-notes")
+@click.argument("chart_name")
+@click.option("--repo-url", default="https://github.com/CloudPirates-io/helm-charts", show_default=True, help="GitHub repository URL.")
+@click.option("--max-commits", default=500, show_default=True, type=int, help="Maximum commits to scan.")
+@click.option("--config", "config_path", default=".changelog-config.yml", show_default=True, help="Path to optional YAML config file.")
+@click.option("--output-file", "-o", type=click.Path(), default=None, help="Write to file instead of stdout.")
+def release_notes(
+    chart_name: str,
+    repo_url: str,
+    max_commits: int,
+    config_path: str,
+    output_file: Optional[str],
+) -> None:
+    """Generate release notes for the latest version of a chart.
+
+    Outputs markdown suitable for a GitHub Release body.
+    Use with: gh release create <tag> --notes-file <file>
+    """
+    repo_root = os.getcwd()
+    repo = git.Repo(repo_root)
+    chart_dir = os.path.join(repo_root, "charts", chart_name)
+
+    if not os.path.isdir(chart_dir):
+        raise click.ClickException(f"Chart not found: {chart_name}")
+
+    config = load_config(config_path)
+    groups = config.get("groups", DEFAULT_GROUPS)
+
+    version, markdown = generate_release_notes(
+        repo=repo,
+        chart_name=chart_name,
+        repo_url=repo_url,
+        groups=groups,
+        max_commits=max_commits,
+    )
+
+    if output_file:
+        with open(output_file, "w") as f:
+            f.write(markdown)
+        click.secho(f"Release notes for {chart_name}-{version} written to {output_file}", fg="green")
+    else:
+        click.echo(markdown)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary

Addresses #844 - replace CHANGELOG.md file commits with scoped release notes injected directly into GitHub Releases.

### The problem

The current pipeline generates CHANGELOG.md files per chart and commits them via a bot. This creates several issues:

- **Git history noise**: every chart change triggers a bot commit (`chore: update CHANGELOG.md for merged changes`), doubling the number of commits
- **Unscoped entries**: changelogs reference unrelated charts (e.g., `cluster-operator` versions in the rabbitmq changelog)
- **Hard to assess impact**: users can't tell if an update affects rendered templates or is purely informational
- **Trigger loops**: the bot commit itself can re-trigger the pipeline, requiring author-based skip logic

### The solution

Instead of committing changelog files, generate scoped release notes and inject them into the GitHub Release body created by chart-releaser. This keeps git history clean and puts the changelog where users actually look for it - the release page.

### How it works

```
push to main
  -> detect unreleased charts (version in Chart.yaml has no matching tag)
  -> chart-releaser creates tag + GitHub Release + .tgz package
  -> OCI push + cosign signing
  -> generate-changelog.py release-notes {chart}     <-- NEW
  -> gh release edit {tag} --notes-file ...           <-- NEW
```

The Python script (`scripts/generate-changelog.py`) generates scoped changelogs by:

1. **Path filtering** - `git log -- charts/{chart}/` so only commits touching the chart directory are included
2. **Version grouping** - parses `Chart.yaml` at each commit to detect version boundaries
3. **Noise filtering** - skips automated commits (changelog updates, merges)
4. **Empty bump detection** - marks versions with only `Chart.yaml` changes as "Version bump only"
5. **Conventional commit classification** - breaking changes, features, fixes, image updates, docs, security
6. **Smart author resolution** - GitHub noreply emails to @username, bot accounts to @name[bot], fallback to linked author name

> **Note on commit classification**: the script currently follows [Conventional Commits](https://www.conventionalcommits.org/) patterns (`feat:`, `fix:`, `chore:`, etc.) as it was adapted from one of my personal repos. The classification groups and regex patterns are fully configurable - either via the `DEFAULT_GROUPS` list in the script or through an optional `.changelog-config.yml` file. Feel free to adjust the categories and emojis to match your project's conventions.

### CLI usage

```bash
# Generate release notes for a single chart (for GitHub Release body)
python scripts/generate-changelog.py release-notes rabbitmq

# Generate CHANGELOG.md files (optional, for local use)
python scripts/generate-changelog.py generate --charts rabbitmq redis

# List all charts with versions
python scripts/generate-changelog.py list

# Debug: inspect commits for a chart with relevance markers
python scripts/generate-changelog.py inspect rabbitmq
```

### Changes

| File | Change |
|---|---|
| `scripts/generate-changelog.py` (new) | Python CLI with click - core changelog engine |
| `.github/actions/generate-changelog/action.yaml` (new) | Reusable composite action (generate or release-notes mode) |
| `.github/workflows/changelog-and-release.yaml` (modified) | Remove changelog-update job, add release notes update step after chart-releaser |

### What is removed

- The entire `changelog-update` job (no more bot commits)
- `workflow_dispatch` inputs: `regenerate_changelog`, `reset_all_changelogs`, `skip_changelog`
- ArtifactHub annotation update step (can be re-added if needed)

### Before / After

**Before (rabbitmq CHANGELOG.md):**
```
## [cluster-operator-0.2.1] - 2026-02-24         <-- wrong chart version
- [busybox] Update image to b3255e7 (#941)        <-- unrelated chart
- [all]: Update documentation ...                  <-- not chart-specific
```

**After (GitHub Release body for rabbitmq-0.19.9):**
```
## Image updates
- [rabbitmq] Update image.repository to 23fe4f2 (#1181) - @renovate[bot]
```

### Dependencies

```
pip install gitpython pyyaml click
```

