### PR TITLE
[rabbitmq-cluster-operator ] Adds missing role/rolebinding delete permission to clusterRole

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "2.21.0"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
@@ -152,6 +152,7 @@ rules:
       - rolebindings
     verbs:
       - create
+      - delete
       - get
       - list
       - update
@@ -162,6 +163,7 @@ rules:
       - roles
     verbs:
       - create
+      - delete
       - get
       - list
       - update


### PR DESCRIPTION
Hey there!

### Description of the change

We've run into an issue when upgrading some clusters. Operator was blocked due to the lack of permissions to delete roles and rolebindings as a consequence of this upstream change https://github.com/rabbitmq/cluster-operator/pull/2128

### Benefits

Fixes the issue caused by the upstream change which led the operator to block any upgrade to the rabbitmqclusters

### Possible drawbacks

As stated in the referenced PR, it adds wider permissions to the cluster operator, but since its been accepted in the upstream, not much to do about it 🤷🏽‍♂️ 

### Applicable issues

Haven't found any and since it was a small change I opened the PR directly

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
