### PR TITLE
[keycloak]: Add seccompProfile RuntimeDefault to podSecurityContext

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.20.3
+version: 0.20.4
 appVersion: "26.5.7"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -136,15 +136,16 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Security
 
-| Parameter                                           | Description                                       | Default   |
-| --------------------------------------------------- | ------------------------------------------------- | --------- |
-| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod               | `1001`    |
-| `containerSecurityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`   |
-| `containerSecurityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`    |
-| `containerSecurityContext.runAsUser`                | User ID for the Keycloak container                | `1001`    |
-| `containerSecurityContext.runAsGroup`               | Group ID for the Keycloak container               | `1001`    |
-| `containerSecurityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `false`   |
-| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]` |
+| Parameter                                           | Description                                       | Default                  |
+| --------------------------------------------------- | ------------------------------------------------- | ------------------------ |
+| `podSecurityContext.fsGroup`                        | Group ID for the volumes of the pod               | `1001`                   |
+| `podSecurityContext.seccompProfile`                 | Seccomp profile for the pod                       | `{type: RuntimeDefault}` |
+| `containerSecurityContext.allowPrivilegeEscalation` | Enable container privilege escalation             | `false`                  |
+| `containerSecurityContext.runAsNonRoot`             | Configure the container to run as a non-root user | `true`                   |
+| `containerSecurityContext.runAsUser`                | User ID for the Keycloak container                | `1001`                   |
+| `containerSecurityContext.runAsGroup`               | Group ID for the Keycloak container               | `1001`                   |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Mount container root filesystem as read-only      | `false`                  |
+| `containerSecurityContext.capabilities.drop`        | Linux capabilities to be dropped                  | `["ALL"]`                |
 
 ### Keycloak Configuration
 

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -621,6 +621,14 @@
             "properties": {
                 "fsGroup": {
                     "type": "integer"
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -82,6 +82,9 @@ extraContainers: []
 podSecurityContext:
   ## @param podSecurityContext.fsGroup Group ID for the volumes of the pod
   fsGroup: 1001
+  ## @param podSecurityContext.seccompProfile Seccomp profile for the pod
+  seccompProfile:
+    type: RuntimeDefault
 
 containerSecurityContext:
   ## @param containerSecurityContext.allowPrivilegeEscalation Enable container privilege escalation


### PR DESCRIPTION
### Description of the change
                                                                                                                                                                                                                                     
  Adds `seccompProfile: RuntimeDefault` to the `podSecurityContext` in the Keycloak chart, mirroring the same change applied to other charts in this repo.                                                                           
                                                                                                                                                                                                                                     
  ### Benefits                                                                                                                                                                                                                       
                                                                                                                                                                                                                                     
  Improves pod-level security by enabling the default seccomp profile, which restricts syscalls available to the container and aligns with Kubernetes security best practices and Pod Security Standards (restricted/baseline).      
                                                                                                                                                                                                                                     
  ### Possible drawbacks                                                                                                                                                                                                             
                                                                                                                                                                                                                                     
  None expected. `RuntimeDefault` is the container runtime's default seccomp profile and is widely supported.                                                                                                                        
                                                                                                                                                                                                                                     
  ### Applicable issues                                                                                                                                                                                                              
                                                                                                                                                                                                                                     
N/A                                                                                                                                                                                                                       

  ### Additional information
                                                                                                                                                                                                                                     
  This is the same change as applied to the RabbitMQ chart in #1238.                                                                                                                                                                 
                                                                                                                                                                                                                                     
  ### Checklist                                                                                                                                                                                                                      
                                                                                                                                                                                                                                     
  - [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.                                                                        
  - [X] Variables are documented in the values.yaml and added to the `README.md`                                                                                                                                                     
  - [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title                                                                                                                                       
  - [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))    