### PR TITLE
[redis] Fix the Redis Sentinel **master discovery** deployment

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.26.8
+version: 0.26.9
 appVersion: "8.6.2"
 keywords:
   - redis

--- a/charts/redis/templates/sentinel-master-deployment.yaml
+++ b/charts/redis/templates/sentinel-master-deployment.yaml
@@ -83,13 +83,14 @@ spec:
             echo "Sentinel Master Name: $SENTINEL_MASTER_NAME"
             echo "Check Interval: ${CHECK_INTERVAL}s"
 
-            oldmaster="<none>"
-
             while true; do
-              # Get a random Redis pod to query Sentinel from
+              # Current master targeted by the service (source of truth across restarts)
+              oldmaster=$(kubectl get service "$MASTER_SERVICE" -n "$NAMESPACE" \
+                -o jsonpath='{.spec.selector.statefulset\.kubernetes\.io/pod-name}' 2>/dev/null || echo "<none>")
+
+              # Get a random Redis Sentinel pod to query Sentinel from
               pod=$(kubectl get pods -n "$NAMESPACE" \
-                --selector="app.kubernetes.io/instance={{ .Release.Name }}" \
-                --selector="app.kubernetes.io/name={{ include "redis.name" . }}" \
+                --selector="app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=sentinel" \
                 -o name 2>/dev/null | shuf | head -n1)
 
               if [ -z "$pod" ]; then
@@ -100,9 +101,8 @@ spec:
 
               echo "Querying Sentinel via pod: $pod"
 
-              # Query Sentinel for the current master hostname
-              # Use the first pod (redis-0) as it should always be available
-              master_hostname=$(kubectl exec -n "$NAMESPACE" "${RELEASE_NAME}-0" -c sentinel -- \
+              # Query Sentinel for the current master hostname via the selected pod
+              master_hostname=$(kubectl exec -n "$NAMESPACE" "$pod" -c sentinel -- \
                 redis-cli --raw -p {{ .Values.sentinel.port }}{{- if .Values.auth.sentinel }} -a "$REDIS_PASSWORD"{{- end }}{{- if .Values.tls.enabled }} {{ include "redis.tls.probeArgs" . }}{{- end }} \
                 sentinel GET-MASTER-ADDR-BY-NAME "$SENTINEL_MASTER_NAME" 2>/dev/null \
                 | head -n1 || echo "")
@@ -131,7 +131,6 @@ spec:
               if kubectl patch service "$MASTER_SERVICE" -n "$NAMESPACE" \
                 -p "{\"spec\": {\"selector\": {\"statefulset.kubernetes.io/pod-name\": \"$master\"}}}"; then
                 echo "Successfully updated service to point to master: $master"
-                oldmaster="$master"
               else
                 echo "Error: Failed to update service, will retry..."
                 sleep 10


### PR DESCRIPTION
### Description of the change
Fixes the Redis Sentinel **master discovery** deployment (`charts/redis/templates/sentinel-master-deployment.yaml`) so the **`-master` Service** selector stays aligned with the current Sentinel-reported master:
- **Pod selection:** Uses a single `kubectl` label selector: `app.kubernetes.io/instance=<release>,app.kubernetes.io/component=sentinel`, so discovery targets Sentinel-enabled Redis pods consistently (avoids relying on multiple `--selector` flags).
- **Change detection:** Reads the **current** master pod name from the **master Service** (`spec.selector.statefulset.kubernetes.io/pod-name`) each loop instead of keeping `oldmaster` only in memory. That way a **restart** of the discovery Deployment does not lose track of what the Service already points at.
- **Sentinel query:** Runs `redis-cli` / `GET-MASTER-ADDR-BY-NAME` via **`kubectl exec` on the randomly chosen pod** from the list step, instead of always using pod `0` (which can be down after a node failure).
### Benefits
- More reliable master routing after **failover** and after **discovery pod restarts**.
- Fewer incorrect or redundant patches when the in-process state and cluster state diverged.
- Sentinel is queried from an **available** Sentinel pod rather than assuming `replica-0` is always up.
### Additional information
**Files touched:** `charts/redis/templates/sentinel-master-deployment.yaml`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))