### PR TITLE
[zookeeper] feat: enable TLS and authenticated clients

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.6.7
+version: 0.7.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -120,6 +120,7 @@ zkCli.sh -server my-zookeeper:2181
 | `zookeeperConfig.admin.serverAddress`       | Admin server address                                | `0.0.0.0`   |
 | `zookeeperConfig.admin.idleTimeout`         | Admin server connection idle timeout (milliseconds) | `30000`     |
 | `zookeeperConfig.admin.commandUrl`          | Admin server command URL                            | `/commands` |
+| `zookeeperConfig.extraConfigs`              | Extra ZooKeeper configuration lines appended to zoo.cfg | `[]`    |
 
 ### Metrics
 
@@ -147,6 +148,7 @@ zkCli.sh -server my-zookeeper:2181
 | ------------------------------ | -------------------------------------------- | ----------- |
 | `service.type`                 | Kubernetes service type                      | `ClusterIP` |
 | `service.ports.client`         | ZooKeeper client service port                | `2181`      |
+| `service.ports.secureClient`   | ZooKeeper secure client service port         | `2281`      |
 | `service.ports.quorum`         | ZooKeeper quorum service port                | `2888`      |
 | `service.ports.leaderElection` | ZooKeeper leader election service port       | `3888`      |
 | `service.ports.admin`          | ZooKeeper admin service port                 | `8080`      |

--- a/charts/zookeeper/templates/configmap.yaml
+++ b/charts/zookeeper/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
     initLimit={{ .Values.zookeeperConfig.initLimit | default 10 }}
     syncLimit={{ .Values.zookeeperConfig.syncLimit | default 5 }}
     clientPort={{ .Values.service.ports.client | default 2181 }}
+    secureClientPort={{ .Values.service.ports.secureClient | default 2281 }}
     electionPortBindRetry={{ .Values.zookeeperConfig.electionPortBindRetry | default 10 }}
     maxClientCnxns={{ .Values.zookeeperConfig.maxClientCnxns | default 60 }}
     #standaloneEnabled={{ .Values.zookeeperConfig.standaloneEnabled | default "false" }}
@@ -35,6 +36,9 @@ data:
     metricsProvider.httpHost=0.0.0.0
     metricsProvider.httpPort={{ .Values.metrics.service.port | default 7000 }}
     metricsProvider.exportJvmInfo=true
+    {{- end }}
+    {{- range .Values.zookeeperConfig.extraConfigs }}
+    {{ . }}
     {{- end }}
     {{- /* Add a line for each server in the ensemble */}}
     {{- include "zookeeper.servers" . | nindent 4 }}

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -29,6 +29,7 @@ spec:
     # Allow inbound connections to ZooKeeper
     - ports:
         - port: {{ .Values.service.ports.client | default 2181 }}
+        - port: {{ .Values.service.ports.secureClient | default 2281 }}
     # Allow internal communications between nodes
     - ports:
         - port: {{ .Values.service.ports.quorum | default 2888 }}

--- a/charts/zookeeper/templates/service.yaml
+++ b/charts/zookeeper/templates/service.yaml
@@ -17,6 +17,10 @@ spec:
       targetPort: client
       protocol: TCP
       name: client
+    - port: {{ .Values.service.ports.secureClient | default 2281 }}
+      targetPort: secure-client
+      protocol: TCP
+      name: secure-client
     - port: {{ .Values.service.ports.admin | default 8080 }}
       targetPort: admin
       protocol: TCP
@@ -40,6 +44,10 @@ spec:
       targetPort: client
       protocol: TCP
       name: client
+    - port: {{ .Values.service.ports.secureClient | default 2281 }}
+      targetPort: secure-client
+      protocol: TCP
+      name: secure-client
     - port: {{ .Values.service.ports.quorum | default 2888 }}
       targetPort: quorum
       protocol: TCP

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -43,6 +43,9 @@ spec:
             - name: client
               containerPort: {{ .Values.service.ports.client | default 2181 }}
               protocol: TCP
+            - name: secure-client
+              containerPort: {{ .Values.service.ports.secureClient | default 2281 }}
+              protocol: TCP
             - name: quorum
               containerPort: {{ .Values.service.ports.quorum | default 2888 }}
               protocol: TCP

--- a/charts/zookeeper/tests/unittest-defaults_test.yaml
+++ b/charts/zookeeper/tests/unittest-defaults_test.yaml
@@ -45,6 +45,21 @@ tests:
           path: data["zoo.cfg"]
           pattern: "tickTime=2000"
 
