### PR TITLE
[all]: Add namespaceOverride Value to all Charts that missing it

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.6.3
+version: 0.7.0
 appVersion: "3.6.10"
 keywords:
   - etcd

--- a/charts/etcd/README.md
+++ b/charts/etcd/README.md
@@ -100,15 +100,16 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/etcd:<version>
 
 ### Common Parameters
 
-| Parameter           | Description                                     | Default |
-| ------------------- | ----------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override etcd.fullname      | `""`    |
-| `fullnameOverride`  | String to fully override etcd.fullname          | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects           | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects      | `{}`    |
-| `replicaCount`      | Number of etcd replicas to deploy (must be odd) | `3`     |
-| `podLabels`         | Additional labels for etcd pods                 | `{}`    |
-| `podAnnotations`    | Additional annotations for etcd pods            | `{}`    |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override etcd.fullname         | `""`    |
+| `fullnameOverride`  | String to fully override etcd.fullname             | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
+| `replicaCount`      | Number of etcd replicas to deploy (must be odd)    | `3`     |
+| `podLabels`         | Additional labels for etcd pods                    | `{}`    |
+| `podAnnotations`    | Additional annotations for etcd pods               | `{}`    |
 
 ### Service Configuration
 

--- a/charts/etcd/templates/_helpers.tpl
+++ b/charts/etcd/templates/_helpers.tpl
@@ -79,7 +79,7 @@ Validate etcd values
 Generate etcd initial cluster string
 */}}
 {{- define "etcd.initialCluster" -}}
-{{- $namespace := .Release.Namespace }}
+{{- $namespace := include "cloudpirates.namespace" . }}
 {{- $name := include "etcd.fullname" . -}}
 {{- $peerPort := .Values.service.peerPort -}}
 {{- $replicaCount := int .Values.replicaCount }}

--- a/charts/etcd/templates/networkpolicy.yaml
+++ b/charts/etcd/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "etcd.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   {{- with (include "etcd.annotations" .) }}

--- a/charts/etcd/templates/poddisruptionbudget.yaml
+++ b/charts/etcd/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "etcd.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   {{- with (include "etcd.annotations" .) }}

--- a/charts/etcd/templates/service.yaml
+++ b/charts/etcd/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "etcd.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   {{- if or (include "etcd.annotations" .) .Values.service.annotations }}
@@ -32,7 +32,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "etcd.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
 spec:

--- a/charts/etcd/templates/serviceaccount.yaml
+++ b/charts/etcd/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "etcd.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   {{- if or (include "etcd.annotations" .) .Values.serviceAccount.annotations }}

--- a/charts/etcd/templates/servicemonitor.yaml
+++ b/charts/etcd/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "etcd.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}
@@ -38,5 +38,5 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "cloudpirates.namespace" . }}
 {{- end }}

--- a/charts/etcd/templates/statefulset.yaml
+++ b/charts/etcd/templates/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "etcd.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "etcd.labels" . | nindent 4 }}
   {{- with (include "etcd.annotations" .) }}
@@ -53,8 +53,8 @@ spec:
             - --name=$(POD_NAME)
             - --listen-peer-urls={{ if .Values.auth.peer.enabled }}https{{ else }}http{{ end }}://{{ .Values.config.listenPeerIp }}:{{ .Values.service.peerPort }}
             - --listen-client-urls={{ if .Values.auth.enabled }}https{{ else }}http{{ end }}://{{ .Values.config.listenClientIp }}:{{ .Values.service.clientPort }}
-            - --advertise-client-urls={{ if .Values.auth.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.clientPort }}
-            - --initial-advertise-peer-urls={{ if .Values.auth.peer.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.peerPort }}
+            - --advertise-client-urls={{ if .Values.auth.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.cluster.local:{{ .Values.service.clientPort }}
+            - --initial-advertise-peer-urls={{ if .Values.auth.peer.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.cluster.local:{{ .Values.service.peerPort }}
             - --initial-cluster={{ include "etcd.initialCluster" . }}
             - --initial-cluster-token={{ .Values.config.initialClusterToken }}
             - --initial-cluster-state={{ .Values.config.initialClusterState }}

--- a/charts/etcd/values.schema.json
+++ b/charts/etcd/values.schema.json
@@ -220,6 +220,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "networkPolicy": {
             "type": "object",
             "properties": {

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override etcd.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.16.7
+version: 0.17.0
 appVersion: "6.25.1"
 keywords:
   - ghost

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -195,13 +195,14 @@ The following tables list the configurable parameters of the Ghost chart organiz
 
 ### Common Parameters
 
-| Parameter           | Description                                 | Default |
-| ------------------- | ------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override ghost.fullname | `""`    |
-| `fullnameOverride`  | String to fully override ghost.fullname     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects       | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects  | `{}`    |
-| `replicaCount`      | Number of Ghost replicas to deploy          | `1`     |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override ghost.fullname        | `""`    |
+| `fullnameOverride`  | String to fully override ghost.fullname            | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
+| `replicaCount`      | Number of Ghost replicas to deploy                 | `1`     |
 
 ### Image Parameters
 

--- a/charts/ghost/templates/configmap.yaml
+++ b/charts/ghost/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ghost.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- with (include "ghost.annotations" .) }}

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ghost.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- with (include "ghost.annotations" .) }}

--- a/charts/ghost/templates/hpa.yaml
+++ b/charts/ghost/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "ghost.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- with (include "ghost.annotations" .) }}

--- a/charts/ghost/templates/httproute.yaml
+++ b/charts/ghost/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/ghost/templates/ingress.yaml
+++ b/charts/ghost/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/ghost/templates/pvc.yaml
+++ b/charts/ghost/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ghost.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}

--- a/charts/ghost/templates/service.yaml
+++ b/charts/ghost/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ghost.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- with (include "ghost.annotations" .) }}

--- a/charts/ghost/templates/serviceaccount.yaml
+++ b/charts/ghost/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ghost.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "ghost.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/ghost/values.schema.json
+++ b/charts/ghost/values.schema.json
@@ -652,6 +652,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override ghost.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.19.8
+version: 0.20.0
 appVersion: "26.5.6"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -76,12 +76,13 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Common parameters
 
-| Parameter           | Description                                    | Default |
-| ------------------- | ---------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override keycloak.fullname | `""`    |
-| `fullnameOverride`  | String to fully override keycloak.fullname     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects          | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects     | `{}`    |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override keycloak.fullname     | `""`    |
+| `fullnameOverride`  | String to fully override keycloak.fullname         | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
 
 ### Keycloak image configuration
 

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -133,7 +133,7 @@ Return the Keycloak hostname
 {{- else if .Values.ingress.enabled -}}
 {{- (index .Values.ingress.hosts 0).host -}}
 {{- else -}}
-{{- printf "%s.%s.svc.cluster.local" (include "keycloak.fullname" .) .Release.Namespace -}}
+{{- printf "%s.%s.svc.cluster.local" (include "keycloak.fullname" .) (include "cloudpirates.namespace" .) -}}
 {{- end -}}
 {{- end }}
 
@@ -155,7 +155,7 @@ Return the Keycloak backchannel hostname
 {{- if .Values.keycloak.hostnameBackchannel -}}
 {{- .Values.keycloak.hostnameBackchannel -}}
 {{- else -}}
-{{- printf "%s.%s.svc.cluster.local" (include "keycloak.fullname" .) .Release.Namespace -}}
+{{- printf "%s.%s.svc.cluster.local" (include "keycloak.fullname" .) (include "cloudpirates.namespace" .) -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/keycloak/templates/certificate.yaml
+++ b/charts/keycloak/templates/certificate.yaml
@@ -12,7 +12,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- with .Values.tls.certManager.annotations }}

--- a/charts/keycloak/templates/configmap.yaml
+++ b/charts/keycloak/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "keycloak.fullname" . }}-cache
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- with (include "keycloak.annotations" .) }}
@@ -20,7 +20,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "keycloak.fullname" . }}-realm
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- with (include "keycloak.annotations" .) }}

--- a/charts/keycloak/templates/httproute.yaml
+++ b/charts/keycloak/templates/httproute.yaml
@@ -14,7 +14,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . | quote }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/keycloak/templates/ingress.yaml
+++ b/charts/keycloak/templates/ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}

--- a/charts/keycloak/templates/metrics-service.yaml
+++ b/charts/keycloak/templates/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keycloak.metrics.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/keycloak/templates/metrics-servicemonitor.yaml
+++ b/charts/keycloak/templates/metrics-servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- else }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- end }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "keycloak.metrics.serviceMonitor.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
@@ -25,7 +21,7 @@ spec:
       app.kubernetes.io/component: metrics
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ include "cloudpirates.namespace" . }}
   endpoints:
     - port: {{ .Values.metrics.service.targetPort }}
       {{- if .Values.metrics.serviceMonitor.interval }}

