### PR TITLE
fix(ci): use yaml.safe_dump for artifacthub.io/changes annotations

### DIFF
--- a/.github/workflows/changelog-and-release.yaml
+++ b/.github/workflows/changelog-and-release.yaml
@@ -196,12 +196,15 @@ jobs:
             echo "Generating ArtifactHub annotation for $CHART_NAME ($COMMIT_RANGE)"
 
             # Generate changes YAML from commit messages
+            # Uses yaml.safe_dump to properly escape special characters
+            # in commit descriptions (fixes ArtifactHub parse errors).
             CHANGES_YAML=$(git log --pretty=format:"%s" "$COMMIT_RANGE" -- "$CHART_DIR/" | \
               grep -v "^Merge " | grep -v "^chore: update CHANGELOG" | \
-              python3 -c "
-          import sys, re
+              REPO_URL="$REPO_URL" python3 -c "
+          import os, sys, re, yaml
           kinds = {'feat': 'added', 'fix': 'fixed', 'chore': 'changed', 'refactor': 'changed', 'docs': 'changed', 'sec': 'security'}
-          lines = []
+          repo_url = os.environ['REPO_URL']
+          changes = []
           for msg in sys.stdin:
               msg = msg.strip()
               if not msg:
@@ -209,12 +212,13 @@ jobs:
               m = re.match(r'^(\w+)(?:\([^)]*\))?!?:\s*(.+)', msg)
               kind = kinds.get(m.group(1), 'changed') if m else 'changed'
               desc = m.group(2) if m else msg
+              entry = {'kind': kind, 'description': desc}
               pr = re.search(r'\(#(\d+)\)', desc)
-              links = ''
               if pr:
-                  links = f'\n    links:\n      - name: \"Pull Request\"\n        url: \"$REPO_URL/pull/{pr.group(1)}\"'
-              lines.append(f'- kind: {kind}\n  description: \"{desc}\"{links}')
-          print('\n'.join(lines))
+                  entry['links'] = [{'name': 'Pull Request', 'url': f'{repo_url}/pull/{pr.group(1)}'}]
+              changes.append(entry)
+          if changes:
+              print(yaml.safe_dump(changes, default_flow_style=False, allow_unicode=True, sort_keys=False).rstrip())
           ")
 
             if [ -n "$CHANGES_YAML" ]; then


### PR DESCRIPTION
## Summary

Fixes the broken `artifacthub.io/changes` annotations reported by @zOnlyKroks in #1194.

**Root cause**: the inline Python script in the changelog workflow used f-string formatting to build YAML, which did not escape special characters in commit descriptions (`{}`, `[]`, `#`, `>=`, embedded double quotes, etc.). ArtifactHub rejected the annotation with:

```
error preparing package: error enriching package from annotations: 1 error occurred:
  * invalid changes annotation. Please use quotes on strings that include
    any of the following characters: {}:[],&*#?|-<>=!%@
```

**Fix**: replace the manual string building with `yaml.safe_dump()` (PyYAML is already installed in the workflow). This handles quoting and escaping automatically for any commit message content.

### Before (broken on special chars)

```yaml
- kind: fixed
  description: "handle "quoted" values in config: key=val"   # ← broken
- kind: changed
  description: "bump go to >=1.22 #security"                 # ← # parsed as comment
```

### After (safe_dump handles it)

```yaml
- kind: fixed
  description: 'handle "quoted" values in config: key=val'   # ← properly quoted
- kind: changed
  description: 'bump go to >=1.22 #security'                 # ← properly quoted
```

Also passes `REPO_URL` via environment variable instead of shell interpolation inside the Python script for better safety.

## Test plan

- [x] Tested locally with commit messages containing all problematic characters (`{}:[],&*#?|-<>=!%@"`)
- [ ] Verify next chart release generates valid ArtifactHub annotations