### PR TITLE
[rabbitmq] Apply global.imageRegistry to init and definitions-reload images

### DIFF
--- a/charts/rabbitmq/CHANGELOG.md
+++ b/charts/rabbitmq/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this chart will be documented in this file.
 
+## [0.21.5] - 2026-06-01
+
+- Fix `global.imageRegistry` not being applied to the init container and definitions auto-reload sidecar images (#1342).
+
 ## [cluster-operator-0.2.2] - 2026-03-27
 
 - Update image.repository to 23fe4f2 (#1181) ([bd28b2b5](https://github.com/CloudPirates-io/helm-charts/commit/bd28b2b5))

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.21.4
+version: 0.21.5
 appVersion: "4.3.0"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/_helpers.tpl
+++ b/charts/rabbitmq/templates/_helpers.tpl
@@ -79,6 +79,20 @@ Return the proper RabbitMQ image name
 {{- end }}
 
 {{/*
+Return the proper RabbitMQ init container image name
+*/}}
+{{- define "rabbitmq.initContainer.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.initContainer.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
+Return the proper RabbitMQ definitions auto-reload image name
+*/}}
+{{- define "rabbitmq.definitions.autoReload.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.definitions.autoReload.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "rabbitmq.imagePullSecrets" -}}

--- a/charts/rabbitmq/templates/statefulset.yaml
+++ b/charts/rabbitmq/templates/statefulset.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       initContainers:
         - name: init-erlang-cookie
-          image: "{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}/{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          image: {{ include "rabbitmq.initContainer.image" . | quote }}
           imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command:
@@ -71,7 +71,7 @@ spec:
           {{- end }}
         {{- if .Values.installPlugins }}
         - name: download-plugins
-          image: "{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}/{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
+          image: {{ include "rabbitmq.initContainer.image" . | quote }}
           imagePullPolicy: "{{ .Values.initContainer.image.pullPolicy }}"
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command:
@@ -294,7 +294,7 @@ spec:
             {{- end }}
         {{- if and .Values.definitions.enabled .Values.definitions.autoReload.enabled }}
         - name: definitions-reloader
-          image: "{{ .Values.definitions.autoReload.image.registry }}/{{ .Values.definitions.autoReload.image.repository }}:{{ .Values.definitions.autoReload.image.tag }}"
+          image: {{ include "rabbitmq.definitions.autoReload.image" . | quote }}
           imagePullPolicy: {{ .Values.definitions.autoReload.image.pullPolicy }}
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command:

--- a/charts/rabbitmq/tests/common-parameters_test.yaml
+++ b/charts/rabbitmq/tests/common-parameters_test.yaml
@@ -95,3 +95,31 @@ tests:
           path: spec.replicas
           value: 3
         template: templates/statefulset.yaml
+
+  - it: should apply global.imageRegistry to all images
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      installPlugins:
+        - rabbitmq_shovel
+      definitions:
+        enabled: true
+        autoReload:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=="init-erlang-cookie")].image
+          pattern: ^myregistry\.example\.com/
+        template: templates/statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[?(@.name=="download-plugins")].image
+          pattern: ^myregistry\.example\.com/
+        template: templates/statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=="rabbitmq")].image
+          pattern: ^myregistry\.example\.com/
+        template: templates/statefulset.yaml
+      - matchRegex:
+          path: spec.template.spec.containers[?(@.name=="definitions-reloader")].image
+          pattern: ^myregistry\.example\.com/
+        template: templates/statefulset.yaml


### PR DESCRIPTION
### Description of the change

Fixes `global.imageRegistry` being ignored for the rabbitmq chart's init containers and the definitions auto-reload sidecar (#1342).

Three image references were built inline instead of going through the `cloudpirates.image` helper:

1. **`init-erlang-cookie` and `download-plugins` init containers** used `{{ .Values.initContainer.image.registry | default .Values.global.imageRegistry }}`. Since `initContainer.image.registry` defaults to `docker.io` (never empty), the `default` branch was never taken and `global.imageRegistry` had no effect.
2. **`definitions-reloader` sidecar** built its image as `{{ .Values.definitions.autoReload.image.registry }}/...` and never referenced `global.imageRegistry` at all.

All three now route through new `rabbitmq.initContainer.image` and `rabbitmq.definitions.autoReload.image` helpers that wrap `cloudpirates.image`, exactly like the existing `rabbitmq.image` helper (and matching the `mongodb.metrics.image` / `mongodb.metrics.uriEncodeImage` pattern used elsewhere in the repo). The `cloudpirates.image` helper gives `global.imageRegistry` precedence over the per-image registry, so it now overrides every image in the chart.

### Benefits

`global.imageRegistry` now applies to **all** images in the chart (main, init containers, plugin download, definitions auto-reload sidecar), making air-gapped / private-registry mirroring work as documented.

### Possible drawbacks

`global.imageRegistry`, when set, now takes precedence over a per-image `registry` for the init/sidecar images (previously the per-image value always won). This matches the behaviour of the main rabbitmq image and the documented intent of `global.imageRegistry`, so it should be the expected behaviour.

### Applicable issues

- fixes #1342

### Additional information

Added a regression test (`tests/common-parameters_test.yaml`) asserting that `global.imageRegistry` is applied to the init container, plugin download init container, main rabbitmq container, and the definitions-reloader sidecar. `helm lint` and `helm unittest` pass (33 tests).

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified
