### PR TITLE
[rabbitmq-cluster-operator] Update RBAC permissions

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "2.19.1"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -26,22 +26,12 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - events
-    verbs:
-      - create
-      - get
-      - patch
-  - apiGroups:
-      - ""
-    resources:
       - secrets
     verbs:
       - create
       - get
       - list
       - patch
-      - update
-      - watch
   - apiGroups:
       - ""
     resources:
@@ -51,9 +41,28 @@ rules:
       - list
       - watch
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - rabbitmq.com
     resources:
       - bindings
+      - exchanges
+      - federations
+      - operatorpolicies
+      - permissions
+      - policies
+      - queues
+      - schemareplications
+      - shovels
+      - superstreams
+      - topicpermissions
+      - users
+      - vhosts
     verbs:
       - create
       - delete
@@ -62,149 +71,43 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - bindings/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - rabbitmq.com
     resources:
       - bindings/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - exchanges
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - exchanges/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - exchanges/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - federations
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - federations/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - federations/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - permissions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - permissions/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
+      - operatorpolicies/finalizers
       - permissions/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - policies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - policies/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - policies/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - queues
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - queues/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - queues/finalizers
+      - schemareplications/finalizers
+      - shovels/finalizers
+      - superstreams/finalizers
+      - topicpermissions/finalizers
+      - users/finalizers
+      - vhosts/finalizers
     verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - bindings/status
+      - exchanges/status
+      - federations/status
+      - operatorpolicies/status
+      - permissions/status
+      - policies/status
+      - queues/status
+      - schemareplications/status
+      - shovels/status
+      - superstreams/status
+      - topicpermissions/status
+      - users/status
+      - vhosts/status
+    verbs:
+      - get
+      - patch
       - update
   - apiGroups:
       - rabbitmq.com
@@ -220,187 +123,5 @@ rules:
       - rabbitmqclusters/status
     verbs:
       - get
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - schemareplications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - schemareplications/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - schemareplications/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - shovels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - shovels/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - shovels/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - superstreams
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - superstreams/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - superstreams/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - users
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - users/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - users/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - vhosts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - vhosts/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - vhosts/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - topicpermissions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - topicpermissions/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - topicpermissions/finalizers
-    verbs:
-      - update
-  - apiGroups:
-    - rabbitmq.com
-    resources:
-    - operatorpolicies
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - rabbitmq.com
-    resources:
-    - operatorpolicies/status
-    verbs:
-    - get
-    - patch
-    - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - operatorpolicies/finalizers
-    verbs:
-      - update
   {{- end }}
 {{- end }}


### PR DESCRIPTION
- updating ClusterRole permissions to align with current version of operator: https://github.com/rabbitmq/messaging-topology-operator/blob/v1.19.2/config/rbac/role.yaml

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

This change updates `ClusterRole` permissions for `rabbitmq-cluster-operator` to align with latest (`1.19.2`) release.

### Benefits

Alignment with currently release operator.

### Possible drawbacks

Nothing really.

### Applicable issues

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
