### PR TITLE
[mongodb] Fix config duplication on init container restart

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.15.0
+version: 0.15.1
 appVersion: "8.2.6"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/init-scripts.yaml
+++ b/charts/mongodb/templates/init-scripts.yaml
@@ -488,7 +488,7 @@ data:
     # Copy extra initialization scripts for ReplicaSet cluster
     cp /scripts/extra-*.sh /extrainitscripts
     echo "Copy custom configuration"
-    touch /configs/mongod.conf
+    : > /configs/mongod.conf
     if [ -d /customconfig ]; then
       echo "Create custom mongodb config"
       cat /customconfig/* >>/configs/mongod.conf


### PR DESCRIPTION
### Description of the change

The init container's `init.sh` uses `touch /configs/mongod.conf` followed by `cat /customconfig/* >> /configs/mongod.conf` to assemble the MongoDB config file into an emptyDir volume.

If the init container restarts (OOMKill, node pressure, etc.), `touch` doesn't truncate so the config content gets appended a second time, producing duplicate YAML mapping keys (e.g. `systemLog` appears twice).

MongoDB 8.x's `docker-entrypoint.sh` parses the config with `js-yaml.load()`, which rejects duplicate keys:

```
  YAMLException: duplicated mapping key at line 6, column -39:
      systemLog:
      ^
  error: unexpected "js-yaml.js" output while parsing config:
```

The fix changes `touch` to `: >` (truncate-or-create) so the file always starts empty, making the init script idempotent across restarts.

### Benefits

- Eliminates a crash loop that requires manually deleting the MongoDB pod to recover
- Makes the init container idempotent - safe across restarts regardless of cause

### Possible drawbacks

  None. `: > file` is POSIX-compliant and behaves identically to `touch` on first run; the only difference is that it truncates if the file already exists, which should be the desired behavior.

### Applicable issues

- None found

### Additional information

I only verified this fix locally and am happy to be corrected on my assumptions