### PR TITLE
[zookeeper] Add support for custom servers list

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.7.0
+version: 0.8.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -114,6 +114,7 @@ zkCli.sh -server my-zookeeper:2181
 | `zookeeperConfig.standaloneEnabled`         | Enable standalone mode                              | `"false"`   |
 | `zookeeperConfig.adminServerEnabled`        | Enable admin server                                 | `"false"`   |
 | `zookeeperConfig.commandsWhitelist`         | 4-letter word commands whitelist                    | `srvr`      |
+| `zookeeperConfig.customServers`             | Custom zoo.cfg server lines. When set, generated `server.N` entries are replaced by these values | `[]`        |
 | `zookeeperConfig.autopurge.purgeInterval`   | Autopurge purge interval (hours)                    | `24`        |
 | `zookeeperConfig.autopurge.snapRetainCount` | Autopurge snapshot retain count                     | `3`         |
 | `zookeeperConfig.admin.enableServer`        | Enable the admin server                             | `"false"`   |

--- a/charts/zookeeper/templates/_helpers.tpl
+++ b/charts/zookeeper/templates/_helpers.tpl
@@ -60,11 +60,19 @@ in a format like:
 - server.0=zkhost0:port:port
 - server.1=zkhost1:port:port
 
+If zookeeperConfig.customServers is set, generated servers are skipped and only
+custom server lines are rendered.
+
 serverIdOffset (default 0) allows shifting server IDs to match existing myid files.
 This is useful when migrating from Bitnami Zookeeper, which uses 1-based IDs (myid=1,2,3).
 Set serverIdOffset=1 to generate server.1, server.2, server.3 instead of server.0, server.1, server.2.
 */}}
 {{- define "zookeeper.servers" -}}
+{{- if .Values.zookeeperConfig.customServers }}
+{{- range .Values.zookeeperConfig.customServers }}
+{{ . }}
+{{- end }}
+{{- else }}
 {{- $namespace := include "cloudpirates.namespace" . }}
 {{- $name := include "zookeeper.fullname" . -}}
 {{- $peersPort := .Values.service.ports.quorum -}}
@@ -72,5 +80,6 @@ Set serverIdOffset=1 to generate server.1, server.2, server.3 instead of server.
 {{- $offset := int (default 0 .Values.serverIdOffset) -}}
 {{- range $idx, $v := until (int .Values.replicaCount) }}
 server.{{ add $idx $offset }}={{ printf "%s-%d.%s-headless.%s.svc.cluster.local:%d:%d" $name $idx $name $namespace (int $peersPort) (int $leaderElectionPort) }}
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -399,6 +399,12 @@
                 "commandsWhitelist": {
                     "type": "string"
                 },
+                "customServers": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "electionPortBindRetry": {
                     "type": "integer"
                 },

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -85,6 +85,13 @@ zookeeperConfig:
   ## possible values are: "srvr,ruok,conf,cons,dump,envi,ruok,mntr,stat" or "*" to allow all commands
   ## @see https://zookeeper.apache.org/doc/r3.5.9/zookeeperAdmin.html#sc_clusterOptions
   commandsWhitelist: "srvr"
+  ## @param zookeeperConfig.customServers Custom zoo.cfg server lines. When set, generated `server.N` entries are replaced by these values.
+  ## Example:
+  ##   zookeeperConfig:
+  ##     customServers:
+  ##       - "server.10=zk-external-0.example.com:2888:3888"
+  ##       - "server.11=zk-external-1.example.com:2888:3888"
+  customServers: []
   autopurge:
     ## @param zookeeperConfig.autopurge.purgeInterval Zookeeper autopurge purge interval (in hours)
     purgeInterval: 24


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

My changes allow overriding the servers list in the zookeeper config.

### Benefits

We can create a custom list of servers that allows us to combine 2 helm releases for the migration purpose, or more importantly, we can create custom services with the ClusterIp instead of headless for static IPs in the topology. This allows us to have no downtime (or at least smaller) on the node pool update or something else.

### Possible drawbacks

No behavior changes without setting the new value.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
