### PR TITLE
[all]: comment out default resources requests/limits (#1215)

### DIFF
--- a/charts/clusterpirate/Chart.yaml
+++ b/charts/clusterpirate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clusterpirate
 description: Client agent for the CloudPirates Managed Observability Platform to connect your Kubernetes cluster to our infrastructure
 type: application
-version: 1.4.3
+version: 1.5.0
 appVersion: "1.0.1"
 keywords:
   - kubernetes

--- a/charts/clusterpirate/README.md
+++ b/charts/clusterpirate/README.md
@@ -96,9 +96,7 @@ The following table lists the configurable parameters of the ClusterPirate chart
 | `deployment.image.repository`          | ClusterPirate image repository             | `koperator-internal/services/clusterpirate` |
 | `deployment.image.tag`                 | ClusterPirate image tag                    | `latest`                                    |
 | `deployment.image.pullPolicy`          | ClusterPirate image pull policy            | `Always`                                    |
-| `deployment.resources.limits.memory`   | Memory limit for ClusterPirate container   | `300Mi`                                     |
-| `deployment.resources.requests.memory` | Memory request for ClusterPirate container | `100Mi`                                     |
-| `deployment.resources.requests.cpu`    | CPU request for ClusterPirate container    | `10m`                                       |
+| `deployment.resources`                 | Resource limits and requests for ClusterPirate container | `{}`                                        |
 | `deployment.extraEnvVars`              | Additional environment variables           | `[]`                                        |
 
 ### Health probe configuration

--- a/charts/clusterpirate/values.schema.json
+++ b/charts/clusterpirate/values.schema.json
@@ -138,28 +138,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 }
             }
         },

--- a/charts/clusterpirate/values.yaml
+++ b/charts/clusterpirate/values.yaml
@@ -32,12 +32,12 @@ image:
 
 deployment:
   # Pod resource limits and requests
-  resources:
-    limits:
-      memory: 256Mi
-    requests:
-      memory: 256Mi
-      cpu: 10m
+  resources: {}
+    # limits:
+    #   memory: 256Mi
+    # requests:
+    #   memory: 256Mi
+    #   cpu: 10m
 
   # Additional environment variables (optional)
   # Example:

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.20.5
+version: 0.21.0
 appVersion: "26.6.1"
 keywords:
   - keycloak

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -300,31 +300,7 @@
                             "type": "string"
                         },
                         "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
+                            "type": "object"
                         },
                         "tag": {
                             "type": "string"
@@ -347,31 +323,7 @@
                             "type": "string"
                         },
                         "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
