### PR TITLE
[valkey] Add pdb, persistentVolumeClaimRetentionPolicy, and topologySpreadConstraints

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.20.2
+version: 0.21.0
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -189,6 +189,14 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 | ----------- | ------------------------------------------- | ------- |
 | `resources` | The resources to allocate for the container | `{}`    |
 
+### Pod Disruption Budget
+
+| Parameter            | Description                                                    | Default |
+| -------------------- | -------------------------------------------------------------- | ------- |
+| `pdb.enabled`        | Enable Pod Disruption Budget                                   | `false` |
+| `pdb.minAvailable`   | Minimum number/percentage of pods that should remain scheduled | `1`     |
+| `pdb.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable | `""`    |
+
 ### Persistence
 
 | Parameter                   | Description                                        | Default             |
@@ -200,6 +208,14 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 | `persistence.size`          | Persistent Volume size                             | `8Gi`               |
 | `persistence.accessModes`   | Persistent Volume access modes                     | `["ReadWriteOnce"]` |
 | `persistence.existingClaim` | The name of an existing PVC to use for persistence | `""`                |
+
+### Persistent Volume Claim Retention Policy
+
+| Parameter                                          | Description                                                                    | Default    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------ | ---------- |
+| `persistentVolumeClaimRetentionPolicy.enabled`     | Enable Persistent volume retention policy for the StatefulSet                  | `false`    |
+| `persistentVolumeClaimRetentionPolicy.whenDeleted` | Volume retention behavior that applies when the StatefulSet is deleted         | `"Retain"` |
+| `persistentVolumeClaimRetentionPolicy.whenScaled`  | Volume retention behavior when the replica count of the StatefulSet is reduced | `"Retain"` |
 
 ### Liveness and readiness probes
 
@@ -226,12 +242,13 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 
 ### Node Selection
 
-| Parameter      | Description                          | Default |
-| -------------- | ------------------------------------ | ------- |
-| `nodeSelector` | Node labels for pod assignment       | `{}`    |
-| `tolerations`  | Toleration labels for pod assignment | `[]`    |
-| `affinity`     | Affinity settings for pod assignment | `{}`    |
-| `hostAliases`  | Pod-level `hostAliases` entries (useful on IPv6-only clusters) | `[]` |
+| Parameter                   | Description                                                    | Default |
+| --------------------------- | -------------------------------------------------------------- | ------- |
+| `nodeSelector`              | Node labels for pod assignment                                 | `{}`    |
+| `tolerations`               | Toleration labels for pod assignment                           | `[]`    |
+| `affinity`                  | Affinity settings for pod assignment                           | `{}`    |
+| `topologySpreadConstraints` | Topology Spread Constraints for pod assignment                 | `[]`    |
+| `hostAliases`               | Pod-level `hostAliases` entries (useful on IPv6-only clusters) | `[]`    |
 
 ### Metrics configuration
 

--- a/charts/valkey/templates/pdb.yaml
+++ b/charts/valkey/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "valkey.fullname" . }}
+  namespace: {{ include "cloudpirates.namespace" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "valkey.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -600,6 +600,15 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
     - metadata:

--- a/charts/valkey/tests/pdb-pvc-topology_test.yaml
+++ b/charts/valkey/tests/pdb-pvc-topology_test.yaml
@@ -1,0 +1,128 @@
+suite: test pdb, persistentVolumeClaimRetentionPolicy, topologySpreadConstraints
+set:
+  image:
+    tag: 8.1.3@sha256:5b8f8c333bef895c925f56629d6ba90aea95a4f7391f62411e625267c600b19c
+tests:
+  - it: should not render PodDisruptionBudget when pdb.enabled is false
+    template: pdb.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render PodDisruptionBudget with minAvailable by default when enabled
+    template: pdb.yaml
+    set:
+      pdb:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - notExists:
+          path: spec.maxUnavailable
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: valkey
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should render PodDisruptionBudget with maxUnavailable when minAvailable is zero
+    template: pdb.yaml
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 0
+        maxUnavailable: "25%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should propagate commonAnnotations to the PodDisruptionBudget
+    template: pdb.yaml
+    set:
+      pdb:
+        enabled: true
+      commonAnnotations:
+        example.com/owner: "team-platform"
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: team-platform
+
+  - it: should not render persistentVolumeClaimRetentionPolicy by default
+    template: statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.persistentVolumeClaimRetentionPolicy
+
+  - it: should render persistentVolumeClaimRetentionPolicy when enabled
+    template: statefulset.yaml
+    set:
+      persistentVolumeClaimRetentionPolicy:
+        enabled: true
+        whenDeleted: Delete
+        whenScaled: Delete
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+
+  - it: should default persistentVolumeClaimRetentionPolicy values to Retain
+    template: statefulset.yaml
+    set:
+      persistentVolumeClaimRetentionPolicy:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Retain
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Retain
+
+  - it: should not render topologySpreadConstraints by default
+    template: statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.topologySpreadConstraints
+
+  - it: should render topologySpreadConstraints when provided
+    template: statefulset.yaml
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: valkey
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: topology.kubernetes.io/zone
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: DoNotSchedule
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: valkey

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -381,6 +381,20 @@
         "nodeSelector": {
             "type": "object"
         },
+        "pdb": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxUnavailable": {
+                    "type": "string"
+                },
+                "minAvailable": {
+                    "type": "integer"
+                }
+            }
+        },
         "persistence": {
             "type": "object",
             "properties": {
@@ -406,6 +420,20 @@
                     "type": "string"
                 },
                 "storageClass": {
+                    "type": "string"
+                }
+            }
+        },
+        "persistentVolumeClaimRetentionPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "whenDeleted": {
+                    "type": "string"
+                },
+                "whenScaled": {
                     "type": "string"
                 }
             }
@@ -611,6 +639,9 @@
             }
         },
         "tolerations": {
+            "type": "array"
+        },
+        "topologySpreadConstraints": {
             "type": "array"
         }
     }

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -202,6 +202,9 @@
                 }
             }
         },
+        "hostAliases": {
+            "type": "array"
+        },
         "image": {
             "type": "object",
             "properties": {

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -232,6 +232,15 @@ resources: {}
   #   cpu: 10m
   #   memory: 64Mi
 
+## @section Pod Disruption Budget
+pdb:
+  ## @param pdb.enabled Enable Pod Disruption Budget
+  enabled: false
+  ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+  minAvailable: 1
+  ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+  maxUnavailable: ""
+
 ## @section Persistence
 persistence:
   ## @param persistence.enabled Enable persistence using Persistent Volume Claims
@@ -249,6 +258,15 @@ persistence:
   ## @param persistence.accessModes Persistent Volume access modes
   accessModes:
     - ReadWriteOnce
+
+## @section Persistent Volume Claim Retention Policy
+persistentVolumeClaimRetentionPolicy:
+  ## @param persistentVolumeClaimRetentionPolicy.enabled Enable Persistent volume retention policy for the StatefulSet
+  enabled: false
+  ## @param persistentVolumeClaimRetentionPolicy.whenScaled Volume retention behavior when the replica count of the StatefulSet is reduced
+  whenScaled: Retain
+  ## @param persistentVolumeClaimRetentionPolicy.whenDeleted Volume retention behavior that applies when the StatefulSet is deleted
+  whenDeleted: Retain
 
 ## @section Liveness and readiness probes
 livenessProbe:
@@ -302,6 +320,9 @@ tolerations: []
 
 ## @param affinity Affinity settings for pod assignment
 affinity: {}
+
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment
+topologySpreadConstraints: []
 
 ## @param hostAliases Pod-level hostAliases (`spec.template.spec.hostAliases`).
 ## Useful on IPv6-only clusters where BusyBox `hostname -i` cannot resolve the


### PR DESCRIPTION
### Description of the change
  
  Ports three optional configs from the `redis` chart to the `valkey` chart for parity:
  
  - **`pdb.*`** — new `PodDisruptionBudget` template (`templates/pdb.yaml`).
  - **`persistentVolumeClaimRetentionPolicy.*`** — `whenDeleted`/`whenScaled` on the StatefulSet.
  - **`topologySpreadConstraints`** — passthrough array on the pod spec.
  
  All three default to disabled / empty, so existing installations are unaffected after upgrade.
  
  ### Benefits

  - Feature parity with the `redis` chart (same value keys and defaults).
  - Enables PDB protection, PVC retention control, and zone-aware pod spreading without forking the chart.
  - Backward-compatible: no manifest diff for existing releases unless opted in.
  
  ### Possible drawbacks

  - `persistentVolumeClaimRetentionPolicy` requires Kubernetes 1.27+ (silently ignored on older clusters).
  
  ### Applicable issues

  - N/A

  ### Additional information
  
  Verified locally with `helm lint`, `helm template` (defaults + all enabled), and `helm unittest` (26 tests pass, 9 new).
  
  ### Checklist

  - [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
  - [x] Variables are documented in the values.yaml and added to the `README.md`
  - [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
  - [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))