--- a/charts/keycloak/templates/realm-secret.yaml
+++ b/charts/keycloak/templates/realm-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keycloak.fullname" . }}-realm
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/keycloak/templates/secret.yaml
+++ b/charts/keycloak/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- with (include "keycloak.annotations" .) }}
@@ -21,7 +21,7 @@ data:
 {{- if and (not .Values.database.existingSecret) (or (eq .Values.database.type "postgres") (eq .Values.database.type "mysql") (eq .Values.database.type "mariadb")) }}
 {{- if and (eq .Values.database.type "postgres") .Values.postgres.enabled }}
 {{- /* Use the existing postgres password when postgres is enabled */}}
-{{- $existingPostgresSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-postgres" .Release.Name)) }}
+{{- $existingPostgresSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (printf "%s-postgres" (include "cloudpirates.namespace" .))) }}
 {{- $postgresPassword := "" }}
 {{- if and $existingPostgresSecret $existingPostgresSecret.data }}
   {{- $postgresPassword = index $existingPostgresSecret.data "postgres-password" }}
@@ -30,7 +30,7 @@ data:
 {{- end }}
 {{- else if and (or (eq .Values.database.type "mysql") (eq .Values.database.type "mariadb")) .Values.mariadb.enabled }}
 {{- /* Use the existing mariadb password when mariadb is enabled */}}
-{{- $existingMariadbSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-mariadb" .Release.Name)) }}
+{{- $existingMariadbSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (printf "%s-mariadb" (include "cloudpirates.namespace" .))) }}
 {{- $mariadbPassword := "" }}
 {{- $mariadbPasswordKey := "" }}
 {{- if .Values.mariadb.auth.username }}
@@ -52,7 +52,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-db" (include "keycloak.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- with (include "keycloak.annotations" .) }}
@@ -69,7 +69,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-db" (include "keycloak.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- with (include "keycloak.annotations" .) }}

--- a/charts/keycloak/templates/service-headless.yaml
+++ b/charts/keycloak/templates/service-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keycloak.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/keycloak/templates/service.yaml
+++ b/charts/keycloak/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/keycloak/templates/serviceaccount.yaml
+++ b/charts/keycloak/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "keycloak.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "keycloak.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -578,6 +578,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override keycloak.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.15.3
+version: 0.16.0
 appVersion: "12.2.2"
 keywords:
   - mariadb

--- a/charts/mariadb/README.md
+++ b/charts/mariadb/README.md
@@ -96,12 +96,13 @@ The following table lists the configurable parameters of the MariaDB chart and t
 
 ### Common Parameters
 
-| Parameter           | Description                                   | Default |
-| ------------------- | --------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override mariadb.fullname | `""`    |
-| `fullnameOverride`  | String to fully override mariadb.fullname     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects         | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects    | `{}`    |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override mariadb.fullname      | `""`    |
+| `fullnameOverride`  | String to fully override mariadb.fullname          | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
 
 ### MariaDB Image Parameters
 

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -106,7 +106,7 @@ Generate Galera cluster address list
 {{- define "mariadb.galeraClusterAddress" -}}
 {{- $fullname := include "mariadb.fullname" . -}}
 {{- $replicaCount := int .Values.galera.replicaCount -}}
-{{- $namespace := .Release.Namespace -}}
+{{- $namespace := include "cloudpirates.namespace" . -}}
 {{- $addresses := list -}}
 {{- range $i := until $replicaCount -}}
 {{- $addresses = append $addresses (printf "%s-%d.%s.%s.svc.cluster.local:4567" $fullname $i $fullname $namespace) -}}
@@ -132,7 +132,7 @@ Generate Galera node name with pod name
 Generate Galera node address
 */}}
 {{- define "mariadb.galeraNodeAddress" -}}
-{{- printf "%s-%s.%s.%s.svc.cluster.local" (include "mariadb.fullname" .) "REPLICA_NUM" (include "mariadb.fullname" .) .Release.Namespace -}}
+{{- printf "%s-%s.%s.%s.svc.cluster.local" (include "mariadb.fullname" .) "REPLICA_NUM" (include "mariadb.fullname" .) (include "cloudpirates.namespace" .) -}}
 {{- end }}
 
 {{/*

--- a/charts/mariadb/templates/configmap.yaml
+++ b/charts/mariadb/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mariadb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}

--- a/charts/mariadb/templates/galera/configmap.yaml
+++ b/charts/mariadb/templates/galera/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mariadb.fullname" . }}-galera
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}

--- a/charts/mariadb/templates/galera/scripts-configmap.yaml
+++ b/charts/mariadb/templates/galera/scripts-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mariadb.fullname" . }}-galera-scripts
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}

--- a/charts/mariadb/templates/galera/secret.yaml
+++ b/charts/mariadb/templates/galera/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mariadb.fullname" . }}-galera
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}

--- a/charts/mariadb/templates/galera/service.yaml
+++ b/charts/mariadb/templates/galera/service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mariadb.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
     app.kubernetes.io/component: headless

--- a/charts/mariadb/templates/httproute.yaml
+++ b/charts/mariadb/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/mariadb/templates/ingress.yaml
+++ b/charts/mariadb/templates/ingress.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/mariadb/templates/metrics-init-script.yaml
+++ b/charts/mariadb/templates/metrics-init-script.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "mariadb.fullname" . }}-init-exporter-user
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}

--- a/charts/mariadb/templates/networkpolicy.yaml
+++ b/charts/mariadb/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "mariadb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- $annotations := .Values.commonAnnotations }}

--- a/charts/mariadb/templates/pvc.yaml
+++ b/charts/mariadb/templates/pvc.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "mariadb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}

--- a/charts/mariadb/templates/secret.yaml
+++ b/charts/mariadb/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mariadb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "mariadb.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "mariadb.fullname" .)) }}
   {{- $existingRootPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingRootPassword = index $existingSecret.data .Values.auth.secretKeys.rootPasswordKey }}

--- a/charts/mariadb/templates/service.yaml
+++ b/charts/mariadb/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mariadb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/mariadb/templates/serviceaccount.yaml
+++ b/charts/mariadb/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "mariadb.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mariadb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mariadb.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}

--- a/charts/mariadb/values.schema.json
+++ b/charts/mariadb/values.schema.json
@@ -475,6 +475,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "networkPolicy": {
             "type": "object",
             "properties": {

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override mariadb.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.11.1
+version: 0.12.0
 appVersion: "1.6.41"
 keywords:
   - memcached

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | ------------------- | -------------------------------------------------------- | ------- |
 | `nameOverride`      | String to partially override memcached.fullname          | `""`    |
 | `fullnameOverride`  | String to fully override memcached.fullname              | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources       | `""`    |
 | `commonLabels`      | Labels to add to all deployed objects                    | `{}`    |
 | `commonAnnotations` | Annotations to add to all deployed objects               | `{}`    |
 | `podAnnotations`    | Annotations to add to the pods created by the deployment | `{}`    |

--- a/charts/memcached/templates/configmap.yaml
+++ b/charts/memcached/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "memcached.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
   {{- with (include "memcached.annotations" .) }}

--- a/charts/memcached/templates/deployment.yaml
+++ b/charts/memcached/templates/deployment.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 {{- end }}
 metadata:
   name: {{ include "memcached.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
   {{- with (include "memcached.annotations" .) }}

--- a/charts/memcached/templates/httproute.yaml
+++ b/charts/memcached/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/memcached/templates/ingress.yaml
+++ b/charts/memcached/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/memcached/templates/pdb.yaml
+++ b/charts/memcached/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "memcached.fullname" . }}-pdb
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels: {{- include "memcached.labels" . | nindent 4 }}
   {{- with (include "memcached.annotations" .) }}
   annotations:

--- a/charts/memcached/templates/service.yaml
+++ b/charts/memcached/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "memcached.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
   {{- with (include "memcached.annotations" .) }}

--- a/charts/memcached/templates/serviceaccount.yaml
+++ b/charts/memcached/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "memcached.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/memcached/templates/servicemonitor.yaml
+++ b/charts/memcached/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "memcached.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -334,6 +334,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override memcached.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/README.md
+++ b/charts/minio/README.md
@@ -117,11 +117,12 @@ The following table lists the configurable parameters of the MinIO chart and the
 
 ### Deployment configuration
 
-| Parameter          | Description                                 | Default |
-| ------------------ | ------------------------------------------- | ------- |
-| `replicaCount`     | Number of MinIO replicas to deploy          | `1`     |
-| `nameOverride`     | String to partially override minio.fullname | `""`    |
-| `fullnameOverride` | String to fully override minio.fullname     | `""`    |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `replicaCount`      | Number of MinIO replicas to deploy                 | `1`     |
+| `nameOverride`      | String to partially override minio.fullname        | `""`    |
+| `fullnameOverride`  | String to fully override minio.fullname            | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
 
 ### Pod annotations and labels
 

--- a/charts/minio/templates/bucket-init-configmap.yaml
+++ b/charts/minio/templates/bucket-init-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "minio.fullname" . }}-bucket-init
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/minio/templates/bucket-init-job.yaml
+++ b/charts/minio/templates/bucket-init-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "minio.fullname" . }}-post-job
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge (include "minio.annotations" . | fromYaml) .Values.bucketInitJob.annotations }}

--- a/charts/minio/templates/configmap.yaml
+++ b/charts/minio/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/minio/templates/httproute-console.yaml
+++ b/charts/minio/templates/httproute-console.yaml
@@ -12,7 +12,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}-console
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
     app.kubernetes.io/component: console

--- a/charts/minio/templates/httproute.yaml
+++ b/charts/minio/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/minio/templates/ingress-console.yaml
+++ b/charts/minio/templates/ingress-console.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-console
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
     app.kubernetes.io/component: console

--- a/charts/minio/templates/ingress.yaml
+++ b/charts/minio/templates/ingress.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}

--- a/charts/minio/templates/pvc.yaml
+++ b/charts/minio/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}

--- a/charts/minio/templates/secret.yaml
+++ b/charts/minio/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "minio.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "minio.fullname" .)) }}
   {{- $existingRootPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingRootPassword = index $existingSecret.data "root-password" }}

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/minio/templates/serviceaccount.yaml
+++ b/charts/minio/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "minio.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/minio/values.schema.json
+++ b/charts/minio/values.schema.json
@@ -418,6 +418,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override minio.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.14.7
+version: 0.15.0
 appVersion: "8.2.6"
 keywords:
   - mongodb

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -81,6 +81,7 @@ The following table lists the configurable parameters of the MongoDB chart and t
 | ---------------------- | ---------------------------------------------------------- | --------------- |
 | `nameOverride`         | String to partially override mongodb.fullname              | `""`            |
 | `fullnameOverride`     | String to fully override mongodb.fullname                  | `""`            |
+| `namespaceOverride`    | String to override the namespace for all resources         | `""`            |
 | `commonLabels`         | Labels to add to all deployed objects                      | `{}`            |
 | `commonAnnotations`    | Annotations to add to all deployed objects                 | `{}`            |
 | `podAnnotations`       | Annotations to add to the pod created by the statefulset   | `{}`            |

--- a/charts/mongodb/templates/_helpers.tpl
+++ b/charts/mongodb/templates/_helpers.tpl
@@ -208,7 +208,7 @@ Return config server connection string for mongos
 */}}
 {{- define "mongodb.configServerConnectionString" -}}
 {{- $configRsName := printf "%s-configserver-rs" (include "mongodb.fullname" .) -}}
