### PR TITLE
[redis] Refactor/redis container name

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.29.0
+version: 0.29.1
 appVersion: "8.6.3"
 keywords:
   - redis

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.29.2
+version: 0.29.3
 appVersion: "8.6.3"
 keywords:
   - redis

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.29.1
+version: 0.29.2
 appVersion: "8.6.3"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -525,7 +525,7 @@ spec:
             {{- end }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: redis
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "redis.image" . | quote }}
           imagePullPolicy: {{ include "cloudpirates.imagePullPolicy" (dict "image" .Values.image) }}


### PR DESCRIPTION
### Description of the change
Replace `{{ .Chart.Name }}` with the hardcoded value `redis` as the container name.

### Benefits
The container name is now explicit and consistent, regardless of the chart name.

### Possible drawbacks
None.

### Applicable issues
- fixes #

### Additional information
N/A

### Checklist
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified