### PR TITLE
[keycloak]: Use correct value for volumeClaimTemplates.metadata.labels

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.3
+version: 0.21.4
 appVersion: "26.6.1"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -399,7 +399,7 @@ spec:
     - metadata:
         name: data
         labels:
-          {{- include "keycloak.labels" . | nindent 10 }}
+          {{- include "keycloak.selectorLabels" . | nindent 10 }}
         {{- $annotations := merge .Values.persistence.annotations .Values.commonAnnotations }}
         {{- with $annotations }}
         annotations:


### PR DESCRIPTION
### Description of the change

Make volumeClaimTemplates.metadata.labels use keycloak.selectorLabels

### Benefits

Smoother upgrades

### Possible drawbacks

### Applicable issues

- fixes #1259

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