-{{- $configService := printf "%s-configserver-headless.%s.svc.%s" (include "mongodb.fullname" .) .Release.Namespace (.Values.replicaSet.clusterDomain | default "cluster.local") -}}
+{{- $configService := printf "%s-configserver-headless.%s.svc.%s" (include "mongodb.fullname" .) (include "cloudpirates.namespace" .) (.Values.replicaSet.clusterDomain | default "cluster.local") -}}
 {{- $configServers := list -}}
 {{- range $i := until (int .Values.shardedCluster.configsvr.replicaCount) -}}
 {{- $host := printf "%s-configserver-%d.%s:27017" (include "mongodb.fullname" $) $i $configService -}}
@@ -224,7 +224,7 @@ Return shard replica set connection string
 {{- $shardIndex := .shardIndex -}}
 {{- $context := .context -}}
 {{- $shardRsName := printf "%s-shard-%d-rs" (include "mongodb.fullname" $context) $shardIndex -}}
-{{- $shardService := printf "%s-shard-%d-headless.%s.svc.%s" (include "mongodb.fullname" $context) $shardIndex $context.Release.Namespace ($context.Values.replicaSet.clusterDomain | default "cluster.local") -}}
+{{- $shardService := printf "%s-shard-%d-headless.%s.svc.%s" (include "mongodb.fullname" $context) $shardIndex (include "cloudpirates.namespace" $context) ($context.Values.replicaSet.clusterDomain | default "cluster.local") -}}
 {{- $shardMembers := list -}}
 {{- range $i := until (int $context.Values.shardedCluster.shardsvr.dataNode.replicaCount) -}}
 {{- $host := printf "%s-shard-%d-%d.%s:27017" (include "mongodb.fullname" $context) $shardIndex $i $shardService -}}

--- a/charts/mongodb/templates/configmap.yaml
+++ b/charts/mongodb/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mongodb.fullname" . }}-config
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   {{- with (include "mongodb.annotations" .) }}
   annotations: 
 {{- . | indent 4 }}

--- a/charts/mongodb/templates/custom-user-secret.yaml
+++ b/charts/mongodb/templates/custom-user-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mongodb.fullname" $ }}-custom-user-{{ $i }}-secret
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" $ | nindent 4 }}
   {{- with (include "mongodb.annotations" $) }}

--- a/charts/mongodb/templates/init-scripts.yaml
+++ b/charts/mongodb/templates/init-scripts.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "mongodb.fullname" . }}-init-scripts
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   {{- with (include "mongodb.annotations" .) }}
   annotations: 
 {{- . | indent 4 }}
@@ -452,12 +452,12 @@ data:
       {{- if .Values.replicaSet.enabled }}
       wait_ready {{ .Values.replicaSet.extraInit.retries }} {{ .Values.replicaSet.extraInit.delay }} {{ .Values.replicaSet.extraInit.initDelay }}
       if [ "$MONGOTYPE" = "ARBITER" ]; then
-        init_arbiter "{{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}" "{{ include "mongodb.fullname" . }}-{{ .Values.replicaSet.arbiter.headlessServiceSuffix }}.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}"
+        init_arbiter "{{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}" "{{ include "mongodb.fullname" . }}-{{ .Values.replicaSet.arbiter.headlessServiceSuffix }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}"
       else
         if [ "$MONGOTYPE" = "HIDDEN" ]; then
-          init_hidden "{{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}" "{{ include "mongodb.fullname" . }}-{{ .Values.replicaSet.hiddenSecondaries.headlessServiceSuffix }}.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}"
+          init_hidden "{{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}" "{{ include "mongodb.fullname" . }}-{{ .Values.replicaSet.hiddenSecondaries.headlessServiceSuffix }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}"
         else
-          init_replicaset "{{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}" "{{ .Values.replicaSet.name }}"
+          init_replicaset "{{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain }}:{{ .Values.service.port }}" "{{ .Values.replicaSet.name }}"
         fi
       fi
       terminatedelay={{ .Values.replicaSet.shutdown.delay }}
@@ -575,20 +575,20 @@ data:
     # $1 - Config server replica set name
     init_configserver_replicaset() {
       local configRsName=$1
-      local configService="{{ include "mongodb.fullname" . }}-configserver-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}"
+      local configService="{{ include "mongodb.fullname" . }}-configserver-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}"
 
       log_shard "Initializing config server replica set: $configRsName"
 
       # Check if config server replica set is already initialized
       # Try without auth first (works for localhost exception or when RS is initialized without users)
-      result=$(kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ .Release.Namespace }} -- mongosh --quiet --eval "rs.status().ok" 2>/dev/null || echo "0")
+      result=$(kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --quiet --eval "rs.status().ok" 2>/dev/null || echo "0")
       if [ "$result" = "1" ]; then
         log_shard "Config server replica set already initialized"
         return 0
       fi
       # Try with auth (works when users already exist)
       {{- if .Values.auth.enabled }}
-      result=$(kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ .Release.Namespace }} -- mongosh --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "rs.status().ok" 2>/dev/null || echo "0")
+      result=$(kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --quiet --eval "rs.status().ok" 2>/dev/null || echo "0")
       if [ "$result" = "1" ]; then
         log_shard "Config server replica set already initialized"
         return 0
@@ -596,10 +596,10 @@ data:
       {{- end }}
 
       # Build config server members array
-      local members="[{{- range $i := until (int .Values.shardedCluster.configsvr.replicaCount) }}{{- if gt $i 0 }}, {{ end }}{_id:{{ $i }}, host:\"{{ include "mongodb.fullname" $ }}-configserver-{{ $i }}.{{ include "mongodb.fullname" $ }}-configserver-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017\"}{{- end }}]"
+      local members="[{{- range $i := until (int .Values.shardedCluster.configsvr.replicaCount) }}{{- if gt $i 0 }}, {{ end }}{_id:{{ $i }}, host:\"{{ include "mongodb.fullname" $ }}-configserver-{{ $i }}.{{ include "mongodb.fullname" $ }}-configserver-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017\"}{{- end }}]"
 
       # Initialize config server replica set using kubectl exec (localhost exception)
-      kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ .Release.Namespace }} -- mongosh --eval "
+      kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --eval "
         rs.initiate({
           _id: '$configRsName',
           configsvr: true,
@@ -615,7 +615,7 @@ data:
       local delay=1
       while [ $retries -gt 0 ]; do
         # Try without auth (works after rs.initiate via localhost exception)
-        result=$(kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ .Release.Namespace }} -- mongosh --quiet --eval "rs.status().members.filter(m => m.state === 1).length" 2>/dev/null || echo "0")
+        result=$(kubectl exec {{ include "mongodb.fullname" . }}-configserver-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --quiet --eval "rs.status().members.filter(m => m.state === 1).length" 2>/dev/null || echo "0")
         if [ "$result" = "1" ]; then
           log_shard "Config server replica set is ready"
           break
@@ -637,7 +637,7 @@ data:
       log_shard "Transitioning config server to config shard mode"
 
       # Get mongos host
