### PR TITLE
[nginx] Add trafficDistribution support for Service

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.11.1
+version: 0.12.0
 appVersion: "1.30.0"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -206,6 +206,7 @@ containerPorts:
 | `service.type`                  | Nginx service type                                             | `ClusterIP` |
 | `service.ports`                 | Array of service ports (advanced configuration) - see examples | `[]`        |
 | `service.internalTrafficPolicy` | Kubernetes service internal traffic policy                     | `Cluster`   |
+| `service.trafficDistribution`   | Kubernetes service traffic distribution                        | `""`        |
 | `service.annotations`           | Additional annotations to add to the service                   | `{}`        |
 
 #### Service Ports Examples

--- a/charts/nginx/templates/service.yaml
+++ b/charts/nginx/templates/service.yaml
@@ -22,3 +22,6 @@ spec:
   selector:
     {{- include "nginx.selectorLabels" . | nindent 4 }}
   internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy | default "Cluster" }}
+  {{- if .Values.service.trafficDistribution }}
+  trafficDistribution: {{ .Values.service.trafficDistribution }}
+  {{- end }}

--- a/charts/nginx/tests/service_test.yaml
+++ b/charts/nginx/tests/service_test.yaml
@@ -1,0 +1,20 @@
+suite: test nginx service
+templates:
+  - service.yaml
+set:
+  image:
+    tag: 1.6.31@sha256:testdigest123
+tests:
+  - it: should not set trafficDistribution by default
+    asserts:
+      - isNull:
+          path: spec.trafficDistribution
+
+  - it: should set trafficDistribution when configured
+    set:
+      service:
+        trafficDistribution: PreferClose
+    asserts:
+      - equal:
+          path: spec.trafficDistribution
+          value: PreferClose

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -510,6 +510,9 @@
                 "internalTrafficPolicy": {
                     "type": "string"
                 },
+                "trafficDistribution": {
+                    "type": "string"
+                },
                 "ports": {
                     "type": "array",
                     "items": {

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -69,6 +69,8 @@ service:
       name: http
   ## @param service.internalTrafficPolicy Kubernetes service internal traffic policy
   internalTrafficPolicy: ""
+  ## @param service.trafficDistribution Kubernetes service traffic distribution
+  trafficDistribution: ""
   ## @param service.annotations Additional annotations to add to the service
   annotations: {}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add support for configuring the `spec.trafficDistribution` field to the `Service` template, gated on Kubernetes `>= 1.31`.

Based on the [documentation](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution) the supported values are:

* PreferSameZone
* PreferSameNode
* PreferClose is a deprecated alias for PreferSameZone.

### Benefits

Use latest [Traffic distribution control](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-distribution) feature within Kubernetes Service 

### Possible drawbacks

None

### Applicable issues

None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
