### PR TITLE
[redis] Fix service monitor relabelings

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.27.2
+version: 0.27.3
 appVersion: "8.6.2"
 keywords:
   - redis

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -32,8 +32,10 @@ spec:
       {{- with .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ . }}
       {{- end }}
-      {{- with .Values.metrics.serviceMonitor.relabelings }}
       relabelings:
+        - targetLabel: scrape_target
+          replacement: redis
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
@@ -52,8 +54,10 @@ spec:
       {{- with .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ . }}
       {{- end }}
-      {{- with .Values.metrics.serviceMonitor.relabelings }}
       relabelings:
+        - targetLabel: scrape_target
+          replacement: sentinel
+      {{- with .Values.metrics.serviceMonitor.relabelings }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.metrics.serviceMonitor.metricRelabelings }}


### PR DESCRIPTION
### Description of the change

Adds a static `scrape_target` relabeling to the Redis ServiceMonitor endpoints:

- `/metrics` is labeled with `scrape_target=redis`
- `/scrape` is labeled with `scrape_target=sentinel`

This allows metrics emitted by the Redis and Sentinel scrape targets to be distinguished when they share the same metric names and Kubernetes labels.

### Benefits

Common metrics exposed by both containers no longer appear to flap between Redis and Sentinel values without a clear way to identify their source.

The screenshot below shows an example of the issue: the same metric alternates between values because both scrape targets expose it without a distinguishing label.

<img width="2066" height="711" alt="image" src="https://github.com/user-attachments/assets/5fc263ff-3ae6-4382-84ee-1e8db4dc831a" />


This makes Prometheus queries, alerts, and Grafana dashboards more reliable because they can filter or group by `scrape_target`.

### Possible drawbacks

Some existing dashboards, alerts, or queries may need to be updated to include or account for the new `scrape_target` label.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