-      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
+      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
 
       # Check if already transitioned to config shard using sh.isConfigShardEnabled()
       local retries={{ .Values.shardedCluster.initialization.retries | default 30 }}
@@ -687,23 +687,23 @@ data:
     init_shard_replicaset() {
       local shardIndex=$1
       local shardRsName=$2
-      local shardService="{{ include "mongodb.fullname" . }}-shard-${shardIndex}-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}"
+      local shardService="{{ include "mongodb.fullname" . }}-shard-${shardIndex}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}"
 
       log_shard "Initializing shard $shardIndex replica set: $shardRsName"
 
       # Check if shard replica set is already initialized
       # Try without auth first (works for localhost exception or when RS is initialized without users)
-      result=$(kubectl exec {{ include "mongodb.fullname" . }}-shard-${shardIndex}-0 -n {{ .Release.Namespace }} -- mongosh --quiet --eval "rs.status().ok" 2>/dev/null || echo "0")
+      result=$(kubectl exec {{ include "mongodb.fullname" . }}-shard-${shardIndex}-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --quiet --eval "rs.status().ok" 2>/dev/null || echo "0")
       if [ "$result" = "1" ]; then
         log_shard "Shard $shardIndex replica set already initialized"
         return 0
       fi
 
       # Build shard members array (data nodes + arbiters)
-      local members="[{{- range $i := until (int .Values.shardedCluster.shardsvr.dataNode.replicaCount) }}{{- if gt $i 0 }}, {{ end }}{_id:{{ $i }}, host:\"{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-{{ $i }}.{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017\"}{{- end }}{{- if gt (int .Values.shardedCluster.shardsvr.arbiter.replicaCount) 0 }}{{- range $i := until (int .Values.shardedCluster.shardsvr.arbiter.replicaCount) }}, {_id:{{ add (int $.Values.shardedCluster.shardsvr.dataNode.replicaCount) $i }}, host:\"{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-arbiter-{{ $i }}.{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-arbiter-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017\", arbiterOnly:true}{{- end }}{{- end }}]"
+      local members="[{{- range $i := until (int .Values.shardedCluster.shardsvr.dataNode.replicaCount) }}{{- if gt $i 0 }}, {{ end }}{_id:{{ $i }}, host:\"{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-{{ $i }}.{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017\"}{{- end }}{{- if gt (int .Values.shardedCluster.shardsvr.arbiter.replicaCount) 0 }}{{- range $i := until (int .Values.shardedCluster.shardsvr.arbiter.replicaCount) }}, {_id:{{ add (int $.Values.shardedCluster.shardsvr.dataNode.replicaCount) $i }}, host:\"{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-arbiter-{{ $i }}.{{ include "mongodb.fullname" $ }}-shard-${shardIndex}-arbiter-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017\", arbiterOnly:true}{{- end }}{{- end }}]"
 
       # Initialize shard replica set using kubectl exec (localhost exception)
-      kubectl exec {{ include "mongodb.fullname" . }}-shard-${shardIndex}-0 -n {{ .Release.Namespace }} -- mongosh --eval "
+      kubectl exec {{ include "mongodb.fullname" . }}-shard-${shardIndex}-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --eval "
         rs.initiate({
           _id: '$shardRsName',
           members: $members
@@ -718,7 +718,7 @@ data:
       local delay=1
       while [ $retries -gt 0 ]; do
         # Try without auth (works after rs.initiate via localhost exception)
-        result=$(kubectl exec {{ include "mongodb.fullname" . }}-shard-${shardIndex}-0 -n {{ .Release.Namespace }} -- mongosh --quiet --eval "rs.status().members.filter(m => m.state === 1).length" 2>/dev/null || echo "0")
+        result=$(kubectl exec {{ include "mongodb.fullname" . }}-shard-${shardIndex}-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --quiet --eval "rs.status().members.filter(m => m.state === 1).length" 2>/dev/null || echo "0")
         if [ "$result" = "1" ]; then
           log_shard "Shard $shardIndex replica set is ready"
           break
@@ -736,7 +736,7 @@ data:
 
     # Add shards to the cluster via mongos
     add_shards_to_cluster() {
-      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
+      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
 
       log_shard "Adding shards to cluster via mongos"
 
@@ -769,7 +769,7 @@ data:
       if [ "$auth_check" = "1" ]; then
         log_shard "Admin user already exists and credentials are valid"
       else
-        result=$(kubectl exec {{ include "mongodb.fullname" . }}-mongos-0 -n {{ .Release.Namespace }} -- mongosh --eval "
+        result=$(kubectl exec {{ include "mongodb.fullname" . }}-mongos-0 -n {{ include "cloudpirates.namespace" . }} -- mongosh --eval "
           try {
             db.getSiblingDB('admin').createUser({
               user: '$MONGO_INITDB_ROOT_USERNAME',
@@ -866,7 +866,7 @@ data:
       result=$(mongosh --host $mongosHost --eval "
       {{- end }}
         try {
-          sh.addShard('{{ include "mongodb.fullname" $ }}-shard-{{ $i }}-rs/{{ include "mongodb.fullname" $ }}-shard-{{ $i }}-0.{{ include "mongodb.fullname" $ }}-shard-{{ $i }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017');
+          sh.addShard('{{ include "mongodb.fullname" $ }}-shard-{{ $i }}-rs/{{ include "mongodb.fullname" $ }}-shard-{{ $i }}-0.{{ include "mongodb.fullname" $ }}-shard-{{ $i }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017');
           print('SUCCESS');
         } catch (e) {
           if (e.code === 20) {
@@ -928,7 +928,7 @@ data:
 
     # Enable sharding on databases and collections
     enable_sharding() {
-      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
+      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
 
       log_shard "Enabling sharding on databases and collections"
 
@@ -973,7 +973,7 @@ data:
 
     # Configure balancer settings
     configure_balancer() {
-      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
+      local mongosHost="{{ include "mongodb.fullname" . }}-mongos-0.{{ include "mongodb.fullname" . }}-mongos-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017"
 
       log_shard "Configuring balancer settings"
 
@@ -1035,7 +1035,7 @@ data:
       local retries=30
       local delay=1
       while [ $retries -gt 0 ]; do
-        if mongosh --host {{ include "mongodb.fullname" $ }}-configserver-{{ $i }}.{{ include "mongodb.fullname" $ }}-configserver-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017 --eval "db.adminCommand('ping')" > /dev/null 2>&1; then
+        if mongosh --host {{ include "mongodb.fullname" $ }}-configserver-{{ $i }}.{{ include "mongodb.fullname" $ }}-configserver-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017 --eval "db.adminCommand('ping')" > /dev/null 2>&1; then
           log_shard "Config server {{ $i }} is reachable"
           break
         fi
@@ -1056,7 +1056,7 @@ data:
       local retries=30
       local delay=1
       while [ $retries -gt 0 ]; do
-        if mongosh --host {{ include "mongodb.fullname" $ }}-shard-{{ $shardIdx }}-{{ $nodeIdx }}.{{ include "mongodb.fullname" $ }}-shard-{{ $shardIdx }}-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017 --eval "db.adminCommand('ping')" > /dev/null 2>&1; then
+        if mongosh --host {{ include "mongodb.fullname" $ }}-shard-{{ $shardIdx }}-{{ $nodeIdx }}.{{ include "mongodb.fullname" $ }}-shard-{{ $shardIdx }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017 --eval "db.adminCommand('ping')" > /dev/null 2>&1; then
           log_shard "Shard {{ $shardIdx }} node {{ $nodeIdx }} is reachable"
           break
         fi

--- a/charts/mongodb/templates/job-add-shards.yaml
+++ b/charts/mongodb/templates/job-add-shards.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "mongodb.fullname" . }}-add-shards
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     job-type: add-shards
@@ -66,7 +66,7 @@ spec:
 
               # Wait for all data pods in parallel (mongos will start after we initialize replica sets)
               echo "Waiting for data pods (configserver + shards): $PODS"
-              kubectl wait --for=condition=ready $PODS -n {{ .Release.Namespace }} --timeout=180s
+              kubectl wait --for=condition=ready $PODS -n {{ include "cloudpirates.namespace" . }} --timeout=180s
 
               echo "***** All pods are ready, proceeding with cluster initialization..."
 

--- a/charts/mongodb/templates/keyfile-secret.yaml
+++ b/charts/mongodb/templates/keyfile-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mongodb.keyfileSecretName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   {{- with (include "mongodb.annotations" .) }}

--- a/charts/mongodb/templates/metrics-networkpolicy.yaml
+++ b/charts/mongodb/templates/metrics-networkpolicy.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ include "mongodb.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/mongodb/templates/metrics-secret.yaml
+++ b/charts/mongodb/templates/metrics-secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mongodb.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-metrics" (include "mongodb.fullname" .))) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (printf "%s-metrics" (include "mongodb.fullname" .))) }}
   {{- $existingPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingPassword = index $existingSecret.data "mongodb-root-password" }}

--- a/charts/mongodb/templates/metrics-service.yaml
+++ b/charts/mongodb/templates/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.metrics.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/mongodb/templates/metrics-servicemonitor.yaml
+++ b/charts/mongodb/templates/metrics-servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "mongodb.fullname" . }}
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- else }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- end }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "mongodb.metrics.serviceMonitor.labels" . | nindent 4 }}
   {{- with .Values.metrics.serviceMonitor.annotations }}
@@ -25,7 +21,7 @@ spec:
       app.kubernetes.io/component: metrics
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ include "cloudpirates.namespace" . }}
   endpoints:
     - port: http-metrics
       {{- if .Values.metrics.serviceMonitor.interval }}

--- a/charts/mongodb/templates/role-init-sharded.yaml
+++ b/charts/mongodb/templates/role-init-sharded.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "mongodb.fullname" . }}-init-sharded
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
 rules:
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "mongodb.fullname" . }}-init-sharded
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
 roleRef:
@@ -25,5 +25,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "mongodb.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "cloudpirates.namespace" . }}
 {{- end }}

--- a/charts/mongodb/templates/secret.yaml
+++ b/charts/mongodb/templates/secret.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mongodb.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   {{- with (include "mongodb.annotations" .) }}
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "mongodb.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "mongodb.fullname" .)) }}
   {{- $existingRootPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingRootPassword = index $existingSecret.data "mongodb-root-password" }}

--- a/charts/mongodb/templates/service-configserver.yaml
+++ b/charts/mongodb/templates/service-configserver.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-configserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: configserver
@@ -34,7 +34,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-configserver-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: configserver

--- a/charts/mongodb/templates/service-headless.yaml
+++ b/charts/mongodb/templates/service-headless.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-{{ .Values.service.headlessServiceSuffix }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: primary-secondary
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-{{ .Values.replicaSet.arbiter.headlessServiceSuffix }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: arbiter
@@ -47,7 +47,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-{{ .Values.replicaSet.hiddenSecondaries.headlessServiceSuffix }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: hidden-secondary

--- a/charts/mongodb/templates/service-mongos.yaml
+++ b/charts/mongodb/templates/service-mongos.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-mongos
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: mongos
@@ -37,7 +37,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}-mongos-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: mongos

--- a/charts/mongodb/templates/service-shard.yaml
+++ b/charts/mongodb/templates/service-shard.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" $ }}-shard-{{ $shardIndex }}-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" $ }}
   labels:
     {{- include "mongodb.labels" $ | nindent 4 }}
     service-type: shard
@@ -44,7 +44,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" $ }}-shard-{{ $shardIndex }}-arbiter-headless
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" $ }}
   labels:
     {{- include "mongodb.labels" $ | nindent 4 }}
     service-type: shard-arbiter

--- a/charts/mongodb/templates/service.yaml
+++ b/charts/mongodb/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "mongodb.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   {{- if or (include "mongodb.annotations" .) .Values.service.annotations }}

--- a/charts/mongodb/templates/serviceaccount.yaml
+++ b/charts/mongodb/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "mongodb.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/mongodb/templates/statefulset-arbiter.yaml
+++ b/charts/mongodb/templates/statefulset-arbiter.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" . }}-arbiter
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: arbiter
@@ -44,7 +44,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mongodb/templates/statefulset-configserver.yaml
+++ b/charts/mongodb/templates/statefulset-configserver.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" . }}-configserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: configserver

--- a/charts/mongodb/templates/statefulset-hidden.yaml
+++ b/charts/mongodb/templates/statefulset-hidden.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" . }}-hidden
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: hidden-secondary
@@ -46,7 +46,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -79,7 +79,7 @@ spec:
               name: keyfile-secret
             {{- end }}
           command: [ "/scripts/init.sh" ]
-          {{- with .Values.initContainer.Resources }}
+          {{- with .Values.initContainer.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" . }}-mongos
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: mongos
@@ -78,7 +78,7 @@ spec:
               # Use isMaster which works without authentication
               echo "Waiting for config server replica set to be initialized..."
               while true; do
-                ISMASTER=$(mongosh --host {{ include "mongodb.fullname" . }}-configserver-0.{{ include "mongodb.fullname" . }}-configserver-headless.{{ .Release.Namespace }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017 --eval "db.adminCommand('isMaster').setName" --quiet 2>&1 | grep -v "Defaulted" | grep -v "^$")
+                ISMASTER=$(mongosh --host {{ include "mongodb.fullname" . }}-configserver-0.{{ include "mongodb.fullname" . }}-configserver-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.replicaSet.clusterDomain | default "cluster.local" }}:27017 --eval "db.adminCommand('isMaster').setName" --quiet 2>&1 | grep -v "Defaulted" | grep -v "^$")
                 if [ ! -z "$ISMASTER" ] && [ "$ISMASTER" != "null" ]; then
                   echo "Config server replica set is initialized: $ISMASTER"
                   break
@@ -123,7 +123,7 @@ spec:
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command:
             - mongos
-            - --configdb={{ include "mongodb.fullname" . }}-configserver-rs/{{- range $i := until (int .Values.shardedCluster.configsvr.replicaCount) }}{{ if gt $i 0 }},{{ end }}{{ include "mongodb.fullname" $ }}-configserver-{{ $i }}.{{ include "mongodb.fullname" $ }}-configserver-headless.{{ $.Release.Namespace }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017{{- end }}
+            - --configdb={{ include "mongodb.fullname" . }}-configserver-rs/{{- range $i := until (int .Values.shardedCluster.configsvr.replicaCount) }}{{ if gt $i 0 }},{{ end }}{{ include "mongodb.fullname" $ }}-configserver-{{ $i }}.{{ include "mongodb.fullname" $ }}-configserver-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.replicaSet.clusterDomain | default "cluster.local" }}:27017{{- end }}
             - --port=27017
             {{- if .Values.auth.enabled }}
             {{- if or .Values.replicaSet.key .Values.replicaSet.keySecretName .Values.shardedCluster.keyFile .Values.shardedCluster.keySecretName }}

--- a/charts/mongodb/templates/statefulset-shard.yaml
+++ b/charts/mongodb/templates/statefulset-shard.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" $ }}-shard-{{ $shardIndex }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" $ }}
   labels:
     {{- include "mongodb.labels" $ | nindent 4 }}
     service-type: shard
