### PR TITLE
[valkey] fix permanently out of sync, argocd

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.21.3
+version: 0.21.4
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -602,7 +602,9 @@ spec:
   {{- end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with $labels := merge (include "valkey.selectorLabels" . | fromYaml) .Values.persistence.labels .Values.podLabels }}
         labels:


### PR DESCRIPTION

<img width="2560" height="1600" alt="20260608-13h28m07s-valkey - Application Details Tree - Argo CD — Mozilla Firefox" src="https://github.com/user-attachments/assets/212bfbf6-962d-4dc7-ae82-404c10505149" />


### Description of the change

add spec fields k8s will auto add after install 

### Benefits
when installing with argocd, the chart will no loner stays in "out of sync" state permanently

### Possible drawbacks

nil

### Applicable issues

nil

### Additional information

nil

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
