### PR TITLE
Feature/redis portname volumepermissions

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.28.0
+version: 0.29.0
 appVersion: "8.6.3"
 keywords:
   - redis

--- a/charts/redis/templates/headless-service.yaml
+++ b/charts/redis/templates/headless-service.yaml
@@ -32,7 +32,7 @@ spec:
     - port: {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}
       targetPort: redis
       protocol: TCP
-      name: redis
+      name: tcp-redis
     {{- range .Values.extraPorts }}
     - port: {{ .port }}
       targetPort: {{ .targetPort | default .name }}

--- a/charts/redis/templates/master-service.yaml
+++ b/charts/redis/templates/master-service.yaml
@@ -25,7 +25,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: redis
       protocol: TCP
-      name: redis
+      name: tcp-redis
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/charts/redis/templates/service.yaml
+++ b/charts/redis/templates/service.yaml
@@ -31,7 +31,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: redis
       protocol: TCP
-      name: redis
+      name: tcp-redis
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -67,7 +67,25 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if (list "replication" "cluster" | has .Values.architecture) }}
+      {{- if or (list "replication" "cluster" | has .Values.architecture) .Values.volumePermissions.enabled }}
+      initContainers:
+        {{- if .Values.volumePermissions.enabled }}
+        - name: volume-permissions
+          image: "{{ .Values.volumePermissions.image.registry | default .Values.global.imageRegistry }}/{{ .Values.volumePermissions.image.repository }}:{{ .Values.volumePermissions.image.tag }}"
+          imagePullPolicy: {{ include "cloudpirates.imagePullPolicy" (dict "image" .Values.volumePermissions.image) }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} {{ .Values.persistence.mountPath }}
+          securityContext:
+            runAsUser: 0
+          resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+        {{- end }}
+        {{- if (list "replication" "cluster" | has .Values.architecture) }}
       initContainers:
         - name: redis-init
           image: {{ include "redis.image" . | quote }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -239,6 +239,28 @@ persistence:
   ## Useful in dev environments and one PV for multiple services
   subPath: ""
 
+## @section Volume Permissions
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner of the PV mount point
+  enabled: false
+  ## @param volumePermissions.image.registry Image registry
+  ## @param volumePermissions.image.repository Image repository
+  ## @param volumePermissions.image.tag Image tag
+  ## @param volumePermissions.image.pullPolicy Image pull policy
+  image:
+    registry: docker.io
+    repository: busybox
+    tag: "1.36.1"
+    pullPolicy: IfNotPresent
+  ## @param volumePermissions.resources Resource limits and requests
+  resources: {}
+    # limits:
+    #   cpu: 50m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 64Mi
+
 ## @section Persistent Volume Claim Retention Policy
 persistentVolumeClaimRetentionPolicy:
   ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for the Statefulset


### PR DESCRIPTION
### Description of the change

This PR introduces two improvements to the Redis Helm chart:

- renames the Redis service port from `redis` to `tcp-redis`
- adds optional `volumePermissions` initContainer support

The service port rename improves compatibility with Istio explicit protocol selection requirements for TCP services.

Additionally, a new optional `volumePermissions` block was added to help resolve persistent volume ownership issues in non-root container environments.

### Benefits

- improves compatibility with Istio TCP protocol detection
- avoids protocol misclassification in service mesh environments
- enables easier deployment in restricted Kubernetes environments
- helps avoid volume permission issues on persistent volumes

### Possible drawbacks

- service port name changes from `redis` to `tcp-redis`
- users relying on the previous port name may need to update dependent manifests/configurations
- `volumePermissions` is disabled by default

### Applicable issues

- fixes #

### Additional information

Istio explicit protocol selection reference:
https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

The implementation follows common Helm chart patterns used in other community charts.

