### PR TITLE
[redis] Fix unexpected EOF in statefulset.yaml (missing {{- end }} and duplicate initContainers)

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.29.1
+version: 0.29.2
 appVersion: "8.6.3"
 keywords:
   - redis
@@ -41,8 +41,8 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
-    - kind: added
-      description: "expose sentinel.monitorTarget to support multi-region/multi-cluster Sentinel quorum"
+    - kind: fixed
+      description: "Fix unexpected EOF in statefulset.yaml due to duplicate initContainers key and missing {{- end }}"
       links:
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis/CHANGELOG.md"

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -86,7 +86,6 @@ spec:
               mountPath: {{ .Values.persistence.mountPath }}
         {{- end }}
         {{- if (list "replication" "cluster" | has .Values.architecture) }}
-      initContainers:
         - name: redis-init
           image: {{ include "redis.image" . | quote }}
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
@@ -523,6 +522,7 @@ spec:
               subPath: {{ include "redis.auth.acl.file" . }}
               readOnly: true
             {{- end }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
## Summary

Fixes #1336

The merge that introduced the outer `{{- if or ... }}` wrapper around `initContainers:` (to unify the `volumePermissions` and `redis-init` blocks) introduced two bugs:

- A duplicate `initContainers:` key was left on the line immediately after the `{{- if (list "replication" "cluster" | has .Values.architecture) }}` check (line 89 of the old file), making the YAML invalid.
- The closing `{{- end }}` for that inner `if` block was missing, causing the template engine to hit an unexpected EOF at line 1327.

## Changes

- Removed the stray duplicate `initContainers:` key so `redis-init` is correctly indented as a list item inside the single `initContainers:` block.
- Added the missing `{{- end }}` to close the `{{- if (list "replication" "cluster" | has .Values.architecture) }}` block.

## Validation

Tested with `helm template` across all affected configurations, no more `unexpected EOF`:
| Configuration | Result |
|---|---|
| `architecture: replication` | ✅ Renders — `redis-init` init container present |
| `architecture: cluster` | ✅ Renders cleanly |
| `architecture: standalone` | ✅ Renders cleanly |
| `architecture: replication` + `volumePermissions.enabled: true` | ✅ Both `volume-permissions` and `redis-init` under a single `initContainers:` key |
