### PR TITLE
[mariadb]: Fix galera should use headless service

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "12.2.2"
 keywords:
   - mariadb

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Generate Galera cluster address list
 {{- $namespace := include "cloudpirates.namespace" . -}}
 {{- $addresses := list -}}
 {{- range $i := until $replicaCount -}}
-{{- $addresses = append $addresses (printf "%s-%d.%s.%s.svc.cluster.local:4567" $fullname $i $fullname $namespace) -}}
+{{- $addresses = append $addresses (printf "%s-%d.%s.%s-headless.svc.cluster.local:4567" $fullname $i $fullname $namespace) -}}
 {{- end -}}
 {{- join "," $addresses -}}
 {{- end }}
@@ -132,7 +132,7 @@ Generate Galera node name with pod name
 Generate Galera node address
 */}}
 {{- define "mariadb.galeraNodeAddress" -}}
-{{- printf "%s-%s.%s.%s.svc.cluster.local" (include "mariadb.fullname" .) "REPLICA_NUM" (include "mariadb.fullname" .) (include "cloudpirates.namespace" .) -}}
+{{- printf "%s-%s.%s.%s-headless.svc.cluster.local" (include "mariadb.fullname" .) "REPLICA_NUM" (include "mariadb.fullname" .) (include "cloudpirates.namespace" .) -}}
 {{- end }}
 
 {{/*

--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -13,10 +13,11 @@ metadata:
 spec:
   {{- if .Values.galera.enabled }}
   replicas: {{ .Values.galera.replicaCount }}
+  serviceName: {{ include "mariadb.fullname" . }}-headless
   {{- else }}
   replicas: 1
-  {{- end }}
   serviceName: {{ include "mariadb.fullname" . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mariadb.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Currently using mariadb with galera used the non-headless service for DNS. According to documentation of both [statefulsets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id)
 and [DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-hostname-and-subdomain-field). A pod can only be referenced via it's hostname via a headless service which matches the subdomain of a pod. Using statefulsets the subdomain is set via the serviceName, which is supposed to be headless aswell.

### Benefits

<!-- What benefits will be realized by the code change? -->
The mariadb galera cluster works on all kubernetes clusters, following the specification.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