+                            "type": "object"
                         },
                         "tag": {
                             "type": "string"

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -503,13 +503,13 @@ initContainers:
     ## @param initContainers.waitForPostgres.pullPolicy PostgreSQL image pull policy
     pullPolicy: IfNotPresent
     ## @param initContainers.waitForPostgres.resources Resource requests and limits for PostgreSQL init container
-    resources:
-      limits:
-        cpu: 100m
-        memory: 64Mi
-      requests:
-        cpu: 100m
-        memory: 32Mi
+    resources: {}
+      # limits:
+      #   cpu: 100m
+      #   memory: 64Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 32Mi
   waitForMariadb:
     ## @param initContainers.waitForMariadb.image MariaDB init container image for waiting (leave empty to use registry/repository/tag)
     image: ""
@@ -522,13 +522,13 @@ initContainers:
     ## @param initContainers.waitForMariadb.pullPolicy MariaDB image pull policy
     pullPolicy: IfNotPresent
     ## @param initContainers.waitForMariadb.resources Resource requests and limits for MariaDB init container
-    resources:
-      limits:
-        cpu: 100m
-        memory: 64Mi
-      requests:
-        cpu: 100m
-        memory: 32Mi
+    resources: {}
+      # limits:
+      #   cpu: 100m
+      #   memory: 64Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 32Mi
 
 ## @section PostgreSQL Configuration (when postgres.enabled=true)
 ## @descriptionStart

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.12.1
+version: 0.13.0
 appVersion: "1.6.41"
 keywords:
   - memcached

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -127,10 +127,9 @@ The following table lists the configurable parameters of the Memcached chart and
 
 ### Resources Parameters
 
-| Parameter            | Description                                          | Default                        |
-| -------------------- | ---------------------------------------------------- | ------------------------------ |
-| `resources.limits`   | The resources limits for the Memcached containers    | `{memory: "128Mi"}`            |
-| `resources.requests` | The requested resources for the Memcached containers | `{cpu: "50m", memory: "64Mi"}` |
+| Parameter   | Description                                   | Default |
+| ----------- | --------------------------------------------- | ------- |
+| `resources` | Resource limits and requests for Memcached pod | `{}`    |
 
 ### Health Check Parameters
 
@@ -247,10 +246,7 @@ All objects in `extraObjects` will be rendered and deployed with the release. Yo
 | `metrics.image.repository`                 | Memcached exporter image repository                                                    | `prom/memcached-exporter` |
 | `metrics.image.tag`                        | Memcached exporter image tag                                                           | `v0.15.4@sha256...`       |
 | `metrics.image.pullPolicy`                 | Memcached exporter image pull policy                                                   | `Always`                  |
-| `metrics.resources.requests.cpu`           | CPU request for the metrics container                                                  | `50m`                     |
-| `metrics.resources.requests.memory`        | Memory request for the metrics container                                               | `64Mi`                    |
-| `metrics.resources.limits.cpu`             | CPU limit for the metrics container                                                    | `nil`                     |
-| `metrics.resources.limits.memory`          | Memory limit for the metrics container                                                 | `64Mi`                    |
+| `metrics.resources`                        | Resource limits and requests for metrics container                                     | `{}`                      |
 | `metrics.extraArgs`                        | Extra arguments for Memcached exporter (e.g. `--log.level=debug`, `--log.format=json`) | `[]`                      |
 | `metrics.service.type`                     | Metrics service type                                                                   | `ClusterIP`               |
 | `metrics.service.port`                     | Metrics service port                                                                   | `9150`                    |

--- a/charts/memcached/tests/metrics_test.yaml
+++ b/charts/memcached/tests/metrics_test.yaml
@@ -21,14 +21,8 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].ports[0].containerPort
           value: 9150
-      - equal:
+      - isEmpty:
           path: spec.template.spec.containers[1].resources
-          value:
-            limits:
-              memory: 64Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
 
   - it: should respect config change
     set:

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -257,28 +257,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -232,12 +232,12 @@ metrics:
     tag: "v0.15.5@sha256:92a6ad5a3d3e2dffc75efd4e18d1470fa5703dd79b6bace53fe11312b634578e"
     pullPolicy: Always
   ## @param metrics.resources Resource limits and requests for metrics container
-  resources:
-    limits:
-      memory: 64Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   memory: 64Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
   ## @param metrics.extraArgs Extra arguments for Memcached exporter, for example:
   ## extraArgs:
   ##   - --log.level=debug

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.16.4
+version: 0.17.0
 appVersion: "8.2.7"
 keywords:
   - mongodb

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -202,7 +202,7 @@ customUsers:
 
 | Parameter      | Description                                  | Default                                                        |
 | -------------- | -------------------------------------------- | -------------------------------------------------------------- |
-| `resources`    | Resource limits and requests for MongoDB pod | `limits: {memory: 512Mi}, requests: {cpu: 50m, memory: 512Mi}` |
+| `resources`    | Resource limits and requests for MongoDB pod | `{}`                                                           |
 | `nodeSelector` | Node selector for pod assignment             | `{}`                                                           |
 | `tolerations`  | Tolerations for pod assignment               | `[]`                                                           |
 | `affinity`     | Affinity rules for pod assignment            | `{}`                                                           |
@@ -266,7 +266,7 @@ customUsers:
 | `metrics.image.repository`         | MongoDB Exporter image repository                                   | `percona/mongodb_exporter`                                                                                                           |
 | `metrics.image.tag`                | MongoDB Exporter image tag                                          | `0.47.2`                                                                                                                             |
 | `metrics.image.pullPolicy`         | MongoDB Exporter image pull policy                                  | `IfNotPresent`                                                                                                                       |
-| `metrics.resources`                | Resource limits and requests for metrics container                  | `limits: { memory: 256Mi }, requests: { cpu: 10m, memory: 64Mi }`                                                                    |
+| `metrics.resources`                | Resource limits and requests for metrics container                  | `{}`                                                                                                                                 |
 | `metrics.containerSecurityContext` | Security context for metrics container                              | `runAsUser: 65534, runAsNonRoot: true, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: { drop: [ALL] }` |
 
 ### Metrics Service Parameters
