### PR TITLE
[redis] expose sentinel.monitorTarget to support multi-region Sentinel quorum

### DIFF
--- a/charts/redis/CHANGELOG.md
+++ b/charts/redis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this chart will be documented in this file.
 
+## [0.28.0] - 2026-05-20
+
+- Add `sentinel.monitorTarget` to override the Sentinel master discovery with an explicit hostname or IP, enabling multi-region and multi-cluster deployments where the chart's default local headless discovery does not work.
+
 ## [0.26.7] - 2026-03-25
 
 - Update image.repository to v8.6.2 (#1183) ([30f53b10](https://github.com/CloudPirates-io/helm-charts/commit/30f53b10))

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.27.9
+version: 0.28.0
 appVersion: "8.6.3"
 keywords:
   - redis
@@ -41,10 +41,8 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
-    - kind: changed
-      description: "propagate priorityClassName to sentinel master-discovery deployment"
+    - kind: added
+      description: "expose sentinel.monitorTarget to support multi-region/multi-cluster Sentinel quorum"
       links:
-        - name: "Pull Request"
-          url: "https://github.com/CloudPirates-io/helm-charts/pull/1188"
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis/CHANGELOG.md"

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -346,6 +346,7 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | `sentinel.image.pullPolicy`                   | Sentinel image pull policy                                                                    | `Always`    |
 | `sentinel.config.announceHostnames`           | Use the hostnames instead of the IP in "announce-ip" commands                                 | `true`      |
 | `sentinel.masterName`                         | Name of the master server                                                                     | `mymaster`  |
+| `sentinel.monitorTarget`                      | Override Sentinel master discovery with an explicit hostname or IP (multi-region/multi-cluster) | `""`        |
 | `sentinel.quorum`                             | Number of Sentinels needed to agree on master failure                                         | `2`         |
 | `sentinel.downAfterMilliseconds`              | Time in ms after master is declared down                                                      | `30000`     |
 | `sentinel.failoverTimeout`                    | Timeout for failover in ms                                                                    | `180000`    |

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -862,7 +862,7 @@ spec:
               bind * -::*
               sentinel resolve-hostnames yes
               sentinel announce-hostnames no
-              sentinel monitor {{ .Values.sentinel.masterName }} ${MASTER_HOST} {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }} {{ .Values.sentinel.quorum }}
+              sentinel monitor {{ .Values.sentinel.masterName }} {{- if .Values.sentinel.monitorTarget }} {{ .Values.sentinel.monitorTarget }}{{- else }} ${MASTER_HOST}{{- end }} {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }} {{ .Values.sentinel.quorum }}
               sentinel down-after-milliseconds {{ .Values.sentinel.masterName }} {{ .Values.sentinel.downAfterMilliseconds }}
               sentinel failover-timeout {{ .Values.sentinel.masterName }} {{ .Values.sentinel.failoverTimeout }}
               sentinel parallel-syncs {{ .Values.sentinel.masterName }} {{ .Values.sentinel.parallelSyncs }}
@@ -1025,7 +1025,7 @@ spec:
               # Enable hostname resolution for Redis Sentinel
               sentinel resolve-hostnames yes
               sentinel announce-hostnames yes
