### PR TITLE
[rabbitmq-cluster-operator] Match messaging-topology-operator roles to upstream

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "2.21.0"
 keywords:
   - rabbitmq-cluster-operator
@@ -45,11 +45,4 @@ annotations:
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
     - kind: changed
-      description: "Move operator images to ghcr.io and bump to upstream latest (cluster-operator 2.21.0, messaging-topology-operator 1.19.2, default-user-credential-updater 1.0.14, RabbitMQ 4.2.6)"
-      links:
-        - name: "Changelog"
-          url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/rabbitmq-cluster-operator/CHANGELOG.md"
-    - kind: changed
-      description: "Switch operator probes to upstream /healthz and /readyz endpoints on a dedicated health port; required for messaging-topology-operator v1.19.0+"
-    - kind: changed
-      description: "Refresh CRDs from upstream cluster-operator v2.21.0 and messaging-topology-operator v1.19.2"
+      description: "Match messaging-topology-operator roles to upstream"

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -24,13 +24,6 @@ rules:
   {{- end }}
   {{- end }}
   - apiGroups:
-      - events.k8s.io
-    resources:
-      - events
-    verbs:
-      - create
-      - patch
-  - apiGroups:
       - ""
     resources:
       - secrets
@@ -38,8 +31,6 @@ rules:
       - create
       - get
       - list
-      - patch
-      - update
       - watch
   - apiGroups:
       - ""
@@ -50,9 +41,28 @@ rules:
       - list
       - watch
   - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - rabbitmq.com
     resources:
       - bindings
+      - exchanges
+      - federations
+      - operatorpolicies
+      - permissions
+      - policies
+      - queues
+      - schemareplications
+      - shovels
+      - superstreams
+      - topicpermissions
+      - users
+      - vhosts
     verbs:
       - create
       - delete
@@ -61,149 +71,43 @@ rules:
       - patch
       - update
       - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - bindings/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - rabbitmq.com
     resources:
       - bindings/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - exchanges
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - exchanges/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - exchanges/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - federations
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - federations/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - federations/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - permissions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - permissions/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
+      - operatorpolicies/finalizers
       - permissions/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - policies
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - policies/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - policies/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - queues
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - queues/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
       - queues/finalizers
+      - schemareplications/finalizers
+      - shovels/finalizers
+      - superstreams/finalizers
+      - topicpermissions/finalizers
+      - users/finalizers
+      - vhosts/finalizers
     verbs:
+      - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - bindings/status
+      - exchanges/status
+      - federations/status
+      - operatorpolicies/status
+      - permissions/status
+      - policies/status
+      - queues/status
+      - schemareplications/status
+      - shovels/status
+      - superstreams/status
+      - topicpermissions/status
+      - users/status
+      - vhosts/status
+    verbs:
+      - get
+      - patch
       - update
   - apiGroups:
       - rabbitmq.com
@@ -219,187 +123,5 @@ rules:
       - rabbitmqclusters/status
     verbs:
       - get
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - schemareplications
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - schemareplications/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - schemareplications/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - shovels
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - shovels/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - shovels/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - superstreams
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - superstreams/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - superstreams/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - users
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - users/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - users/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - vhosts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - vhosts/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - vhosts/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - topicpermissions
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - topicpermissions/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - topicpermissions/finalizers
-    verbs:
-      - update
-  - apiGroups:
-    - rabbitmq.com
-    resources:
-    - operatorpolicies
-    verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
-  - apiGroups:
-    - rabbitmq.com
-    resources:
-    - operatorpolicies/status
-    verbs:
-    - get
-    - patch
-    - update
-  - apiGroups:
-      - rabbitmq.com
-    resources:
-      - operatorpolicies/finalizers
-    verbs:
-      - update
   {{- end }}
 {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/role.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/role.yaml
@@ -11,6 +11,18 @@ metadata:
   {{- end }}
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -23,22 +35,10 @@ rules:
       - patch
       - delete
   - apiGroups:
-      - events.k8s.io
+      - ""
     resources:
       - events
     verbs:
       - create
       - patch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
 {{- end }}


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Update ClusterRole and Role to match upstream. This includes:

- remove `patch` and `update` verbs for `secrets` in cluster role
- change `events` apiGroup back to core in leader election role
- reorder and organize rules to match upstream manifests

### Benefits

Match roles' templates to upstream as close as possible to simplify maintenance.

### Possible drawbacks

None.

### Applicable issues

- fixes N/A

### Additional information

Upstream references:
- https://github.com/rabbitmq/messaging-topology-operator/blob/v1.19.2/config/rbac/leader_election_role.yaml
- https://github.com/rabbitmq/messaging-topology-operator/blob/v1.19.2/config/rbac/role.yaml

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
