### PR TITLE
[valkey] Use shared helper for metrics container securityContext

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.21.1
+version: 0.21.2
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -507,16 +507,7 @@ spec:
         - name: metrics
           image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           env:
             {{- if .Values.auth.enabled }}
             - name: REDIS_PASSWORD


### PR DESCRIPTION
### Description of the change

The `metrics` (redis_exporter) container in the valkey StatefulSet defined its `securityContext` as a hardcoded inline block, while every other container (`valkey-init`, `valkey`, `sentinel`) renders it through the shared `cloudpirates.renderContainerSecurityContext` helper. This change switches the metrics container to use the same helper, so all containers in the chart derive their security context from `.Values.containerSecurityContext`.

This is the same convention already followed by the `redis` chart, whose metrics container uses the shared helper.

### Benefits

- Consistency: a single source of truth for container security context across all containers in the chart.
- The metrics container now honors `.Values.containerSecurityContext` overrides instead of ignoring them.
- Removes 9 lines of duplicated, drift-prone configuration.

### Possible drawbacks

The metrics container previously hardcoded `runAsUser: 65534` / `runAsGroup: 65534` (nobody). It now inherits the chart's standard container security context (`runAsUser: 999` / `runAsGroup: 1000` by default). The `redis_exporter` image runs fine as non-root, so this is safe, but anyone relying on the metrics container running specifically as `65534` should set `.Values.containerSecurityContext` accordingly.

### Applicable issues

<!-- none -->

### Additional information

Verified with `helm template charts/valkey --set metrics.enabled=true` — the metrics container renders a valid `securityContext` from the helper.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))