### PR TITLE
[redis] Fix extraConfig being ignored in standalone architecture

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.30.3
+version: 0.30.4
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/templates/configmap.yaml
+++ b/charts/redis/templates/configmap.yaml
@@ -36,4 +36,8 @@ data:
     {{- if and .Values.auth.acl.enabled (eq .Values.architecture "standalone") }}
     aclfile {{ include "redis.auth.acl.path" . }}
     {{- end }}
+    {{- if and .Values.extraConfig (eq .Values.architecture "standalone") }}
+    # Extra configuration from values.yaml
+    {{- .Values.extraConfig | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -415,6 +415,9 @@
                 "existingClaim": {
                     "type": "string"
                 },
+                "labels": {
+                    "type": "object"
+                },
                 "mountPath": {
                     "type": "string"
                 },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -200,6 +200,8 @@ cluster:
 
 ## @param extraConfig Additional Redis configuration to be appended to the generated config
 ## This provides flexibility to add any Redis configuration directives
+## Note: in standalone architecture this is appended to the chart-managed ConfigMap, so it has
+## no effect when config.existingConfigmap is set (add the directives to your own ConfigMap instead)
 ## Example:
 ## extraConfig: |
 ##   # Custom memory policy


### PR DESCRIPTION
## Description

Fixes #1376

`extraConfig` is only consumed by the config-builder init container, which runs solely in the `replication`/`cluster` architectures. In `standalone` (the default), redis runs directly off the chart-managed ConfigMap, which never rendered `extraConfig` — so the value was silently ignored.

## Changes

- **templates/configmap.yaml**: append `extraConfig` at the end of `redis.conf`, gated to `standalone` to avoid duplicating it in replication/cluster (where the init container already appends it). Appending last keeps user settings overriding chart defaults.
- **values.yaml**: note that `extraConfig` has no effect with `config.existingConfigmap` in standalone, since the chart doesn't own that ConfigMap.
- **Chart.yaml**: bump version to `0.30.4`.

## Verification

```console
$ helm template test charts/redis --set-string 'extraConfig=maxmemory 19gb' -s templates/configmap.yaml
  redis.conf: |
    ...
    port 6379
    # Extra configuration from values.yaml
    maxmemory 19gb
```

Replication/cluster render unchanged (no duplication), multi-line values indent correctly, `helm lint` passes.

## Related
This also unblocks the workaround for #1377 : with extraConfig working in standalone, maxmemory/maxmemory-policy can be set so Redis evicts keys instead of being OOM-killed:
Examplee:
```
resources:
  limits:
    memory: 24Gi
extraConfig: |
  maxmemory 19gb
  maxmemory-policy allkeys-lru
```
