### PR TITLE
[mongodb]: Fix inconsistencies on sharded cluster setup

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: "8.2.6"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/statefulset-configserver.yaml
+++ b/charts/mongodb/templates/statefulset-configserver.yaml
@@ -108,7 +108,7 @@ spec:
             - name: mongodb-keyfile-data
               mountPath: /keyfile-data
             {{- end }}
-          resources: {{ toYaml (coalesce .Values.shardedCluster.configsvr.resources .Values.initContainer.resources) | nindent 12 }}
+          resources: {{ toYaml (coalesce .Values.initContainer.resources .Values.shardedCluster.configsvr.resources) | nindent 12 }}
       containers:
         - name: mongodb-configserver
           image: {{ include "mongodb.image" . }}
@@ -243,7 +243,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           securityContext: {{ toYaml .Values.metrics.containerSecurityContext | nindent 12 }}
           command:
-            - mongodb_exporter
+            - /mongodb_exporter
             - --mongodb.uri=mongodb://{{ if .Values.auth.enabled }}$(MONGODB_METRICS_USERNAME):$(MONGODB_METRICS_PASSWORD)@{{ end }}localhost:27017{{ if .Values.auth.enabled }}/admin{{ end }}
             - --web.listen-address=:9216
             - --collect-all

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -115,7 +115,7 @@ spec:
             - name: mongodb-keyfile-data
               mountPath: /keyfile-data
             {{- end }}
-          resources: {{ toYaml (coalesce .Values.shardedCluster.mongos.resources .Values.initContainer.resources) | nindent 12 }}
+          resources: {{ toYaml (coalesce .Values.initContainer.resources .Values.shardedCluster.mongos.resources) | nindent 12 }}
       containers:
         - name: mongos
           image: {{ include "mongodb.image" . }}
@@ -223,7 +223,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           securityContext: {{ toYaml .Values.metrics.containerSecurityContext | nindent 12 }}
           command:
-            - mongodb_exporter
+            - /mongodb_exporter
             - --mongodb.uri=mongodb://{{ if .Values.auth.enabled }}$(MONGODB_METRICS_USERNAME):$(MONGODB_METRICS_PASSWORD)@{{ end }}localhost:27017{{ if .Values.auth.enabled }}/admin{{ end }}
             - --web.listen-address=:9216
             - --collect-all

--- a/charts/mongodb/templates/statefulset-shard.yaml
+++ b/charts/mongodb/templates/statefulset-shard.yaml
@@ -119,7 +119,7 @@ spec:
             - name: mongodb-keyfile-data
               mountPath: /keyfile-data
             {{- end }}
-          resources: {{ toYaml (coalesce $.Values.shardedCluster.shardsvr.dataNode.resources $.Values.initContainer.resources) | nindent 12 }}
+          resources: {{ toYaml (coalesce $.Values.initContainer.resources $.Values.shardedCluster.shardsvr.dataNode.resources) | nindent 12 }}
       containers:
         - name: mongodb-shard-{{ $shardIndex }}
           image: {{ include "mongodb.image" $ }}
@@ -260,7 +260,7 @@ spec:
           imagePullPolicy: {{ $.Values.metrics.image.pullPolicy }}
           securityContext: {{ toYaml $.Values.metrics.containerSecurityContext | nindent 12 }}
           command:
-            - mongodb_exporter
+            - /mongodb_exporter
             - --mongodb.uri=mongodb://{{ if $.Values.auth.enabled }}$(MONGODB_METRICS_USERNAME):$(MONGODB_METRICS_PASSWORD)@{{ end }}localhost:27017{{ if $.Values.auth.enabled }}/admin{{ end }}
             - --web.listen-address=:9216
             - --collect-all
@@ -468,7 +468,7 @@ spec:
             - name: mongodb-keyfile-data
               mountPath: /keyfile-data
             {{- end }}
-          resources: {{ toYaml (coalesce $.Values.shardedCluster.shardsvr.arbiter.resources $.Values.initContainer.resources) | nindent 12 }}
+          resources: {{ toYaml (coalesce $.Values.initContainer.resources $.Values.shardedCluster.shardsvr.arbiter.resources) | nindent 12 }}
       containers:
         - name: mongodb-shard-{{ $shardIndex }}-arbiter
           image: {{ include "mongodb.image" $ }}


### PR DESCRIPTION
### Description of the change

  Fixes two bugs in the MongoDB sharded cluster templates:

  1. **Metrics exporter not found in PATH**: `statefulset-shard.yaml`, `statefulset-configserver.yaml`, and `statefulset-mongos.yaml` used
  `mongodb_exporter` as a bare command, relying on PATH lookup. The binary lives at `/mongodb_exporter` in the container image. Changed to
  `/mongodb_exporter` (absolute path), consistent with the non-sharded `statefulset.yaml`.

  2. **Init container resources ignored when component resources are set**: The `coalesce` order in the sharded statefulsets was `coalesce
  <component-resources> <initContainer.resources>`, causing globally configured `initContainer.resources` to be silently ignored whenever
  component-level resources were also set. Swapped the order so `initContainer.resources` takes priority.

  ### Benefits

  - Metrics exporter works in sharded clusters.
  - `initContainer.resources` behaves consistently — global values are no longer overridden by component-level resource settings.

  ### Possible drawbacks

  ### Applicable issues

  ### Additional information

  ### Checklist

  - [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
  - [X] Variables are documented in the values.yaml and added to the `README.md`
  - [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
  - [X] All commits are signed and verified