@@ -361,7 +361,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" $ }}-shard-{{ $shardIndex }}-arbiter
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" $ }}
   labels:
     {{- include "mongodb.labels" $ | nindent 4 }}
     service-type: shard-arbiter

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "mongodb.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: primary-secondary

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -79,14 +79,14 @@
         "customLivenessProbe": {
             "type": "object"
         },
-        "customUsers": {
-            "type": "array"
-        },
         "customReadinessProbe": {
             "type": "object"
         },
         "customStartupProbe": {
             "type": "object"
+        },
+        "customUsers": {
+            "type": "array"
         },
         "extraEnvVars": {
             "type": "array"

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -54,6 +54,9 @@
                 "existingConfigmap": {
                     "type": "string"
                 },
+                "existingConfigmapKey": {
+                    "type": "string"
+                },
                 "mountPath": {
                     "type": "string"
                 }
@@ -73,10 +76,22 @@
                 }
             }
         },
+        "customLivenessProbe": {
+            "type": "object"
+        },
         "customUsers": {
             "type": "array"
         },
+        "customReadinessProbe": {
+            "type": "object"
+        },
+        "customStartupProbe": {
+            "type": "object"
+        },
         "extraEnvVars": {
+            "type": "array"
+        },
+        "extraInitContainers": {
             "type": "array"
         },
         "extraObjects": {
@@ -358,6 +373,9 @@
             }
         },
         "nameOverride": {
+            "type": "string"
+        },
+        "namespaceOverride": {
             "type": "string"
         },
         "networkPolicy": {

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override mongodb.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects
@@ -78,6 +80,8 @@ config:
       bindIpAll: true
   ## param config.existingConfigmap Name of an existing Configmap to use instead of creating one
   existingConfigmap: ""
+  ## param config.existingConfigmapKey Name of the key that will hold configuration 
+  existingConfigmapKey: ""
 
 ## @section customUsers Optional users to be created at initialisation
 customUsers: []
@@ -180,6 +184,9 @@ livenessProbe:
   ## @param livenessProbe.successThreshold Number of successes to mark probe as successful
   successThreshold: 1
 
+## @section Custom liveness probe configuration
+customLivenessProbe: {}
+
 readinessProbe:
   ## @param readinessProbe.enabled Enable readiness probe
   enabled: true
@@ -194,6 +201,9 @@ readinessProbe:
   ## @param readinessProbe.successThreshold Number of successes to mark probe as successful
   successThreshold: 1
 
+## @section Custom readiness probe configuration
+customReadinessProbe: {}
+
 startupProbe:
   ## @param startupProbe.enabled Enable startup probe
   enabled: true
@@ -207,6 +217,9 @@ startupProbe:
   successThreshold: 1
   ## @param startupProbe.periodSeconds How often to perform the probe
   periodSeconds: 5
+
+## @section Custom startup probe configuration
+customStartupProbe: {}
 
 ## @param extraEnvVars Additional environment variables to set
 extraEnvVars: []
@@ -371,6 +384,9 @@ initContainer:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+
+## @section extraInitContainers Optional extra init containers configuration
+extraInitContainers:  []
 
 ## @section replicaSet Parameters to build a MongoDB replica set (HA mode)
 replicaSet:

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -80,7 +80,7 @@ config:
       bindIpAll: true
   ## param config.existingConfigmap Name of an existing Configmap to use instead of creating one
   existingConfigmap: ""
-  ## param config.existingConfigmapKey Name of the key that will hold configuration 
+  ## param config.existingConfigmapKey Name of the key that will hold configuration
   existingConfigmapKey: ""
 
 ## @section customUsers Optional users to be created at initialisation
@@ -386,7 +386,7 @@ initContainer:
     #   memory: 128Mi
 
 ## @section extraInitContainers Optional extra init containers configuration
-extraInitContainers:  []
+extraInitContainers: []
 
 ## @section replicaSet Parameters to build a MongoDB replica set (HA mode)
 replicaSet:

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.9.2
+version: 0.10.0
 appVersion: "1.29.7"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -118,12 +118,13 @@ The following table lists the configurable parameters of the Nginx chart and the
 
 ### Common Parameters
 
-| Parameter           | Description                                 | Default |
-| ------------------- | ------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override nginx.fullname | `""`    |
-| `fullnameOverride`  | String to fully override nginx.fullname     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects       | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects  | `{}`    |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override nginx.fullname        | `""`    |
+| `fullnameOverride`  | String to fully override nginx.fullname            | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
 
 
 ### Nginx Image Parameters

--- a/charts/nginx/templates/configmap.yaml
+++ b/charts/nginx/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "nginx.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- with (include "nginx.annotations" .) }}

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: {{ if .Values.daemonset.enabled }}DaemonSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ include "nginx.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- with (include "nginx.annotations" .) }}

--- a/charts/nginx/templates/hpa.yaml
+++ b/charts/nginx/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "nginx.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- with (include "nginx.annotations" .) }}

--- a/charts/nginx/templates/httproute.yaml
+++ b/charts/nginx/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/nginx/templates/ingress.yaml
+++ b/charts/nginx/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/nginx/templates/metrics-service.yaml
+++ b/charts/nginx/templates/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nginx.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/nginx/templates/service.yaml
+++ b/charts/nginx/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "nginx.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/nginx/templates/serviceaccount.yaml
+++ b/charts/nginx/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "nginx.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/nginx/templates/servicemonitor.yaml
+++ b/charts/nginx/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "nginx.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "nginx.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -464,6 +464,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override nginx.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.18.3
+version: 0.19.0
 appVersion: "18.3.0"
 keywords:
   - postgres

--- a/charts/postgres/README.md
+++ b/charts/postgres/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the PostgreSQL chart an
 | `replicaCount`                  | Number of PostgreSQL replicas to deploy (Note: PostgreSQL doesn't support multi-master replication by default) | `1`     |
 | `nameOverride`                  | String to partially override postgres.fullname                                                                 | `""`    |
 | `fullnameOverride`              | String to fully override postgres.fullname                                                                     | `""`    |
+| `namespaceOverride`             | String to override the namespace for all resources                                                             | `""`    |
 | `commonLabels`                  | Labels to add to all deployed objects                                                                          | `{}`    |
 | `commonAnnotations`             | Annotations to add to all deployed objects                                                                     | `{}`    |
 | `priorityClassName`             | Priority class name to be used for the pods                                                                    | ``      |

--- a/charts/postgres/templates/configmap.yaml
+++ b/charts/postgres/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "postgres.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/postgres/templates/custom-user-secret.yaml
+++ b/charts/postgres/templates/custom-user-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.customUser .Values.customUser.name (not .Values.customUser.existingSecret) }}
-{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "postgres.custom-user-configname" .)) }}
+{{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "postgres.custom-user-configname" .)) }}
 {{- $existingPassword := "" }}
 {{- if and $existingSecret $existingSecret.data }}
   {{- $existingPassword = index $existingSecret.data "CUSTOM_PASSWORD" }}
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "postgres.custom-user-configname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/postgres/templates/httproute.yaml
+++ b/charts/postgres/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/postgres/templates/ingress.yaml
+++ b/charts/postgres/templates/ingress.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}

