### PR TITLE
[redis]: Add option to explicitly enable verbose logging

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.27.3
+version: 0.27.4
 appVersion: "8.6.2"
 keywords:
   - redis

--- a/charts/redis/templates/sentinel-master-deployment.yaml
+++ b/charts/redis/templates/sentinel-master-deployment.yaml
@@ -49,14 +49,16 @@ spec:
         securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 10 }}
         resources:
           {{- toYaml .Values.sentinel.masterService.resources | nindent 10 }}
-        {{- if and .Values.auth.enabled (not .Values.auth.acl.enabled) }}
         env:
+          {{- if and .Values.auth.enabled (not .Values.auth.acl.enabled) }}
           - name: REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ include "redis.secretName" . }}
                 key: {{ include "redis.secretPasswordKey" . }}
-        {{- end }}
+          {{- end }}
+          - name: VERBOSE
+            value: "{{ .Values.sentinel.masterService.verbose }}"
         {{- if and .Values.auth.acl.enabled .Values.auth.acl.existingSecret }}
         volumeMounts:
           - name: acl-file
@@ -99,7 +101,7 @@ spec:
                 continue
               fi
 
-              echo "Querying Sentinel via pod: $pod"
+              [ "${VERBOSE:-false}" = "true" ] && echo "Querying Sentinel via pod: $pod"
 
               # Query Sentinel for the current master hostname via the selected pod
               master_hostname=$(kubectl exec -n "$NAMESPACE" "$pod" -c sentinel -- \
@@ -116,11 +118,11 @@ spec:
                 continue
               fi
 
-              echo "Current master from Sentinel: $master"
+              [ "${VERBOSE:-false}" = "true" ] && echo "Current master from Sentinel: $master"
 
               # Check if master has changed
               if [ "$master" = "$oldmaster" ]; then
-                echo "Master unchanged, sleeping for ${CHECK_INTERVAL}s..."
+                [ "${VERBOSE:-false}" = "true" ] && echo "Master unchanged, sleeping for ${CHECK_INTERVAL}s..."
                 sleep "$CHECK_INTERVAL"
                 continue
               fi

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -601,6 +601,9 @@
                         },
                         "type": {
                             "type": "string"
+                        },
+                        "verbose": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -456,6 +456,8 @@ sentinel:
       # requests:
       #   cpu: 10m
       #   memory: 32Mi
+    ## @param sentinel.masterService.verbose Enable verbose logging for master discovery
+    verbose: false
 
   livenessProbe:
     ## @param sentinel.livenessProbe.enabled Enable liveness probe


### PR DESCRIPTION
### Description of the change

Adds a new field to the values.yaml, to explicitly enable verbose logging of the redis master discovery

### Benefits

Less log clutter

### Possible drawbacks

None

### Applicable issues

- fixes #1277

### Additional information

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
