### PR TITLE
[redis]: Configurable startup delay for starting the redis-server

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.26.9
+version: 0.26.10
 appVersion: "8.6.2"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -267,6 +267,10 @@ spec:
               fi
               {{- end }}
               {{- else if eq .Values.architecture "cluster" }}
+              {{- if gt (int .Values.cluster.startupSleepTime) 0 }}
+              echo "Sleeping for {{ .Values.cluster.startupSleepTime }}s (cluster.startupSleepTime configured)..."
+              sleep {{ .Values.cluster.startupSleepTime }}
+              {{- end }}
               echo "" >> /tmp/redis.conf
               echo "# Default cluster settings" >> /tmp/redis.conf
               echo "cluster-enabled yes" >> /tmp/redis.conf
@@ -403,6 +407,10 @@ spec:
               fi
               {{- end }}
               {{- else if eq .Values.architecture "cluster" }}
+              {{- if gt (int .Values.cluster.startupSleepTime) 0 }}
+              echo "Sleeping for {{ .Values.cluster.startupSleepTime }}s (cluster.startupSleepTime configured)..."
+              sleep {{ .Values.cluster.startupSleepTime }}
+              {{- end }}
               echo "" >> /tmp/redis.conf
               echo "# Redis Cluster Configuration" >> /tmp/redis.conf
               echo "cluster-enabled yes" >> /tmp/redis.conf

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -267,10 +267,6 @@ spec:
               fi
               {{- end }}
               {{- else if eq .Values.architecture "cluster" }}
-              {{- if gt (int .Values.cluster.startupSleepTime) 0 }}
-              echo "Sleeping for {{ .Values.cluster.startupSleepTime }}s (cluster.startupSleepTime configured)..."
-              sleep {{ .Values.cluster.startupSleepTime }}
-              {{- end }}
               echo "" >> /tmp/redis.conf
               echo "# Default cluster settings" >> /tmp/redis.conf
               echo "cluster-enabled yes" >> /tmp/redis.conf
@@ -407,10 +403,6 @@ spec:
               fi
               {{- end }}
               {{- else if eq .Values.architecture "cluster" }}
-              {{- if gt (int .Values.cluster.startupSleepTime) 0 }}
-              echo "Sleeping for {{ .Values.cluster.startupSleepTime }}s (cluster.startupSleepTime configured)..."
-              sleep {{ .Values.cluster.startupSleepTime }}
-              {{- end }}
               echo "" >> /tmp/redis.conf
               echo "# Redis Cluster Configuration" >> /tmp/redis.conf
               echo "cluster-enabled yes" >> /tmp/redis.conf
@@ -525,6 +517,10 @@ spec:
               CONFIG_FILE="/tmp/redis.conf"
               {{- else }}
               CONFIG_FILE="{{ include "redis.configFullName" . }}"
+              {{- end }}
+              {{- if gt (int .Values.cluster.startupSleepTime) 0 }}
+              echo "Sleeping for {{ .Values.cluster.startupSleepTime }}s (cluster.startupSleepTime configured)..."
+              sleep {{ .Values.cluster.startupSleepTime }}
               {{- end }}
 
               redis-server "$CONFIG_FILE" {{- if and .Values.auth.enabled (not .Values.auth.acl.enabled) }} --requirepass "${REDIS_PASSWORD}" {{- end }} {{- range .Values.extraFlags }} {{ . }}{{- end }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -61,6 +61,9 @@
                             "type": "boolean"
                         }
                     }
+                },
+                "startupSleepTime": {
+                    "type": "integer"
                 }
             }
         },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -174,6 +174,11 @@ cluster:
   ## When enabled, Redis will announce pod hostnames instead of IPs, making cluster more resilient to pod restarts
   ## This addresses the issue where pod IP changes on restart cause connection errors
   announceHostnames: false
+  ## @param cluster.startupSleepTime Seconds to sleep in the init container before configuring Redis Cluster
+  ## Useful when persistence is disabled: gives the cluster time to detect a failed master and elect
+  ## a new one before the restarting pod rejoins, preventing the old master from re-entering as master
+  ## with an empty dataset. Set to 0 to disable (default).
+  startupSleepTime: 0
   ## @param cluster.config Additional cluster-specific configuration settings
   ## These settings are automatically applied when architecture=cluster
   config:


### PR DESCRIPTION
### Description of the change

Adds a configurable startup time to the regis-server startup, useful in master-slave setups

### Benefits

See #1211

### Possible drawbacks

None, by default this new option changes nothing

### Applicable issues

- fixes #1211 

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