--- a/charts/postgres/templates/init-scripts-configmap.yaml
+++ b/charts/postgres/templates/init-scripts-configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-init-scripts" (include "postgres.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/postgres/templates/replication-standby-init-configmap.yaml
+++ b/charts/postgres/templates/replication-standby-init-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-replication" (include "postgres.fullname" .) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/postgres/templates/secret.yaml
+++ b/charts/postgres/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "postgres.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -12,13 +12,13 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "postgres.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "postgres.fullname" .)) }}
   {{- $existingPostgresPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingPostgresPassword = index $existingSecret.data "postgres-password" }}
   {{- end }}
   {{- $postgresPassword := $existingPostgresPassword | default (.Values.auth.password | default (randAlphaNum 32) | b64enc) }}
-  {{- $host := printf "%s.%s.svc" (include "postgres.fullname" .) .Release.Namespace }}
+  {{- $host := printf "%s.%s.svc" (include "postgres.fullname" .) (include "cloudpirates.namespace" .) }}
   {{- $port := .Values.service.port | toString }}
   {{- $username := include "postgres.username" . }}
   {{- $database := include "postgres.database" . }}

--- a/charts/postgres/templates/service-metrics.yaml
+++ b/charts/postgres/templates/service-metrics.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "postgres.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/postgres/templates/service.yaml
+++ b/charts/postgres/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "postgres.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
@@ -33,7 +33,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "postgres.fullname" . }}-headless
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/postgres/templates/serviceaccount.yaml
+++ b/charts/postgres/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "postgres.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/postgres/templates/servicemonitor.yaml
+++ b/charts/postgres/templates/servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "postgres.fullname" . }}-metrics
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -6,7 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "postgres.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "postgres.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/postgres/values.schema.json
+++ b/charts/postgres/values.schema.json
@@ -511,6 +511,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/postgres/values.yaml
+++ b/charts/postgres/values.yaml
@@ -11,6 +11,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override postgres.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "2.19.1"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/README.md
+++ b/charts/rabbitmq-cluster-operator/README.md
@@ -78,6 +78,7 @@ The following table lists the configurable values of the RabbitMQ chart and thei
 | `kubeVersion`            | Override Kubernetes version                          | `""`            |
 | `nameOverride`           | String to partially override common.names.fullname   | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname       | `""`            |
+| `namespaceOverride`      | String to override the namespace for all resources   | `""`            |
 | `commonLabels`           | Labels to add to all deployed objects                | `{}`            |
 | `commonAnnotations`      | Annotations to add to all deployed objects           | `{}`            |
 | `clusterDomain`          | Kubernetes cluster domain name                       | `cluster.local` |

--- a/charts/rabbitmq-cluster-operator/values.schema.json
+++ b/charts/rabbitmq-cluster-operator/values.schema.json
@@ -1130,6 +1130,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "rabbitmqImage": {
             "type": "object",
             "properties": {

--- a/charts/rabbitmq-cluster-operator/values.yaml
+++ b/charts/rabbitmq-cluster-operator/values.yaml
@@ -25,6 +25,8 @@ kubeVersion: ""
 nameOverride: ""
 ## @param fullnameOverride String to fully override cloudpirates.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.19.9
+version: 0.20.0
 appVersion: "4.2.5"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -98,13 +98,14 @@ The following table lists the configurable parameters of the RabbitMQ chart and 
 
 ### Common parameters
 
-| Parameter           | Description                                    | Default         |
-| ------------------- | ---------------------------------------------- | --------------- |
-| `nameOverride`      | String to partially override rabbitmq.fullname | `""`            |
-| `fullnameOverride`  | String to fully override rabbitmq.fullname     | `""`            |
-| `commonLabels`      | Labels to add to all deployed objects          | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects     | `{}`            |
-| `clusterDomain`     | Kubernetes cluster domain                      | `cluster.local` |
+| Parameter           | Description                                        | Default         |
+| ------------------- | -------------------------------------------------- | --------------- |
+| `nameOverride`      | String to partially override rabbitmq.fullname     | `""`            |
+| `fullnameOverride`  | String to fully override rabbitmq.fullname         | `""`            |
+| `namespaceOverride` | String to override the namespace for all resources | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain                          | `cluster.local` |
 
 ### RabbitMQ image parameters
 

--- a/charts/rabbitmq/templates/configmap.yaml
+++ b/charts/rabbitmq/templates/configmap.yaml
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "rabbitmq.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- with (include "rabbitmq.annotations" .) }}
@@ -45,7 +45,7 @@ data:
     cluster_formation.k8s.host = kubernetes.default.svc.{{ .Values.clusterDomain }}
     cluster_formation.k8s.address_type = {{ .Values.peerDiscoveryK8sPlugin.addressType }}
     cluster_formation.k8s.service_name = {{ include "rabbitmq.fullname" . }}-headless
-    cluster_formation.k8s.hostname_suffix = .{{ include "rabbitmq.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+    cluster_formation.k8s.hostname_suffix = .{{ include "rabbitmq.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}
     {{- end }}
 
 

--- a/charts/rabbitmq/templates/definitions-configmap.yaml
+++ b/charts/rabbitmq/templates/definitions-configmap.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "rabbitmq.fullname" . }}-definitions
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- with (include "rabbitmq.annotations" .) }}

