### PR TITLE
[mongodb] Fix namespace context in custom-user-secret range loop

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.15.1
+version: 0.15.2
 appVersion: "8.2.6"
 keywords:
   - mongodb

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: "8.2.6"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/custom-user-secret.yaml
+++ b/charts/mongodb/templates/custom-user-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "mongodb.fullname" $ }}-custom-user-{{ $i }}-secret
-  namespace: {{ include "cloudpirates.namespace" . }}
+  namespace: {{ include "cloudpirates.namespace" $ }}
   labels:
     {{- include "mongodb.labels" $ | nindent 4 }}
   {{- with (include "mongodb.annotations" $) }}


### PR DESCRIPTION
## Problem

When `customUsers` is configured in the MongoDB chart, the chart fails to render with:

`template: mongodb/templates/custom-user-secret.yaml:8:16: nil pointer evaluating interface {}.Namespace`

## Root Cause

In `charts/mongodb/templates/custom-user-secret.yaml` line 8, the `cloudpirates.namespace` helper is called with `.` (dot) inside a `{{- range }}` block. Inside `range`, `.` is reassigned to the current loop variable (`$user`), which does not have `.Release.Namespace`. This causes a nil pointer error.

Other helpers in the same file (`mongodb.fullname`, `mongodb.labels`) correctly use `$` to reference the root context.

## Fix

Changed `.` to `$` on line 8:

  ```diff
  -  namespace: {{ include "cloudpirates.namespace" . }}
  +  namespace: {{ include "cloudpirates.namespace" $ }}
```