### PR TITLE
[etcd] Add clusterDomain to define custom dns suffix

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "3.6.11"
 keywords:
   - etcd
@@ -34,7 +34,7 @@ annotations:
     - name: etcd
       url: https://etcd.io/
     - name: Helm Chart
-      url: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/mariadb
+      url: https://github.com/CloudPirates-io/helm-charts/tree/main/charts/etcd
     - name: Application
       url: https://github.com/etcd-io/etcd
     - name: Maintainer CloudPirates

--- a/charts/etcd/README.md
+++ b/charts/etcd/README.md
@@ -84,6 +84,7 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/etcd:<version>
 ## Configuration
 
 ### Global Parameters
+
 | Parameter                 | Description                           | Default |
 | ------------------------- | ------------------------------------- | ------- |
 | `global.imageRegistry`    | Global Docker image registry override | `""`    |
@@ -100,16 +101,17 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/etcd:<version>
 
 ### Common Parameters
 
-| Parameter           | Description                                        | Default |
-| ------------------- | -------------------------------------------------- | ------- |
-| `nameOverride`      | String to partially override etcd.fullname         | `""`    |
-| `fullnameOverride`  | String to fully override etcd.fullname             | `""`    |
-| `namespaceOverride` | String to override the namespace for all resources | `""`    |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`    |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`    |
-| `replicaCount`      | Number of etcd replicas to deploy (must be odd)    | `3`     |
-| `podLabels`         | Additional labels for etcd pods                    | `{}`    |
-| `podAnnotations`    | Additional annotations for etcd pods               | `{}`    |
+| Parameter           | Description                                        | Default           |
+| ------------------- | -------------------------------------------------- | ----------------- |
+| `nameOverride`      | String to partially override etcd.fullname         | `""`              |
+| `fullnameOverride`  | String to fully override etcd.fullname             | `""`              |
+| `namespaceOverride` | String to override the namespace for all resources | `""`              |
+| `commonLabels`      | Labels to add to all deployed objects              | `{}`              |
+| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`              |
+| `replicaCount`      | Number of etcd replicas to deploy (must be odd)    | `3`               |
+| `podLabels`         | Additional labels for etcd pods                    | `{}`              |
+| `podAnnotations`    | Additional annotations for etcd pods               | `{}`              |
+| `clusterDomain`     | DNS suffix for internal service discovery          | `"cluster.local"` |
 
 ### Service Configuration
 

--- a/charts/etcd/templates/_helpers.tpl
+++ b/charts/etcd/templates/_helpers.tpl
@@ -84,10 +84,11 @@ Generate etcd initial cluster string
 {{- $peerPort := .Values.service.peerPort -}}
 {{- $replicaCount := int .Values.replicaCount }}
 {{- $protocol := "http" }}
+{{- $clusterDomain := .Values.clusterDomain }}
 {{- if .Values.auth.peer.enabled }}
 {{- $protocol = "https" }}
 {{- end }}
 {{- range $i := until $replicaCount }}
-{{- if $i }},{{ end -}}{{ $name }}-{{ $i }}={{ $protocol }}://{{ $name }}-{{ $i }}.{{ $name }}-headless.{{ $namespace }}.svc.cluster.local:{{ $peerPort }}
+{{- if $i }},{{ end -}}{{ $name }}-{{ $i }}={{ $protocol }}://{{ $name }}-{{ $i }}.{{ $name }}-headless.{{ $namespace }}.svc.{{ $clusterDomain }}:{{ $peerPort }}
 {{- end }}
 {{- end }}

--- a/charts/etcd/templates/statefulset.yaml
+++ b/charts/etcd/templates/statefulset.yaml
@@ -53,8 +53,8 @@ spec:
             - --name=$(POD_NAME)
             - --listen-peer-urls={{ if .Values.auth.peer.enabled }}https{{ else }}http{{ end }}://{{ .Values.config.listenPeerIp }}:{{ .Values.service.peerPort }}
             - --listen-client-urls={{ if .Values.auth.enabled }}https{{ else }}http{{ end }}://{{ .Values.config.listenClientIp }}:{{ .Values.service.clientPort }}
-            - --advertise-client-urls={{ if .Values.auth.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.cluster.local:{{ .Values.service.clientPort }}
-            - --initial-advertise-peer-urls={{ if .Values.auth.peer.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.cluster.local:{{ .Values.service.peerPort }}
+            - --advertise-client-urls={{ if .Values.auth.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.clientPort }}
+            - --initial-advertise-peer-urls={{ if .Values.auth.peer.enabled }}https{{ else }}http{{ end }}://$(POD_NAME).{{ include "etcd.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}:{{ .Values.service.peerPort }}
             - --initial-cluster={{ include "etcd.initialCluster" . }}
             - --initial-cluster-token={{ .Values.config.initialClusterToken }}
             - --initial-cluster-state={{ .Values.config.initialClusterState }}

--- a/charts/etcd/tests/etcd-functionality_test.yaml
+++ b/charts/etcd/tests/etcd-functionality_test.yaml
@@ -65,6 +65,21 @@ tests:
           path: spec.template.spec.containers[0].args
           content: "--listen-client-urls=http://127.0.0.1:2379"
 
+  - it: should configure cluster domain
+    template: statefulset.yaml
+    set:
+      clusterDomain: "unit.test"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--advertise-client-urls=http://$(POD_NAME).RELEASE-NAME-etcd-headless.NAMESPACE.svc.unit.test:2379"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--initial-advertise-peer-urls=http://$(POD_NAME).RELEASE-NAME-etcd-headless.NAMESPACE.svc.unit.test:2380"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--initial-cluster=RELEASE-NAME-etcd-0=http://RELEASE-NAME-etcd-0.RELEASE-NAME-etcd-headless.NAMESPACE.svc.unit.test:2380,RELEASE-NAME-etcd-1=http://RELEASE-NAME-etcd-1.RELEASE-NAME-etcd-headless.NAMESPACE.svc.unit.test:2380,RELEASE-NAME-etcd-2=http://RELEASE-NAME-etcd-2.RELEASE-NAME-etcd-headless.NAMESPACE.svc.unit.test:2380"
+
   - it: should add extraArgs
     template: statefulset.yaml
     set:

--- a/charts/etcd/values.schema.json
+++ b/charts/etcd/values.schema.json
@@ -27,6 +27,9 @@
                 }
             }
         },
+        "clusterDomain": {
+            "type": "string"
+        },
         "commonAnnotations": {
             "type": "object"
         },

--- a/charts/etcd/values.yaml
+++ b/charts/etcd/values.yaml
@@ -37,6 +37,9 @@ podLabels: {}
 ## @param podAnnotations Additional annotations for etcd pods
 podAnnotations: {}
 
+## @param clusterDomain DNS suffix for internal service discovery
+clusterDomain: cluster.local
+
 ## @section Service configuration
 service:
   ## @param service.type Kubernetes service type


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

This enables one to specify the internal kubernetes cluster domain in scenarios where it differs from the default cluster.local

### Benefits

Allows the etcd cluster to be deployed in environments where the default cluster domain was overwritten.

### Possible drawbacks

None.

### Applicable issues

None.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