--- a/charts/rabbitmq/templates/httproute.yaml
+++ b/charts/rabbitmq/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}

--- a/charts/rabbitmq/templates/pdb.yaml
+++ b/charts/rabbitmq/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-pdb
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels: {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- with (include "rabbitmq.annotations" .) }}
   annotations:

--- a/charts/rabbitmq/templates/role.yaml
+++ b/charts/rabbitmq/templates/role.yaml
@@ -3,7 +3,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-peer-discovery
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels: {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- with (include "rabbitmq.annotations" .) }}
   annotations:

--- a/charts/rabbitmq/templates/rolebinding.yaml
+++ b/charts/rabbitmq/templates/rolebinding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "rabbitmq.fullname" . }}-peer-discovery
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels: {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- with (include "rabbitmq.annotations" .) }}
   annotations:
@@ -11,7 +11,7 @@ metadata:
   {{- end }}
 subjects:
   - kind: ServiceAccount
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "cloudpirates.namespace" . }}
     name: {{ include "rabbitmq.serviceAccountName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/rabbitmq/templates/secret.yaml
+++ b/charts/rabbitmq/templates/secret.yaml
@@ -1,11 +1,11 @@
 {{- if not .Values.auth.existingSecret }}
 {{- $secretName := include "rabbitmq.fullname" . }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $existingSecret := lookup "v1" "Secret" (include "cloudpirates.namespace" .) $secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   annotations:

--- a/charts/rabbitmq/templates/service-headless.yaml
+++ b/charts/rabbitmq/templates/service-headless.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rabbitmq.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- if or (include "rabbitmq.annotations" .) .Values.service.annotationsHeadless }}

--- a/charts/rabbitmq/templates/service.yaml
+++ b/charts/rabbitmq/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- if or (include "rabbitmq.annotations" .) .Values.service.annotations }}

--- a/charts/rabbitmq/templates/serviceaccount.yaml
+++ b/charts/rabbitmq/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "rabbitmq.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
   {{- if or (include "rabbitmq.annotations" .) .Values.serviceAccount.annotations }}

--- a/charts/rabbitmq/templates/servicemonitor.yaml
+++ b/charts/rabbitmq/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "rabbitmq.labels" . | nindent 4 }}
     {{- with .Values.metrics.serviceMonitor.labels }}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "rabbitmq.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- toYaml (merge (include "rabbitmq.labels" . | fromYaml) .Values.statefulsetLabels) | nindent 4 }}
   {{- if or (include "rabbitmq.annotations" .) .Values.statefulsetAnnotations }}
@@ -224,7 +224,7 @@ spec:
                   fieldPath: metadata.name
             {{- if .Values.peerDiscoveryK8sPlugin.useLongname }}
             - name: RABBITMQ_NODENAME
-              value: rabbit@$(NODE_NAME).{{ include "rabbitmq.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+              value: rabbit@$(NODE_NAME).{{ include "rabbitmq.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}
             {{- else }}
             - name: RABBITMQ_NODENAME
               value: rabbit@$(NODE_NAME)

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -517,6 +517,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -11,6 +11,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override rabbitmq.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: (ALPHA) High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/README.md
+++ b/charts/rustfs/README.md
@@ -92,12 +92,13 @@ The following table lists the configurable parameters of the RustFS chart and th
 
 ### Common parameters
 
-| Parameter           | Description                                  | Default |
-| ------------------- | -------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override rustfs.fullname | `""`    |
-| `fullnameOverride`  | String to fully override rustfs.fullname     | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects        | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects   | `{}`    |
+| Parameter           | Description                                        | Default |
+| ------------------- | -------------------------------------------------- | ------- |
+| `nameOverride`      | String to partially override rustfs.fullname       | `""`    |
+| `fullnameOverride`  | String to fully override rustfs.fullname           | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources | `""`    |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
 
 ### RustFS image configuration
 

--- a/charts/rustfs/templates/_helpers.tpl
+++ b/charts/rustfs/templates/_helpers.tpl
@@ -163,7 +163,7 @@ Example: http://rfs-rustfs-{0...1}.rfs-rustfs-headless.rustfs.svc.cluster.local
          http://[NODE].[HEADLESS-SERVICE].[NAMESPACE].svc.cluster.local
 */}}
 {{- define "rustfs.statefulNodes" -}}
-{{- $namespace := .Release.Namespace }}
+{{- $namespace := include "cloudpirates.namespace" . }}
 {{- $name := include "rustfs.fullname" . -}}
 {{- $maxNode := sub (include "rustfs.replicaCount" . | int) 1 }}
 {{- printf "http://%s-{0...%d}.%s-headless.%s.svc.cluster.local" $name $maxNode $name $namespace -}}

--- a/charts/rustfs/templates/configmap.yaml
+++ b/charts/rustfs/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "rustfs.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rustfs/templates/deployment.yaml
+++ b/charts/rustfs/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "rustfs.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rustfs/templates/httproute.yaml
+++ b/charts/rustfs/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}
@@ -83,7 +83,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $consoleFullName }}-console
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: console

--- a/charts/rustfs/templates/ingress.yaml
+++ b/charts/rustfs/templates/ingress.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}
@@ -52,7 +52,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-console
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: console

--- a/charts/rustfs/templates/pvc.yaml
+++ b/charts/rustfs/templates/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "rustfs.dataPvcName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: data
@@ -34,7 +34,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "rustfs.logsPvcName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: logs
@@ -65,7 +65,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "rustfs.tlsPvcName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: tls

--- a/charts/rustfs/templates/secret.yaml
+++ b/charts/rustfs/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "rustfs.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "rustfs.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "rustfs.fullname" .)) }}
   {{- $existingSecretKey := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingSecretKey = index $existingSecret.data "secret-key" }}

--- a/charts/rustfs/templates/service.yaml
+++ b/charts/rustfs/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rustfs.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
@@ -25,7 +25,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rustfs.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- with $annotations }}
@@ -49,7 +49,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "rustfs.fullname" . }}-console
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
     app.kubernetes.io/component: console

--- a/charts/rustfs/templates/serviceaccount.yaml
+++ b/charts/rustfs/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "rustfs.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/rustfs/templates/setup-pod.yaml
+++ b/charts/rustfs/templates/setup-pod.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "rustfs.fullname" . }}-setup-{{ randAlpha 5 | lower }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rustfs/templates/setup-secret.yaml
+++ b/charts/rustfs/templates/setup-secret.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "rustfs.fullname" . }}-setup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rustfs/templates/statefulset.yaml
+++ b/charts/rustfs/templates/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "rustfs.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rustfs/values.schema.json
+++ b/charts/rustfs/values.schema.json
@@ -411,6 +411,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/rustfs/values.yaml
+++ b/charts/rustfs/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override rustfs.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.10.4
+version: 0.11.0
 appVersion: "2.26.1"
 keywords:
   - timescaledb

--- a/charts/timescaledb/README.md
+++ b/charts/timescaledb/README.md
@@ -90,6 +90,7 @@ The following table lists the configurable parameters of the TimescaleDB chart a
 | `replicaCount`      | Number of TimescaleDB replicas to deploy (Note: TimescaleDB doesn't support multi-master replication by default) | `1`     |
 | `nameOverride`      | String to partially override timescaledb.fullname                                                                | `""`    |
 | `fullnameOverride`  | String to fully override timescaledb.fullname                                                                    | `""`    |
+| `namespaceOverride` | String to override the namespace for all resources                                                               | `""`    |
 | `commonLabels`      | Labels to add to all deployed objects                                                                            | `{}`    |
 | `commonAnnotations` | Annotations to add to all deployed objects                                                                       | `{}`    |
 

--- a/charts/timescaledb/templates/configmap.yaml
+++ b/charts/timescaledb/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "timescaledb.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "timescaledb.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/timescaledb/templates/secret.yaml
+++ b/charts/timescaledb/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "timescaledb.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "timescaledb.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "timescaledb.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "timescaledb.fullname" .)) }}
   {{- $existingPostgresPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingPostgresPassword = index $existingSecret.data "postgres-password" }}

--- a/charts/timescaledb/templates/service.yaml
+++ b/charts/timescaledb/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "timescaledb.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "timescaledb.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "timescaledb.fullname" . }}-headless
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "timescaledb.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/timescaledb/templates/statefulset.yaml
+++ b/charts/timescaledb/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "timescaledb.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "timescaledb.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/timescaledb/values.schema.json
+++ b/charts/timescaledb/values.schema.json
@@ -174,6 +174,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/timescaledb/values.yaml
+++ b/charts/timescaledb/values.yaml
@@ -10,6 +10,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override timescaledb.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.18.0
+version: 0.19.0
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the Valkey chart and th
 | `clusterDomain`        | Kubernetes cluster domain                                                                      | `cluster.local` |
 | `nameOverride`         | String to partially override valkey.fullname                                                   | `""`            |
 | `fullnameOverride`     | String to fully override valkey.fullname                                                       | `""`            |
