### PR TITLE
[rabbitmq]: Add seccompProfile RuntimeDefault to podSecurityContext

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.20.0
+version: 0.20.1
 appVersion: "4.2.5"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -312,16 +312,17 @@ kubectl edit configmap my-rabbitmq-definitions -n <namespace>
 
 ### Security Context
 
-| Parameter                                           | Description                                       | Default   |
-| --------------------------------------------------- | ------------------------------------------------- | --------- |
-| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod               | `999`     |
-| `containerSecurityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
-| `containerSecurityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
-| `containerSecurityContext.runAsUser`                | User ID for the RabbitMQ container                | `999`     |
-| `containerSecurityContext.runAsGroup`               | Group ID for the RabbitMQ container               | `999`     |
-| `containerSecurityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `true`    |
-| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
-| `priorityClassName`                                 | Priority class for the rabbitmq instance          | `""`      |
+| Parameter                                           | Description                                       | Default                  |
+| --------------------------------------------------- | ------------------------------------------------- | ------------------------ |
+| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod               | `999`                    |
+| `podSecurityContext.seccompProfile`                 | Seccomp profile for the pod                       | `{type: RuntimeDefault}` |
+| `containerSecurityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`                  |
+| `containerSecurityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`                   |
+| `containerSecurityContext.runAsUser`                | User ID for the RabbitMQ container                | `999`                    |
+| `containerSecurityContext.runAsGroup`               | Group ID for the RabbitMQ container               | `999`                    |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `true`                   |
+| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]`                |
+| `priorityClassName`                                 | Priority class for the rabbitmq instance          | `""`                     |
 
 ### Liveness and readiness probes
 

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -611,6 +611,14 @@
             "properties": {
                 "fsGroup": {
                     "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -436,6 +436,9 @@ containerSecurityContext:
 podSecurityContext:
   ## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
   fsGroup: 999
+  ## @param podSecurityContext.seccompProfile Seccomp profile for the pod
+  seccompProfile:
+    type: RuntimeDefault
 
 ## @param priorityClassName Priority class for the rabbitmq instance
 priorityClassName: ""


### PR DESCRIPTION
### Description of the change

  Adds `seccompProfile: type: RuntimeDefault` to the `podSecurityContext` of the RabbitMQ chart.

  ### Benefits

  Improves the security posture of the RabbitMQ pod by restricting system calls to the container runtime's default seccomp profile, reducing the attack surface.

  ### Possible drawbacks

  None. `RuntimeDefault` is the standard seccomp profile and is supported by all major Kubernetes distributions.

  ### Applicable issues

  N/A

  ### Additional information

  N/A

  ### Checklist

  - [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
  - [X] Variables are documented in the values.yaml and added to the `README.md`
  - [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
  - [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