+  - it: should append extraConfigs to zoo.cfg
+    template: configmap.yaml
+    set:
+      zookeeperConfig:
+        extraConfigs:
+          - "secureClientPort=2281"
+          - "authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
+    asserts:
+      - matchRegex:
+          path: data["zoo.cfg"]
+          pattern: "secureClientPort=2281"
+      - matchRegex:
+          path: data["zoo.cfg"]
+          pattern: "authProvider\.sasl=org\.apache\.zookeeper\.server\.auth\.SASLAuthenticationProvider"
+
   - it: should create volumeClaimTemplates by default (persistence enabled)
     template: statefulset.yaml
     asserts:

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -317,13 +317,13 @@
                         "client": {
                             "type": "integer"
                         },
-                        "secureClient": {
-                            "type": "integer"
-                        },
                         "leaderElection": {
                             "type": "integer"
                         },
                         "quorum": {
+                            "type": "integer"
+                        },
+                        "secureClient": {
                             "type": "integer"
                         }
                     }
@@ -399,14 +399,11 @@
                 "commandsWhitelist": {
                     "type": "string"
                 },
-                "extraConfigs": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "electionPortBindRetry": {
                     "type": "integer"
+                },
+                "extraConfigs": {
+                    "type": "array"
                 },
                 "initLimit": {
                     "type": "integer"

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -403,10 +403,7 @@
                     "type": "string"
                 },
                 "customServers": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "array"
                 },
                 "electionPortBindRetry": {
                     "type": "integer"

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -317,6 +317,9 @@
                         "client": {
                             "type": "integer"
                         },
+                        "secureClient": {
+                            "type": "integer"
+                        },
                         "leaderElection": {
                             "type": "integer"
                         },
@@ -395,6 +398,12 @@
                 },
                 "commandsWhitelist": {
                     "type": "string"
+                },
+                "extraConfigs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "electionPortBindRetry": {
                     "type": "integer"

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -99,6 +99,10 @@ zookeeperConfig:
     idleTimeout: 30000
     ## @param zookeeperConfig.admin.commandUrl Zookeeper Admin server command URL
     commandUrl: "/commands"
+  ## @param zookeeperConfig.extraConfigs Extra ZooKeeper configuration lines to append to zoo.cfg
+  extraConfigs: []
+  #  - "secureClientPort=2281"
+  #  - "authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
 
 
 ## @section Zookeeper Metrics configuration
@@ -175,6 +179,8 @@ service:
   ports:
     ## @param service.ports.client Zookeeper client service port
     client: 2181
+    ## @param service.ports.secureClient Zookeeper secure client service port
+    secureClient: 2281
     ## @param service.ports.quorum Zookeeper quorum service port
     quorum: 2888
     ## @param service.ports.leaderElection Zookeeper leader election service port


### PR DESCRIPTION
### Description of the change

This PR enables ZooKeeper TLS and authenticated client connectivity by adding a dedicated secure client port and exposing related configuration paths needed to wire secure client traffic end to end.

The change includes:
- Secure client service port support in chart values and schema
- Template updates so the secure client port is exposed consistently across services, pod ports, and network policy rules
- ZooKeeper configuration support for secure client port settings
- Documentation and tests updates aligned with the new configuration surface
- Chart version bump for this feature release

### Benefits

- Enables secure client traffic path configuration for ZooKeeper deployments
- Improves support for TLS and authenticated client scenarios
- Keeps chart docs, schema validation, and test coverage aligned with new values

### Possible drawbacks

- Additional port exposure and config surface slightly increases deployment complexity
- Secure client port support alone does not fully enforce TLS and authentication unless users also provide the required ZooKeeper security settings and certificates in their deployment

### Applicable issues

- fixes #N/A

### Additional information

Validation performed:
- Helm lint passed for the chart
- End to end chart deployment with clients apps connected over tls and sasl

### Checklist

- [X] Chart version bumped in [charts/zookeeper/Chart.yaml](charts/zookeeper/Chart.yaml) according to [semver](http://semver.org/). This is not necessary when the changes only affect README.md files.
- [X] Variables are documented in [charts/zookeeper/values.yaml](charts/zookeeper/values.yaml) and added to [charts/zookeeper/README.md](charts/zookeeper/README.md)
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](CONTRIBUTING.md#setting-up-your-development-environment))