+| `namespaceOverride`    | String to override the namespace for all resources                                             | `""`            |
 | `commonLabels`         | Labels to add to all deployed objects                                                          | `{}`            |
 | `commonAnnotations`    | Annotations to add to all deployed objects                                                     | `{}`            |
 

--- a/charts/valkey/templates/configmap.yaml
+++ b/charts/valkey/templates/configmap.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "valkey.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}

--- a/charts/valkey/templates/httproute.yaml
+++ b/charts/valkey/templates/httproute.yaml
@@ -13,7 +13,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- $annotations := merge $httpRoute.annotations .Values.commonAnnotations }}

--- a/charts/valkey/templates/ingress.yaml
+++ b/charts/valkey/templates/ingress.yaml
@@ -14,7 +14,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.ingress.annotations .Values.commonAnnotations }}

--- a/charts/valkey/templates/master-service.yaml
+++ b/charts/valkey/templates/master-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}-master
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: master

--- a/charts/valkey/templates/prestop-configmap.yaml
+++ b/charts/valkey/templates/prestop-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "valkey.fullname" . }}-prestop-script
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -23,8 +23,8 @@ data:
     VALKEY_PORT="{{ .Values.service.port }}"
     SENTINEL_PORT="{{ .Values.sentinel.port }}"
     MASTER_NAME="{{ .Values.sentinel.masterName }}"
-    HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
-    VALKEY_SERVICE="{{ include "valkey.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
+    HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+    VALKEY_SERVICE="{{ include "valkey.fullname" . }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
 
     # Set authentication if enabled
     {{- if .Values.auth.enabled }}

--- a/charts/valkey/templates/secret.yaml
+++ b/charts/valkey/templates/secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "valkey.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- if .Values.commonAnnotations }}
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "valkey.fullname" .)) }}
+  {{- $existingSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (include "valkey.fullname" .)) }}
   {{- $existingPassword := "" }}
   {{- if and $existingSecret $existingSecret.data }}
     {{- $existingPassword = index $existingSecret.data "password" }}

--- a/charts/valkey/templates/sentinel-service.yaml
+++ b/charts/valkey/templates/sentinel-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}-sentinel
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: sentinel

--- a/charts/valkey/templates/service-metrics.yaml
+++ b/charts/valkey/templates/service-metrics.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/valkey/templates/service.yaml
+++ b/charts/valkey/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "valkey.fullname" . }}-headless
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}

--- a/charts/valkey/templates/serviceaccount.yaml
+++ b/charts/valkey/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "valkey.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
       {{- include "valkey.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}

--- a/charts/valkey/templates/servicemonitor.yaml
+++ b/charts/valkey/templates/servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "valkey.fullname" . }}-metrics
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "valkey.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -399,6 +399,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "nodeSelector": {
             "type": "object"
         },

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -13,6 +13,8 @@ clusterDomain: cluster.local
 nameOverride: ""
 ## @param fullnameOverride String to fully override valkey.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.6.7
+version: 0.7.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -88,18 +88,19 @@ zkCli.sh -server my-zookeeper:2181
 
 ### Common Parameters
 
-| Parameter                            | Description                                                                             | Default |
-| ------------------------------------ | --------------------------------------------------------------------------------------- | ------- |
-| `nameOverride`                       | String to partially override fullname                                                   | `""`    |
-| `fullnameOverride`                   | String to fully override fullname                                                       | `""`    |
-| `commonLabels`                       | Labels to add to all deployed objects                                                   | `{}`    |
-| `commonAnnotations`                  | Annotations to add to all deployed objects                                              | `{}`    |
-| `replicaCount`                       | Number of ZooKeeper replicas to deploy                                                  | `3`     |
-| `podDisruptionBudget.enabled`        | Create a Pod Disruption Budget to ensure high availability during voluntary disruptions | `true`  |
-| `podDisruptionBudget.minAvailable`   | minAvailable for Pod Disruption Budget. Value is not mandatory.                         | `""`    |
-| `podDisruptionBudget.maxUnavailable` | minAvailable for Pod Disruption Budget. Value is not mandatory.                         | `""`    |
-| `networkPolicy.enabled`              | Enable network policies                                                                 | `true`  |
-| `command`                            | Override default container command (useful when the default entrypoint needs to be replaced) | `[]` |
+| Parameter                            | Description                                                                                  | Default |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- | ------- |
+| `nameOverride`                       | String to partially override fullname                                                        | `""`    |
+| `fullnameOverride`                   | String to fully override fullname                                                            | `""`    |
+| `namespaceOverride`                  | String to override the namespace for all resources                                           | `""`    |
+| `commonLabels`                       | Labels to add to all deployed objects                                                        | `{}`    |
+| `commonAnnotations`                  | Annotations to add to all deployed objects                                                   | `{}`    |
+| `replicaCount`                       | Number of ZooKeeper replicas to deploy                                                       | `3`     |
+| `podDisruptionBudget.enabled`        | Create a Pod Disruption Budget to ensure high availability during voluntary disruptions      | `true`  |
+| `podDisruptionBudget.minAvailable`   | minAvailable for Pod Disruption Budget. Value is not mandatory.                              | `""`    |
+| `podDisruptionBudget.maxUnavailable` | minAvailable for Pod Disruption Budget. Value is not mandatory.                              | `""`    |
+| `networkPolicy.enabled`              | Enable network policies                                                                      | `true`  |
+| `command`                            | Override default container command (useful when the default entrypoint needs to be replaced) | `[]`    |
 
 ### ZooKeeper Configuration
 

--- a/charts/zookeeper/templates/_helpers.tpl
+++ b/charts/zookeeper/templates/_helpers.tpl
@@ -65,7 +65,7 @@ This is useful when migrating from Bitnami Zookeeper, which uses 1-based IDs (my
 Set serverIdOffset=1 to generate server.1, server.2, server.3 instead of server.0, server.1, server.2.
 */}}
 {{- define "zookeeper.servers" -}}
-{{- $namespace := .Release.Namespace }}
+{{- $namespace := include "cloudpirates.namespace" . }}
 {{- $name := include "zookeeper.fullname" . -}}
 {{- $peersPort := .Values.service.ports.quorum -}}
 {{- $leaderElectionPort := .Values.service.ports.leaderElection -}}

--- a/charts/zookeeper/templates/configmap.yaml
+++ b/charts/zookeeper/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "zookeeper.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
   {{- with (include "zookeeper.annotations" .) }}

--- a/charts/zookeeper/templates/metrics-service.yaml
+++ b/charts/zookeeper/templates/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "zookeeper.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -3,7 +3,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
   {{- with (include "zookeeper.annotations" .) }}

--- a/charts/zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/zookeeper/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
   {{- with (include "zookeeper.annotations" .) }}

--- a/charts/zookeeper/templates/service.yaml
+++ b/charts/zookeeper/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
   {{- $annotations := merge .Values.service.annotations .Values.commonAnnotations }}
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "zookeeper.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
 spec:

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "zookeeper.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "zookeeper.labels" . | nindent 4 }}
   {{- with (include "zookeeper.annotations" .) }}

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -188,6 +188,9 @@
         "nameOverride": {
             "type": "string"
         },
+        "namespaceOverride": {
+            "type": "string"
+        },
         "networkPolicy": {
             "type": "object",
             "properties": {

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -12,6 +12,8 @@ global:
 nameOverride: ""
 ## @param fullnameOverride String to fully override zookeeper.fullname
 fullnameOverride: ""
+## @param namespaceOverride String to override the namespace for all resources
+namespaceOverride: ""
 ## @param serverIdOffset Offset for server IDs in zoo.cfg (set to 1 for Bitnami migration where myid starts at 1)
 ## When migrating from Bitnami Zookeeper:
 ##   1. Set serverIdOffset: 1 (Bitnami uses 1-based myid: 1,2,3 vs default 0-based: 0,1,2)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add the capability to override the namespace for each Chart and fixes some value errors in `mongodb`/`rabbitmq-cluster-Operator Chart`.

[all]: Add the `namespaceOverride` Value used in commons to all Charts that it not used yet.

[mongodb]:
- Fix wrong value `.Value.imagePullSecret` to `.Value.global.imagePullSecret` in `spec.template.spec.imagePullSecret` of `statefulset-arbiter.yaml`
- Fix wrong value `.Value.imagePullSecret` to `.Value.global.imagePullSecret` in `spec.template.spec.imagePullSecret` of `statefulset-hidden.yaml`
- Fix wrong value `.Value.initContainer.Resources` to `.Value.initContainer.resources` in `spec.template.spec.initContainers[0]` of `statefulset-hidden.yaml`
- Add missing Value `extraInitContainers`
- Add missing Value `customLivenessProbe`
- Add missing Value `customReadinessProbe`
- Add missing Value `customStartupProbe`
- Add missing Value `config.existingConfigmapKey`

[rabbitmq-cluster-Operator]:
- Add Value namespaceOverride to documentation

### Benefits

All Charts can now be used in a multi-namespace system, such as with an Umbrella Chart.

### Possible drawbacks

Not observed.

### Applicable issues


### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