@@ -424,7 +424,7 @@ For MongoDB sharded cluster deployments, enable `shardedCluster.enabled` instead
 | `shardedCluster.configsvr.replicaCount`                                | Number of config server replicas (minimum 1, recommended 3 for production)                                   | `3`             |
 | `shardedCluster.configsvr.enableConfigShard`                           | Enable config shard mode (MongoDB 8.0+): config servers also store user data via `transitionFromDedicatedConfigServer` | `false` |
 | `shardedCluster.configsvr.priorityClassName`                           | Priority class name for config server pods                                                                   | `""`            |
-| `shardedCluster.configsvr.resources`                                   | Resource limits and requests for config server pods                                                          | `limits: {memory: 512Mi}, requests: {cpu: 100m, memory: 512Mi}` |
+| `shardedCluster.configsvr.resources`                                   | Resource limits and requests for config server pods                                                          | `{}`            |
 | `shardedCluster.configsvr.nodeSelector`                                | Node selector for config server pods                                                                         | `{}`            |
 | `shardedCluster.configsvr.tolerations`                                 | Tolerations for config server pods                                                                           | `[]`            |
 | `shardedCluster.configsvr.affinity`                                    | Affinity rules for config server pods                                                                        | `{}`            |
@@ -440,7 +440,7 @@ For MongoDB sharded cluster deployments, enable `shardedCluster.enabled` instead
 | ------------------------------------------ | -------------------------------------------------------------------------------------- | --------------- |
 | `shardedCluster.mongos.replicaCount`       | Number of mongos router instances (minimum 1, recommended 2+ for production)          | `2`             |
 | `shardedCluster.mongos.priorityClassName`  | Priority class name for mongos router pods                                             | `""`            |
-| `shardedCluster.mongos.resources`          | Resource limits and requests for mongos router pods                                    | `limits: {memory: 256Mi}, requests: {cpu: 50m, memory: 256Mi}` |
+| `shardedCluster.mongos.resources`          | Resource limits and requests for mongos router pods                                    | `{}`            |
 | `shardedCluster.mongos.nodeSelector`       | Node selector for mongos router pods                                                   | `{}`            |
 | `shardedCluster.mongos.tolerations`        | Tolerations for mongos router pods                                                     | `[]`            |
 | `shardedCluster.mongos.affinity`           | Affinity rules for mongos router pods                                                  | `{}`            |
@@ -463,7 +463,7 @@ For MongoDB sharded cluster deployments, enable `shardedCluster.enabled` instead
 | `shardedCluster.shardsvr.customInit`                                        | Custom shell commands run during shard initialisation (executed on each data node pod)                           | `""`            |
 | `shardedCluster.shardsvr.dataNode.replicaCount`                             | Number of data node replicas per shard (minimum 1, recommended 3 for production)                                 | `3`             |
 | `shardedCluster.shardsvr.dataNode.priorityClassName`                        | Priority class name for shard data node pods                                                                     | `""`            |
-| `shardedCluster.shardsvr.dataNode.resources`                                | Resource limits and requests for shard data node pods                                                            | `limits: {memory: 1Gi}, requests: {cpu: 100m, memory: 1Gi}` |
+| `shardedCluster.shardsvr.dataNode.resources`                                | Resource limits and requests for shard data node pods                                                            | `{}`            |
 | `shardedCluster.shardsvr.dataNode.nodeSelector`                             | Node selector for shard data node pods (overrides `shardsvr.nodeSelector`)                                       | `{}`            |
 | `shardedCluster.shardsvr.dataNode.tolerations`                              | Tolerations for shard data node pods (overrides `shardsvr.tolerations`)                                          | `[]`            |
 | `shardedCluster.shardsvr.dataNode.affinity`                                 | Affinity rules for shard data node pods (overrides `shardsvr.affinity`)                                          | `{}`            |
@@ -477,7 +477,7 @@ For MongoDB sharded cluster deployments, enable `shardedCluster.enabled` instead
 | ------------------------------------------------------- | ---------------------------------------------------------------------------------- | --------------- |
 | `shardedCluster.shardsvr.arbiter.replicaCount`          | Number of arbiter replicas per shard (0 to disable, recommended 0)                 | `0`             |
 | `shardedCluster.shardsvr.arbiter.priorityClassName`     | Priority class name for arbiter pods                                               | `""`            |
