### PR TITLE
[mongodb] fix recently introduced typo in mongodb chart

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.17.5
+version: 0.17.6
 appVersion: "8.3.2"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -330,4 +330,4 @@ spec:
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- end }
+{{- end }}


### PR DESCRIPTION
### Description of the change

Fix a typo that I sadly introduced in PR #1372 when adding a feature to the mongodb chart.
The typo broke version 0.17.5 of the mongodb chart.

### Benefits

The mongodb helm chart will work again.

### Possible drawbacks

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
