### PR TITLE
[mongodb] Add missing containerSecurityContext for metrics-uri-init containers

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.17.4
+version: 0.17.5
 appVersion: "8.3.2"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/statefulset-configserver.yaml
+++ b/charts/mongodb/templates/statefulset-configserver.yaml
@@ -113,6 +113,7 @@ spec:
         - name: metrics-uri-init
           image: {{ include "mongodb.metrics.uriEncodeImage" . | quote }}
           imagePullPolicy: {{ .Values.metrics.uriEncodeImage.pullPolicy }}
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -120,6 +120,7 @@ spec:
         - name: metrics-uri-init
           image: {{ include "mongodb.metrics.uriEncodeImage" . | quote }}
           imagePullPolicy: {{ .Values.metrics.uriEncodeImage.pullPolicy }}
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |
@@ -329,4 +330,4 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- end }}
+{{- end }

--- a/charts/mongodb/templates/statefulset-shard.yaml
+++ b/charts/mongodb/templates/statefulset-shard.yaml
@@ -218,6 +218,7 @@ spec:
         - name: metrics-uri-init
           image: {{ include "mongodb.metrics.uriEncodeImage" $ | quote }}
           imagePullPolicy: {{ $.Values.metrics.uriEncodeImage.pullPolicy }}
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -91,6 +91,7 @@ spec:
         - name: metrics-uri-init
           image: {{ include "mongodb.metrics.uriEncodeImage" . | quote }}
           imagePullPolicy: {{ .Values.metrics.uriEncodeImage.pullPolicy }}
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           command: ["/bin/sh", "-c"]
           args:
             - |


### PR DESCRIPTION
### Description of the change

Fixes the mongodb chart to consistently apply the containerSecurityContext.
It was present in all containers except for the "metrics-uri-init" initContainer.

### Benefits

Allows the chart to be configured for the "restricted" kubernetes Pod Security Standards with these value overrides:

```
podSecurityContext:
  seccompProfile:
    type: RuntimeDefault
```

In particular the following policies now pass:
 - require-run-as-nonroot
 - disallow-privilege-escalation

### Possible drawbacks

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
