### PR TITLE
[RustFS chart] custom clusterDomain

### DIFF
--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: (ALPHA) High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/README.md
+++ b/charts/rustfs/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the RustFS chart and th
 | `namespaceOverride` | String to override the namespace for all resources | `""`    |
 | `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
 | `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
+| `clusterDomain`     | Kubernetes cluster domain                          | `cluster.local` |
 
 ### RustFS image configuration
 

--- a/charts/rustfs/templates/_helpers.tpl
+++ b/charts/rustfs/templates/_helpers.tpl
@@ -160,13 +160,13 @@ Return minimal Replicas in statefulset mode
 {{/*
 Return RustFS Stateful Nodes
 Example: http://rfs-rustfs-{0...1}.rfs-rustfs-headless.rustfs.svc.cluster.local
-         http://[NODE].[HEADLESS-SERVICE].[NAMESPACE].svc.cluster.local
+         http://[NODE].[HEADLESS-SERVICE].[NAMESPACE].svc.[CLUSTER-DOMAIN]
 */}}
 {{- define "rustfs.statefulNodes" -}}
 {{- $namespace := include "cloudpirates.namespace" . }}
 {{- $name := include "rustfs.fullname" . -}}
 {{- $maxNode := sub (include "rustfs.replicaCount" . | int) 1 }}
-{{- printf "http://%s-{0...%d}.%s-headless.%s.svc.cluster.local" $name $maxNode $name $namespace -}}
+{{- printf "http://%s-{0...%d}.%s-headless.%s.svc.%s" $name $maxNode $name $namespace .Values.clusterDomain -}}
 {{- end }}
 
 {{/*

--- a/charts/rustfs/tests/common-parameters_test.yaml
+++ b/charts/rustfs/tests/common-parameters_test.yaml
@@ -2,6 +2,7 @@ suite: test rustfs common parameters
 templates:
   - deployment.yaml
   - statefulset.yaml
+  - configmap.yaml
 set:
   deploymentType: statefulset
   image:
@@ -205,3 +206,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should respect clusterDomain when rendering stateful node volumes
+    set:
+      deploymentType: statefulset
+      clusterDomain: custom.internal
+      replicaCount: 4
+    template: configmap.yaml
+    asserts:
+      - equal:
+          path: data.RUSTFS_VOLUMES
+          value: http://RELEASE-NAME-rustfs-{0...3}.RELEASE-NAME-rustfs-headless.NAMESPACE.svc.custom.internal:9000/data

--- a/charts/rustfs/values.schema.json
+++ b/charts/rustfs/values.schema.json
@@ -28,6 +28,9 @@
         "commonAnnotations": {
             "type": "object"
         },
+        "clusterDomain": {
+            "type": "string"
+        },
         "commonLabels": {
             "type": "object"
         },

--- a/charts/rustfs/values.schema.json
+++ b/charts/rustfs/values.schema.json
@@ -25,11 +25,11 @@
                 }
             }
         },
-        "commonAnnotations": {
-            "type": "object"
-        },
         "clusterDomain": {
             "type": "string"
+        },
+        "commonAnnotations": {
+            "type": "object"
         },
         "commonLabels": {
             "type": "object"

--- a/charts/rustfs/values.yaml
+++ b/charts/rustfs/values.yaml
@@ -16,6 +16,8 @@ namespaceOverride: ""
 commonLabels: {}
 ## @param commonAnnotations Annotations to add to all deployed objects
 commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain
+clusterDomain: cluster.local
 
 ## @section RustFS image configuration
 image:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add `clusterDomain` parameter to RustFS chart and update related configurations

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->
Works with K8s clusters has custom cluster domain

### Possible drawbacks

None

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
