### PR TITLE
[redis] Allow separate affinity for the master discovery deployment

### DIFF
--- a/charts/redis/CHANGELOG.md
+++ b/charts/redis/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this chart will be documented in this file.
 
+## [0.29.4] - 2026-05-29
+
+- Add `sentinel.masterService.affinity` to allow the master discovery deployment to use affinity rules independent from the main Redis workload. Defaults to `.Values.affinity` when unset, so existing behavior is unchanged (#1213).
+
 ## [0.28.0] - 2026-05-20
 
 - Add `sentinel.monitorTarget` to override the Sentinel master discovery with an explicit hostname or IP, enabling multi-region and multi-cluster deployments where the chart's default local headless discovery does not work.

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.29.3
+version: 0.29.4
 appVersion: "8.6.3"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -371,6 +371,7 @@ Redis Sentinel provides high availability for Redis through automatic failover. 
 | `sentinel.readinessProbe.timeoutSeconds`      | Timeout for each probe attempt                                                                | `5`         |
 | `sentinel.readinessProbe.failureThreshold`    | Number of failures before pod is marked unready                                               | `6`         |
 | `sentinel.readinessProbe.successThreshold`    | Number of successes to mark probe as successful                                               | `1`         |
+| `sentinel.masterService.affinity`             | Affinity rules for the master discovery deployment (defaults to `affinity` if not set)        | `{}`        |
 
 ### ServiceAccount
 

--- a/charts/redis/templates/sentinel-master-deployment.yaml
+++ b/charts/redis/templates/sentinel-master-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with (.Values.sentinel.masterService.affinity | default .Values.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/redis/tests/master-service-affinity_test.yaml
+++ b/charts/redis/tests/master-service-affinity_test.yaml
@@ -1,0 +1,64 @@
+suite: test redis master discovery affinity
+templates:
+  - sentinel-master-deployment.yaml
+set:
+  architecture: replication
+  sentinel:
+    enabled: true
+    masterService:
+      enabled: true
+  config:
+    content: |
+      # Redis configuration
+      port 6379
+tests:
+  - it: should inherit global affinity when masterService.affinity is not set
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values:
+                      - ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: disktype
+
+  - it: should use masterService.affinity when set, overriding the global affinity
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values:
+                      - ssd
+      sentinel:
+        masterService:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: role
+                        operator: In
+                        values:
+                          - helper
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key
+          value: role
+      - notExists:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution
+
+  - it: should render no affinity when neither global nor masterService affinity is set
+    asserts:
+      - notExists:
+          path: spec.template.spec.affinity

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -604,6 +604,9 @@
                         },
                         "verbose": {
                             "type": "boolean"
+                        },
+                        "affinity": {
+                            "type": "object"
                         }
                     }
                 },

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -567,6 +567,9 @@
                 "masterService": {
                     "type": "object",
                     "properties": {
+                        "affinity": {
+                            "type": "object"
+                        },
                         "annotations": {
                             "type": "object"
                         },
@@ -604,9 +607,6 @@
                         },
                         "verbose": {
                             "type": "boolean"
-                        },
-                        "affinity": {
-                            "type": "object"
                         }
                     }
                 },
@@ -825,6 +825,34 @@
         },
         "useDeployment": {
             "type": "boolean"
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object"
+                }
+            }
         }
     }
 }

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -498,6 +498,8 @@ sentinel:
       #   memory: 32Mi
     ## @param sentinel.masterService.verbose Enable verbose logging for master discovery
     verbose: false
+    ## @param sentinel.masterService.affinity Affinity rules for the master discovery deployment (defaults to .Values.affinity if not set)
+    affinity: {}
 
   livenessProbe:
     ## @param sentinel.livenessProbe.enabled Enable liveness probe


### PR DESCRIPTION
Closes #1213.

## What

Adds a new `sentinel.masterService.affinity` value so the master discovery deployment can use affinity rules independent from the main Redis workload.

## Why

The master discovery deployment (`sentinel-master-deployment.yaml`) shared the same `.Values.affinity` as the main Redis StatefulSet/Deployment. When users set pod anti-affinity to spread the main Redis pods across nodes, that identical constraint was forced onto the lightweight `alpine/kubectl` discovery pod — which has no need to be spread out. This could trigger unnecessary cluster autoscaling (a new node spun up just to place the helper pod), as reported in #1213.

## How

- `sentinel-master-deployment.yaml` now resolves affinity as `sentinel.masterService.affinity | default .Values.affinity`.
- New `sentinel.masterService.affinity` value (defaults to `{}`).

This mirrors the existing convention in the same chart, where `sentinel.masterService.type` falls back to `service.type`.

**Backwards compatible:** when `sentinel.masterService.affinity` is unset, the deployment continues to inherit `.Values.affinity` exactly as before. Users can now override it (or set a lighter rule) for the discovery pod without affecting the main Redis pods.

## Changes

- `templates/sentinel-master-deployment.yaml` — affinity fallback
- `values.yaml` — new param + doc
- `values.schema.json` — schema entry
- `README.md` — documented parameter
- `tests/master-service-affinity_test.yaml` — unit tests (inherit / override / none)
- `Chart.yaml` — version bump `0.29.3` → `0.29.4`
- `CHANGELOG.md` — entry

## Testing

- `helm unittest .` → 49 passed (3 new)
- `helm lint .` → passes
- `helm template` verified: master inherits global when unset, uses its own when set, renders no affinity when neither is set; main Redis workload unaffected by the override.