### PR TITLE
[valkey] Add metrics.extraEnvVars for the metrics exporter container

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.21.4
+version: 0.22.0
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -260,6 +260,7 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 | `metrics.image.tag`                        | Valkey exporter image tag                                                       | `v1.80.1-alpine`           |
 | `metrics.image.pullPolicy`                 | Valkey exporter image pull policy                                               | `Always`                   |
 | `metrics.resources`                        | Resource limits and requests for metrics container                              | `{}`                       |
+| `metrics.extraEnvVars`                     | Additional environment variables to set on the metrics exporter container      | `[]`                       |
 | `metrics.service.annotations`              | Additional custom annotations for Metrics service                               | `{}`                       |
 | `metrics.service.labels`                   | Additional custom labels for Metrics service                                    | `{}`                       |
 | `metrics.service.port`                     | Metrics service port                                                            | `9121`                     |

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -516,6 +516,9 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ include "valkey.passwordKey" . }}
             {{- end }}
+            {{- with .Values.metrics.extraEnvVars }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 9121

--- a/charts/valkey/tests/metrics-extra-env-vars_test.yaml
+++ b/charts/valkey/tests/metrics-extra-env-vars_test.yaml
@@ -1,0 +1,58 @@
+suite: test valkey metrics exporter extra env vars
+templates:
+  - statefulset.yaml
+set:
+  metrics:
+    enabled: true
+tests:
+  - it: should only set REDIS_PASSWORD on the metrics container by default
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[1].env
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[1].env[0].name
+          value: REDIS_PASSWORD
+
+  - it: should render metrics.extraEnvVars on the metrics container
+    set:
+      metrics:
+        enabled: true
+        extraEnvVars:
+          - name: REDIS_EXPORTER_CHECK_KEYS
+            value: "sessions*,tokens*"
+          - name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+            value: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_EXPORTER_CHECK_KEYS
+            value: "sessions*,tokens*"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_EXPORTER_INCL_SYSTEM_METRICS
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          any: true
+          content:
+            name: REDIS_PASSWORD
+
+  - it: should render metrics.extraEnvVars when auth is disabled
+    set:
+      auth:
+        enabled: false
+      metrics:
+        enabled: true
+        extraEnvVars:
+          - name: REDIS_EXPORTER_CHECK_KEYS
+            value: "sessions*"
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[1].env
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[1].env[0].name
+          value: REDIS_EXPORTER_CHECK_KEYS

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -304,6 +304,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "extraEnvVars": {
+                    "type": "array"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -369,6 +369,8 @@ metrics:
     pullPolicy: Always
   ## @param metrics.resources Resource limits and requests for metrics container
   resources: {}
+  ## @param metrics.extraEnvVars Additional environment variables to set on the metrics exporter container
+  extraEnvVars: []
   ## Metrics service configuration
   service:
     ## @param metrics.service.annotations Additional custom annotations for Metrics service


### PR DESCRIPTION
### Description of the change

Adds a new `metrics.extraEnvVars` value that renders additional environment variables on the metrics exporter sidecar container, using the same rendering style as the existing top-level `extraEnvVars`.

### Benefits

The bundled `redis_exporter` supports a number of configuration options that are only reachable via environment variables or command-line flags (e.g. `REDIS_EXPORTER_CHECK_KEYS` / `REDIS_EXPORTER_CHECK_SINGLE_KEYS` for per-key size gauges, `REDIS_EXPORTER_INCL_SYSTEM_METRICS`, …). Currently the metrics container's `env` block is fixed (only `REDIS_PASSWORD` when auth is enabled), so these exporter features cannot be used without replacing the sidecar entirely via `extraObjects`. This is also a common migration need for users coming from the Bitnami redis/valkey charts, which expose the equivalent `metrics.extraEnvVars`.

### Possible drawbacks

None known — the value defaults to `[]` and the change is fully backwards compatible.

### Applicable issues

- none

### Additional information

Includes a new unit test suite (`tests/metrics-extra-env-vars_test.yaml`) covering the default behavior, rendering with auth enabled, and rendering with auth disabled. `helm lint` and `helm unittest` pass (29 tests).

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))