### PR TITLE
[zookeeper] Add support for custom health checks

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -204,25 +204,27 @@ zkCli.sh -server my-zookeeper:2181
 
 #### Liveness Probe
 
-| Parameter                           | Description                     | Default |
-| ----------------------------------- | ------------------------------- | ------- |
-| `livenessProbe.enabled`             | Enable livenessProbe            | `true`  |
-| `livenessProbe.initialDelaySeconds` | LivenessProbe initial delay     | `30`    |
-| `livenessProbe.periodSeconds`       | LivenessProbe period seconds    | `10`    |
-| `livenessProbe.timeoutSeconds`      | LivenessProbe timeout seconds   | `5`     |
-| `livenessProbe.failureThreshold`    | LivenessProbe failure threshold | `6`     |
-| `livenessProbe.successThreshold`    | LivenessProbe success threshold | `1`     |
+| Parameter                           | Description                                                | Default |
+| ----------------------------------- | ---------------------------------------------------------- | ------- |
+| `livenessProbe.enabled`             | Enable livenessProbe                                       | `true`  |
+| `livenessProbe.initialDelaySeconds` | LivenessProbe initial delay                                | `30`    |
+| `livenessProbe.periodSeconds`       | LivenessProbe period seconds                               | `10`    |
+| `livenessProbe.timeoutSeconds`      | LivenessProbe timeout seconds                              | `5`     |
+| `livenessProbe.failureThreshold`    | LivenessProbe failure threshold                            | `6`     |
+| `livenessProbe.successThreshold`    | LivenessProbe success threshold                            | `1`     |
+| `livenessProbe.custom`              | Custom action handler; replaces default tcpSocket when set | `{}`    |
 
 #### Readiness Probe
 
-| Parameter                            | Description                      | Default |
-| ------------------------------------ | -------------------------------- | ------- |
-| `readinessProbe.enabled`             | Enable readinessProbe            | `true`  |
-| `readinessProbe.initialDelaySeconds` | ReadinessProbe initial delay     | `5`     |
-| `readinessProbe.periodSeconds`       | ReadinessProbe period seconds    | `10`    |
-| `readinessProbe.timeoutSeconds`      | ReadinessProbe timeout seconds   | `5`     |
-| `readinessProbe.failureThreshold`    | ReadinessProbe failure threshold | `6`     |
-| `readinessProbe.successThreshold`    | ReadinessProbe success threshold | `1`     |
+| Parameter                            | Description                                                | Default |
+| ------------------------------------ | ---------------------------------------------------------- | ------- |
+| `readinessProbe.enabled`             | Enable readinessProbe                                      | `true`  |
+| `readinessProbe.initialDelaySeconds` | ReadinessProbe initial delay                               | `5`     |
+| `readinessProbe.periodSeconds`       | ReadinessProbe period seconds                              | `10`    |
+| `readinessProbe.timeoutSeconds`      | ReadinessProbe timeout seconds                             | `5`     |
+| `readinessProbe.failureThreshold`    | ReadinessProbe failure threshold                           | `6`     |
+| `readinessProbe.successThreshold`    | ReadinessProbe success threshold                           | `1`     |
+| `readinessProbe.custom`              | Custom action handler; replaces default tcpSocket when set | `{}`    |
 
 #### Startup Probe
 

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -89,16 +89,24 @@ spec:
               exec /docker-entrypoint.sh zkServer.sh start-foreground
               {{- end }}
           livenessProbe:
+            {{- if .Values.livenessProbe.custom }}
+            {{- toYaml .Values.livenessProbe.custom | nindent 12 }}
+            {{- else }}
             tcpSocket:
               port: client
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
           readinessProbe:
+            {{- if .Values.readinessProbe.custom }}
+            {{- toYaml .Values.readinessProbe.custom | nindent 12 }}
+            {{- else }}
             tcpSocket:
               port: client
+            {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -105,6 +105,9 @@
         "livenessProbe": {
             "type": "object",
             "properties": {
+                "custom": {
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },
@@ -262,6 +265,9 @@
         "readinessProbe": {
             "type": "object",
             "properties": {
+                "custom": {
+                    "type": "object"
+                },
                 "enabled": {
                     "type": "boolean"
                 },

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -258,6 +258,8 @@ livenessProbe:
   failureThreshold: 6
   ## @param livenessProbe.successThreshold Success threshold for livenessProbe
   successThreshold: 1
+  ## @param livenessProbe.custom Custom probe action handler; when set, replaces the default tcpSocket on client port. Use exec/httpGet/etc.
+  custom: {}
 
 readinessProbe:
   ## @param readinessProbe.enabled Enable readinessProbe on zookeeper containers
@@ -272,6 +274,8 @@ readinessProbe:
   failureThreshold: 6
   ## @param readinessProbe.successThreshold Success threshold for readinessProbe
   successThreshold: 1
+  ## @param readinessProbe.custom Custom probe action handler; when set, replaces the default tcpSocket on client port. Use exec/httpGet/etc.
+  custom: {}
 
 
 startupProbe:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

My changes allow overriding liveness/readiness health checks

### Benefits

We can use a custom script for health checks. The current default creates a connection to Zookeeper, but it does not use the Zookeeper syntax, and we are getting alerts on increased sessionless_connections_expired.

### Possible drawbacks

No behavior changes without setting the new value.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
