### PR TITLE
[valkey] Add support for extra environment variables in metrics exporter

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.21.4
+version: 0.22.0
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -260,6 +260,7 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 | `metrics.image.tag`                        | Valkey exporter image tag                                                       | `v1.80.1-alpine`           |
 | `metrics.image.pullPolicy`                 | Valkey exporter image pull policy                                               | `Always`                   |
 | `metrics.resources`                        | Resource limits and requests for metrics container                              | `{}`                       |
+| `metrics.extraEnvVars`                     | Additional environment variables to set for the metrics exporter container      | `[]`                       |
 | `metrics.service.annotations`              | Additional custom annotations for Metrics service                               | `{}`                       |
 | `metrics.service.labels`                   | Additional custom labels for Metrics service                                    | `{}`                       |
 | `metrics.service.port`                     | Metrics service port                                                            | `9121`                     |

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -516,6 +516,9 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ include "valkey.passwordKey" . }}
             {{- end }}
+            {{- with .Values.metrics.extraEnvVars }}
+{{ toYaml . | indent 12 }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 9121

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -304,6 +304,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "extraEnvVars": {
+                    "type": "array"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -369,6 +369,14 @@ metrics:
     pullPolicy: Always
   ## @param metrics.resources Resource limits and requests for metrics container
   resources: {}
+  ## @param metrics.extraEnvVars Additional environment variables to set for the metrics exporter container
+  ## Can be used to pass redis_exporter command line flags as environment variables, e.g.:
+  ## extraEnvVars:
+  ##   - name: REDIS_EXPORTER_CHECK_KEYS
+  ##     value: "db0=mykey*"
+  ##   - name: REDIS_EXPORTER_IS_CLUSTER
+  ##     value: "true"
+  extraEnvVars: []
   ## Metrics service configuration
   service:
     ## @param metrics.service.annotations Additional custom annotations for Metrics service


### PR DESCRIPTION


<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change
Adds a new metrics.extraEnvVars value that renders additional environment variables on the metrics exporter sidecar container, using the same rendering style as the existing top-level extraEnvVars.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
The bundled redis_exporter supports a number of configuration options that are only reachable via environment variables or command-line flags (e.g. REDIS_EXPORTER_CHECK_KEYS / REDIS_EXPORTER_CHECK_SINGLE_KEYS for per-key size gauges, REDIS_EXPORTER_INCL_SYSTEM_METRICS, …). Currently the metrics container's env block is fixed (only REDIS_PASSWORD when auth is enabled)
List of supported environment variables can be found here https://github.com/oliver006/redis_exporter#command-line-flags

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