-| `shardedCluster.shardsvr.arbiter.resources`             | Resource limits and requests for arbiter pods                                      | `limits: {memory: 256Mi}, requests: {cpu: 50m, memory: 256Mi}` |
+| `shardedCluster.shardsvr.arbiter.resources`             | Resource limits and requests for arbiter pods                                      | `{}`            |
 | `shardedCluster.shardsvr.arbiter.nodeSelector`          | Node selector for arbiter pods (overrides `shardsvr.nodeSelector`)                 | `{}`            |
 | `shardedCluster.shardsvr.arbiter.tolerations`           | Tolerations for arbiter pods (overrides `shardsvr.tolerations`)                    | `[]`            |
 | `shardedCluster.shardsvr.arbiter.affinity`              | Affinity rules for arbiter pods (overrides `shardsvr.affinity`)                    | `{}`            |

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -272,28 +272,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -664,28 +643,7 @@
             }
         },
         "resources": {
-            "type": "object",
-            "properties": {
-                "limits": {
-                    "type": "object",
-                    "properties": {
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "requests": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+            "type": "object"
         },
         "revisionHistoryLimit": {
             "type": "integer"
@@ -799,28 +757,7 @@
                             "type": "integer"
                         },
                         "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
+                            "type": "object"
                         },
                         "tolerations": {
                             "type": "array"
@@ -878,28 +815,7 @@
                             "type": "integer"
                         },
                         "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
+                            "type": "object"
                         },
                         "service": {
                             "type": "object",
@@ -951,28 +867,7 @@
                                     "type": "integer"
                                 },
                                 "resources": {
-                                    "type": "object",
-                                    "properties": {
-                                        "limits": {
-                                            "type": "object",
-                                            "properties": {
-                                                "memory": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        "requests": {
-                                            "type": "object",
-                                            "properties": {
-                                                "cpu": {
-                                                    "type": "string"
-                                                },
-                                                "memory": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
+                                    "type": "object"
                                 },
                                 "tolerations": {
                                     "type": "array"
@@ -998,28 +893,7 @@
                                     "type": "integer"
                                 },
                                 "resources": {
-                                    "type": "object",
-                                    "properties": {
-                                        "limits": {
-                                            "type": "object",
-                                            "properties": {
-                                                "memory": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        },
-                                        "requests": {
-                                            "type": "object",
-                                            "properties": {
-                                                "cpu": {
-                                                    "type": "string"
-                                                },
-                                                "memory": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
+                                    "type": "object"
                                 },
                                 "tolerations": {
                                     "type": "array"

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -138,12 +138,12 @@ persistence:
   persistentVolumeClaimRetentionPolicy:
 
 ## @param resources Resource limits and requests for MongoDB pod
-resources:
-  limits:
-    memory: 512Mi
-  requests:
-    cpu: 50m
-    memory: 512Mi
+resources: {}
+  # limits:
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 512Mi
 
 ## @param nodeSelector Node selector for pod assignment
 nodeSelector: {}
@@ -278,12 +278,12 @@ metrics:
     tag: "musl"
     pullPolicy: IfNotPresent
   ## @param metrics.resources Resource limits and requests for metrics container
-  resources:
-    limits:
-      memory: 256Mi
-    requests:
-      cpu: 10m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 64Mi
   ## @param metrics.containerSecurityContext Security context for metrics container
   containerSecurityContext:
     runAsUser: 65534
@@ -557,12 +557,12 @@ shardedCluster:
     ## @param shardedCluster.configsvr.priorityClassName Priority class name for config server pods
     priorityClassName: ""
     ## @param shardedCluster.configsvr.resources Resource limits and requests for config server pods
-    resources:
-      limits:
-        memory: 512Mi
-      requests:
-        cpu: 100m
-        memory: 512Mi
+    resources: {}
+      # limits:
+      #   memory: 512Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 512Mi
     ## @param shardedCluster.configsvr.nodeSelector Node selector for config server pods
     nodeSelector: {}
     ## @param shardedCluster.configsvr.tolerations Tolerations for config server pods
@@ -592,12 +592,12 @@ shardedCluster:
     ## @param shardedCluster.mongos.priorityClassName Priority class name for mongos router pods
     priorityClassName: ""
     ## @param shardedCluster.mongos.resources Resource limits and requests for mongos router pods
-    resources:
-      limits:
-        memory: 256Mi
-      requests:
-        cpu: 50m
-        memory: 256Mi
+    resources: {}
+      # limits:
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 256Mi
     ## @param shardedCluster.mongos.nodeSelector Node selector for mongos router pods
     nodeSelector: {}
     ## @param shardedCluster.mongos.tolerations Tolerations for mongos router pods
@@ -652,12 +652,12 @@ shardedCluster:
       ## @param shardedCluster.shardsvr.dataNode.priorityClassName Priority class name for shard data node pods
       priorityClassName: ""
       ## @param shardedCluster.shardsvr.dataNode.resources Resource limits and requests for shard data node pods
-      resources:
-        limits:
-          memory: 1Gi
-        requests:
-          cpu: 100m
-          memory: 1Gi
+      resources: {}
+        # limits:
+        #   memory: 1Gi
+        # requests:
+        #   cpu: 100m
+        #   memory: 1Gi
       ## @param shardedCluster.shardsvr.dataNode.nodeSelector Node selector for shard data node pods (overrides shardsvr.nodeSelector)
       nodeSelector: {}
       ## @param shardedCluster.shardsvr.dataNode.tolerations Tolerations for shard data node pods (overrides shardsvr.tolerations)
@@ -675,12 +675,12 @@ shardedCluster:
       ## @param shardedCluster.shardsvr.arbiter.priorityClassName Priority class name for arbiter pods
       priorityClassName: ""
       ## @param shardedCluster.shardsvr.arbiter.resources Resource limits and requests for arbiter pods
-      resources:
-        limits:
-          memory: 256Mi
-        requests:
-          cpu: 50m
-          memory: 256Mi
+      resources: {}
+        # limits:
+        #   memory: 256Mi
+        # requests:
+        #   cpu: 50m
+        #   memory: 256Mi
       ## @param shardedCluster.shardsvr.arbiter.nodeSelector Node selector for arbiter pods (overrides shardsvr.nodeSelector)
       nodeSelector: {}
       ## @param shardedCluster.shardsvr.arbiter.tolerations Tolerations for arbiter pods (overrides shardsvr.tolerations)

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.10.2
+version: 0.11.0
 appVersion: "1.30.0"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -318,9 +318,7 @@ readinessProbe:
 | `metrics.image.repository`                 | Nginx exporter image repository                                | `nginx/nginx-prometheus-exporter` |
 | `metrics.image.tag`                        | Nginx exporter image tag                                       | `"1.5@sha256:..."`                |
 | `metrics.image.pullPolicy`                 | Nginx exporter image pull policy                               | `Always`                          |
-| `metrics.resources.limits.memory`          | Memory limit for metrics container                             | `64Mi`                            |
-| `metrics.resources.requests.cpu`           | CPU request for metrics container                              | `50m`                             |
-| `metrics.resources.requests.memory`        | Memory request for metrics container                           | `64Mi`                            |
+| `metrics.resources`                        | Resource limits and requests for metrics container             | `{}`                              |
 | `metrics.extraArgs`                        | Extra arguments for nginx exporter                             | `[]`                              |
 | `metrics.service.type`                     | Metrics service type                                           | `ClusterIP`                       |
 | `metrics.service.port`                     | Metrics service port                                           | `9113`                            |

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -375,28 +375,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -313,12 +313,12 @@ metrics:
     tag: "1.5@sha256:bf76e58df548a13e52bd543ac70f6d3d667e14884e8b51c149bd81994ca75ccd"
     pullPolicy: Always
   ## @param metrics.resources Resource limits and requests for metrics container
-  resources:
-    limits:
-      memory: 64Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   memory: 64Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
   ## @param metrics.extraArgs Extra arguments for nginx exporter, for example:
   ## extraArgs:
   ##   - --log.level=info

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.20.2
+version: 0.21.0
 appVersion: "4.2.5"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -164,7 +164,7 @@ The chart supports automatic reloading of definitions when the ConfigMap or Secr
 | `definitions.autoReload.image.repository` | Container image repository for the config watcher sidecar      | `curlimages/curl` |
 | `definitions.autoReload.image.tag`        | Container image tag for the config watcher sidecar             | `8.11.1`          |
 | `definitions.autoReload.image.pullPolicy` | Container image pull policy for the config watcher sidecar     | `IfNotPresent`    |
-| `definitions.autoReload.resources`        | Resource limits and requests for the config watcher sidecar    | See values.yaml   |
+| `definitions.autoReload.resources`        | Resource limits and requests for the config watcher sidecar    | `{}`              |
 
 **How it works:**
 

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -186,31 +186,7 @@
                             }
                         },
                         "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
+                            "type": "object"
                         }
                     }
                 },

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -717,10 +717,10 @@ definitions:
       tag: "8.18.0"
       pullPolicy: IfNotPresent
     ## @param definitions.autoReload.resources Resource limits and requests for the config watcher sidecar
-    resources:
-      requests:
-        cpu: 10m
-        memory: 16Mi
-      limits:
-        cpu: 50m
-        memory: 32Mi
+    resources: {}
+      # requests:
+      #   cpu: 10m
+      #   memory: 16Mi
+      # limits:
+      #   cpu: 50m
+      #   memory: 32Mi

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.26.11
+version: 0.27.0
 appVersion: "8.6.2"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -229,10 +229,7 @@ user sentinel >sentinelpassword ~* +client +info +ping +publish +subscribe +psub
 | `metrics.image.repository`                 | Redis exporter image repository                                                         | `oliver006/redis_exporter` |
 | `metrics.image.tag`                        | Redis exporter image tag                                                                | `v1.80.1-alpine`           |
 | `metrics.image.pullPolicy`                 | Redis exporter image pull policy                                                        | `Always`                   |
-| `metrics.resources.requests.cpu`           | CPU request for the metrics container                                                   | `50m`                      |
-| `metrics.resources.requests.memory`        | Memory request for the metrics container                                                | `64Mi`                     |
-| `metrics.resources.limits.cpu`             | CPU limit for the metrics container                                                     | `nil`                      |
-| `metrics.resources.limits.memory`          | Memory limit for the metrics container                                                  | `64Mi`                     |
+| `metrics.resources`                        | Resource limits and requests for metrics container                                      | `{}`                       |
 | `metrics.extraArgs`                        | Extra arguments for Redis exporter (e.g. `--redis.addr`, `--web.listen-address`)        | `[]`                       |
 | `metrics.service.type`                     | Metrics service type                                                                    | `ClusterIP`                |
 | `metrics.service.port`                     | Metrics service port                                                                    | `9121`                     |
@@ -283,11 +280,9 @@ user sentinel >sentinelpassword ~* +client +info +ping +publish +subscribe +psub
 
 ### Resource Management
 
-| Parameter                   | Description    | Default |
-| --------------------------- | -------------- | ------- |
-| `resources.limits.memory`   | Memory limit   | `256Mi` |
-| `resources.requests.cpu`    | CPU request    | `50m`   |
-| `resources.requests.memory` | Memory request | `128Mi` |
+| Parameter   | Description                                | Default |
+| ----------- | ------------------------------------------ | ------- |
+| `resources` | Resource limits and requests for Redis pod | `{}`    |
 
 ### Pod Assignment / Eviction
 
@@ -359,9 +354,7 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | `sentinel.port`                               | Sentinel port                                                                                 | `26379`     |
 | `sentinel.service.type`                       | Kubernetes service type for Sentinel                                                          | `ClusterIP` |
 | `sentinel.service.port`                       | Sentinel service port                                                                         | `26379`     |
-| `sentinel.resources.limits.memory`            | Memory limit for Sentinel pods                                                                | `128Mi`     |
-| `sentinel.resources.requests.cpu`             | CPU request for Sentinel pods                                                                 | `25m`       |
-| `sentinel.resources.requests.memory`          | Memory request for Sentinel pods                                                              | `64Mi`      |
+| `sentinel.resources`                          | Resource limits and requests for Sentinel pods                                                | `{}`        |
 | `sentinel.extraVolumeMounts`                  | Additional volume mounts for Sentinel container                                               | `[]`        |
 | `sentinel.redisShutdownWaitFailover`          | Whether Redis waits for Sentinel failover before shutdown (zero-downtime upgrades)            | `true`      |
 | `sentinel.preStop.enabled`                    | Enable preStop hook for Sentinel container (waits for failover before terminating)            | `true`      |
@@ -411,9 +404,6 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | Parameter                                  | Description                                      | Default |
 | ------------------------------------------ | ------------------------------------------------ | ------- |
 | `clusterInitJob.resources`                 | Resource limits and requests for clusterInit Job | `{}`    |
-| `clusterInitJob.resources.limits.memory`   | Memory limit for clusterInit Job                 | `128Mi` |
-| `clusterInitJob.resources.requests.cpu`    | CPU request for clusterInit Job                  | `10m`   |
-| `clusterInitJob.resources.requests.memory` | Memory request for clusterInit Job               | `64Mi`  |
 
 #### Extra Objects
 

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -74,31 +74,7 @@
             "type": "object",
             "properties": {
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 }
             }
         },
@@ -253,31 +229,7 @@
             "type": "object",
             "properties": {
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 }
             }
         },
@@ -334,31 +286,7 @@
                     }
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",
@@ -559,31 +487,7 @@
             "type": "integer"
         },
         "resources": {
-            "type": "object",
-            "properties": {
-                "limits": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "requests": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+            "type": "object"
         },
         "revisionHistoryLimit": {
             "type": "integer"
@@ -693,31 +597,7 @@
                             "type": "string"
                         },
                         "resources": {
-                            "type": "object",
-                            "properties": {
-                                "limits": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "requests": {
-                                    "type": "object",
-                                    "properties": {
-                                        "cpu": {
-                                            "type": "string"
-                                        },
-                                        "memory": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
+                            "type": "object"
                         },
                         "type": {
                             "type": "string"
@@ -768,31 +648,7 @@
                     "type": "boolean"
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -238,13 +238,13 @@ persistentVolumeClaimRetentionPolicy:
   whenDeleted: Retain
 
 ## @param resources Resource limits and requests for Redis pod
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 50m
-    memory: 128Mi
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 128Mi
 
 ## @param nodeSelector Node selector for pod assignment
 nodeSelector: {}
@@ -416,13 +416,13 @@ sentinel:
     ## @param sentinel.service.ipFamilyPolicy IP family policy for the sentinel service
     ipFamilyPolicy: ""
   ## @param sentinel.resources Resource limits and requests for Sentinel pods
-  resources:
-    limits:
-      cpu: 200m
-      memory: 128Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   cpu: 200m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
   ## @param sentinel.redisShutdownWaitFailover Whether Redis should wait for Sentinel failover before shutdown
   ## When true: On master termination, waits for failover to complete (zero-downtime)
   ## When false: Shuts down immediately without waiting for failover
@@ -449,13 +449,13 @@ sentinel:
       tag: "1.35.2"
       pullPolicy: IfNotPresent
     ## @param sentinel.masterService.resources Resource limits and requests for master discovery deployment
-    resources:
-      limits:
-        cpu: 25m
-        memory: 64Mi
-      requests:
-        cpu: 10m
-        memory: 32Mi
+    resources: {}
+      # limits:
+      #   cpu: 25m
+      #   memory: 64Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 32Mi
 
   livenessProbe:
     ## @param sentinel.livenessProbe.enabled Enable liveness probe
@@ -495,13 +495,13 @@ sentinel:
 
 ## @param resources Resource limits and requests for Redis init container pod
 initContainer:
-  resources:
-    limits:
-      cpu: 50m
-      memory: 128Mi
-    requests:
-      cpu: 25m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   cpu: 50m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 64Mi
 
 ## @section Redis metrics parameters
 ## Prometheus metrics configuration
@@ -518,13 +518,13 @@ metrics:
     tag: "v1.82.0-alpine@sha256:da9e89ee4e755bfa1b6a6b2ed345c2de63ca3976f95c9f1e9538882bc1414cb8"
     pullPolicy: Always
   ## @param metrics.resources Resource limits and requests for metrics container
-  resources:
-    limits:
-      cpu: 100m
-      memory: 64Mi
-    requests:
-      cpu: 50m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 64Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 64Mi
   ## @param metrics.extraArgs Extra arguments for redis exporter, for example:
   ## extraArgs:
   ##   - --redis.addr=redis://localhost:6379
@@ -638,10 +638,10 @@ customScripts:
 ## @section clusterInitJob Configurations for the Job-Template
 clusterInitJob:
   ## @param clusterInitJob.resources Resource limits and requests for clusterInit Job
-  resources:
-    limits:
-      cpu: 25m
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   cpu: 25m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 64Mi

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.19.0
+version: 0.20.0
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -277,19 +277,13 @@ Sentinel provides high availability for Valkey replication. When enabled, Sentin
 | `sentinel.extraVolumeMounts`         | Additional volume mounts to add to the Sentinel container                           | `[]`                                                                                         |
 | `sentinel.service.type`              | Kubernetes service type for Sentinel                                                | `ClusterIP`                                                                                  |
 | `sentinel.service.port`              | Sentinel service port                                                               | `26379`                                                                                      |
-| `sentinel.resources.limits.memory`   | Memory limit for Sentinel container                                                 | `128Mi`                                                                                      |
-| `sentinel.resources.limits.cpu`      | CPU limit for Sentinel container                                                    | Not set                                                                                      |
-| `sentinel.resources.requests.cpu`    | CPU request for Sentinel container                                                  | `25m`                                                                                        |
-| `sentinel.resources.requests.memory` | Memory request for Sentinel container                                               | `64Mi`                                                                                       |
+| `sentinel.resources`                 | Resource limits and requests for Sentinel container                                 | `{}`                                                                                         |
 
 ### Init Container Configuration
 
-| Parameter                                 | Description                       | Default |
-| ----------------------------------------- | --------------------------------- | ------- |
-| `initContainer.resources.limits.cpu`      | CPU limit for init container      | `50m`   |
-| `initContainer.resources.limits.memory`   | Memory limit for init container   | `128Mi` |
-| `initContainer.resources.requests.cpu`    | CPU request for init container    | `25m`   |
-| `initContainer.resources.requests.memory` | Memory request for init container | `64Mi`  |
+| Parameter                 | Description                                            | Default |
+| ------------------------- | ------------------------------------------------------ | ------- |
+| `initContainer.resources` | Resource limits and requests for Valkey init container | `{}`    |
 
 ### Additional Configuration
 

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -265,31 +265,7 @@
             "type": "object",
             "properties": {
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 }
             }
         },
@@ -478,28 +454,7 @@
             "type": "integer"
         },
         "resources": {
-            "type": "object",
-            "properties": {
-                "limits": {
-                    "type": "object",
-                    "properties": {
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "requests": {
-                    "type": "object",
-                    "properties": {
-                        "cpu": {
-                            "type": "string"
-                        },
-                        "memory": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+            "type": "object"
         },
         "revisionHistoryLimit": {
             "type": "integer"
@@ -557,28 +512,7 @@
                     "type": "integer"
                 },
                 "resources": {
-                    "type": "object",
-                    "properties": {
-                        "limits": {
-                            "type": "object",
-                            "properties": {
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "requests": {
-                            "type": "object",
-                            "properties": {
-                                "cpu": {
-                                    "type": "string"
-                                },
-                                "memory": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
+                    "type": "object"
                 },
                 "service": {
                     "type": "object",

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -225,12 +225,12 @@ gatewayAPI:
               value: /
 
 ## @section Resources
-resources:
-  limits:
-    memory: 64Mi
-  requests:
-    cpu: 10m
-    memory: 64Mi
+resources: {}
+  # limits:
+  #   memory: 64Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 64Mi
 
 ## @section Persistence
 persistence:
@@ -410,19 +410,19 @@ sentinel:
     ## @param sentinel.service.port Sentinel service port
     port: 26379
   ## @param sentinel.resources Resource limits and requests for Sentinel pods
-  resources:
-    limits:
-      memory: 128Mi
-    requests:
-      cpu: 25m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 64Mi
 
 ## @param resources Resource limits and requests for Valkey init container pod
 initContainer:
-  resources:
-    limits:
-      cpu: 50m
-      memory: 128Mi
-    requests:
-      cpu: 25m
-      memory: 64Mi
+  resources: {}
+    # limits:
+    #   cpu: 50m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 64Mi


### PR DESCRIPTION
### Description of the change

Replace populated resources blocks with `resources: {}` across chart values.yaml files, keeping the original limits/requests as comments so users have examples to uncomment and tune. Aligns these charts with the convention already used by mariadb, ghost, zookeeper, postgres, etcd, timescaledb, minio, rustfs and rabbitmq-cluster-operator.

Affected charts: clusterpirate, keycloak, memcached, mongodb, nginx, rabbitmq, redis, valkey.

### Benefits

Full control over the resource requests and limits.

### Possible drawbacks

No default resources, so one more thing to configure.

### Applicable issues

- fixes #1215 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [[semver](http://semver.org/)](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [[CONTRIBUTING.md](https://github.com/CloudPirates-io/helm-charts/CONTRIBUTING.md#setting-up-your-development-environment)])