### PR TITLE
[redis]: Fix use of podLabels for sts volumeClaimTemplates.labels

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.29.4
+version: 0.30.0
 appVersion: "8.6.3"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -259,16 +259,17 @@ user sentinel >sentinelpassword ~* +client +info +ping +publish +subscribe +psub
 
 ### Persistence
 
-| Parameter                   | Description                                        | Default         |
-| --------------------------- | -------------------------------------------------- | --------------- |
-| `persistence.enabled`       | Enable persistent storage                          | `true`          |
-| `persistence.storageClass`  | Storage class for persistent volume                | `""`            |
-| `persistence.accessMode`    | Access mode for persistent volume                  | `ReadWriteOnce` |
-| `persistence.size`          | Size of persistent volume                          | `8Gi`           |
-| `persistence.mountPath`     | Mount path for Redis data                          | `/data`         |
-| `persistence.annotations`   | Annotations for persistent volume claims           | `{}`            |
-| `persistence.existingClaim` | The name of an existing PVC to use for persistence | `""`            |
-| `persistence.subPath`       | The subdirectory of the volume to mount to         | `""`            |
+| Parameter                   | Description                                                 | Default         |
+| --------------------------- | ----------------------------------------------------------- | --------------- |
+| `persistence.enabled`       | Enable persistent storage                                   | `true`          |
+| `persistence.storageClass`  | Storage class for persistent volume                         | `""`            |
+| `persistence.accessMode`    | Access mode for persistent volume                           | `ReadWriteOnce` |
+| `persistence.size`          | Size of persistent volume                                   | `8Gi`           |
+| `persistence.mountPath`     | Mount path for Redis data                                   | `/data`         |
+| `persistence.annotations`   | Annotations for persistent volume claims                    | `{}`            |
+| `persistence.existingClaim` | The name of an existing PVC to use for persistence          | `""`            |
+| `persistence.subPath`       | The subdirectory of the volume to mount to                  | `""`            |
+| `persistence.labels`        | Map of labels to add to the Persistent Volume Claims (PVCs) | `""`            |
 
 ### Persistent Volume Claim Retention Policy
 

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1306,7 +1306,7 @@ spec:
         name: data
         labels:
           {{- include "redis.selectorLabels" . | nindent 10 }}
-          {{- with .Values.podLabels }}
+          {{- with .Values.persistence.labels }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- with .Values.persistence.annotations }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -238,6 +238,8 @@ persistence:
   ## @param persistence.subPath The subdirectory of the volume to mount to
   ## Useful in dev environments and one PV for multiple services
   subPath: ""
+  ## @param Map of labels to add to the Persistent Volume Claims (PVCs)
+  labels: {}
 
 ## @section Volume Permissions
 volumePermissions:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Currently changing podLabels is requires deleting existing PVCs, as the podLabels are used in the immutable part of the sts, effectively resulting in data loss and/or downtimes when one wants to alter podLabels. This is not necessary if PVCs get their own set of labels just like it is done for the bitnami redis-cluster helm-chart. https://github.com/bitnami/charts/blob/f9ad394743e85cb52afaded00b2f6c37b4af3157/bitnami/redis-cluster/templates/redis-statefulset.yaml#L487
In order to make this change backwards compatible persistence.labels was introduced to be used for labelling PVCs instead.

### Benefits

Possibility to use mutable podLabels and generally being less restricted in changing podLabels after an initial setup.

### Possible drawbacks

The need to maintain existing podLabels under persistence.labels.

### Applicable issues

n/a

### Additional information

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
