### PR TITLE
[rabbitmq] Add tpl support for hostname and tls secretName

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.21.1
+version: 0.21.2
 appVersion: "4.2.5"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/httproute.yaml
+++ b/charts/rabbitmq/templates/httproute.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if $hostnames }}
   hostnames:
     {{- range $hostnames }}
-    - {{ . | quote }}
+    - {{ tpl . $ | quote }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/rabbitmq/templates/ingress.yaml
+++ b/charts/rabbitmq/templates/ingress.yaml
@@ -29,14 +29,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl . $ | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl .secretName $ }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add tpl support for `hostname` and `secretName` in ingress
Add tpl support for `hostname `in httpRoute

### Benefits

When rabbitMQ is used in other helm charts as dependency, you usually want to define a single place for hostname and tls secrets (e.g. global.domainName or global.tls.secretName) within your `values.yaml`.

However, passing something like {{ .Values.global.domainName }} as hostname is not possible because rabbitmq helm chart doesn't evaluate template strings within ingress or httpRoute template resources.

### Possible drawbacks

This change is fully backward-compatible. When values contain no template syntax, tpl acts as a no-op

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #1260 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