-              sentinel monitor {{ .Values.sentinel.masterName }} ${MASTER_HOST} {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }} {{ .Values.sentinel.quorum }}
+              sentinel monitor {{ .Values.sentinel.masterName }} {{- if .Values.sentinel.monitorTarget }} {{ .Values.sentinel.monitorTarget }}{{- else }} ${MASTER_HOST}{{- end }} {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }} {{ .Values.sentinel.quorum }}
               sentinel down-after-milliseconds {{ .Values.sentinel.masterName }} {{ .Values.sentinel.downAfterMilliseconds }}
               sentinel failover-timeout {{ .Values.sentinel.masterName }} {{ .Values.sentinel.failoverTimeout }}
               sentinel parallel-syncs {{ .Values.sentinel.masterName }} {{ .Values.sentinel.parallelSyncs }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -564,6 +564,9 @@
                 "masterName": {
                     "type": "string"
                 },
+                "monitorTarget": {
+                    "type": "string"
+                },
                 "masterService": {
                     "type": "object",
                     "properties": {

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -564,9 +564,6 @@
                 "masterName": {
                     "type": "string"
                 },
-                "monitorTarget": {
-                    "type": "string"
-                },
                 "masterService": {
                     "type": "object",
                     "properties": {
@@ -609,6 +606,9 @@
                             "type": "boolean"
                         }
                     }
+                },
+                "monitorTarget": {
+                    "type": "string"
                 },
                 "parallelSyncs": {
                     "type": "integer"
@@ -803,6 +803,22 @@
         },
         "topologySpreadConstraints": {
             "type": "array"
+        },
+        "updateStrategy": {
+            "type": "object",
+            "properties": {
+                "rollingUpdate": {
+                    "type": "object",
+                    "properties": {
+                        "maxUnavailable": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
         },
         "useDeployment": {
             "type": "boolean"

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -403,6 +403,13 @@ sentinel:
     loglevel: notice
   ## @param sentinel.masterName Name of the master server (default: mymaster)
   masterName: mymaster
+  ## @param sentinel.monitorTarget Override the Sentinel master discovery with an explicit hostname or IP
+  ## When unset (default), the chart's startup script discovers the master locally via the headless
+  ## service hostname (redis-X.redis-headless.<ns>.svc.cluster.local). In multi-region or multi-cluster
+  ## deployments that hostname only resolves inside the local cluster, preventing Sentinel quorum from
+  ## forming across clusters. Set this to an externally-resolvable hostname or IP (e.g., an internal
+  ## NLB DNS name or a Route53 record) that all Sentinels can reach to monitor a shared master.
+  monitorTarget: ""
   ## @param sentinel.quorum Number of Sentinels that need to agree about the fact the master is not reachable
   quorum: 2
   ## @param sentinel.downAfterMilliseconds Time in milliseconds after the master is declared down


### PR DESCRIPTION
### Description of the change

Adds a new optional value `sentinel.monitorTarget` that, when set, overrides the chart's local headless hostname discovery in the Sentinel configuration. When unset (default), behavior is unchanged.

### Benefits

Enables multi-region and multi-cluster deployments where the Redis master is reachable via an externally-resolvable hostname or IP (e.g., an internal NLB DNS name or a Route53 record). Without this override, the chart's startup script pins the Sentinel monitor target to `redis-X.redis-headless.<ns>.svc.cluster.local`, which only resolves inside the local cluster. In a multi-region setup each cluster's Sentinel ends up monitoring its own local pod and cross-region quorum cannot form. A per-cluster `monitorTarget` pointing at a shared, externally-resolvable address lets all Sentinels monitor the same master and form quorum via `__sentinel__:hello`.

### Possible drawbacks

None for users who do not set the value. Fully backward compatible: when `sentinel.monitorTarget` is empty (default), the chart renders the exact same `sentinel monitor mymaster ${MASTER_HOST} ...` line as before.

### Applicable issues

- fixes #

### Additional information

- The change is applied to both render paths of `templates/statefulset.yaml` (StatefulSet mode and Deployment mode), guarded by `{{- if .Values.sentinel.monitorTarget }}`.
- The value is documented inline in `values.yaml`, added to `values.schema.json` and to the README parameter table.
- Chart version bumped from `0.27.9` to `0.28.0` (minor bump for the new feature).
- Validated locally by rendering both branches:
  - `monitorTarget` empty → `sentinel monitor mymaster ${MASTER_HOST} 6379 2`
  - `monitorTarget=redis-master.example.com` → `sentinel monitor mymaster redis-master.example.com 6379 2`

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))