### PR TITLE
[valkey] Always set masterauth for non-standalone architectures

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.22.0
+version: 0.22.1
 appVersion: "9.0.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -183,6 +183,15 @@ spec:
               fi
               {{- end }}
 
+              {{- if and .Values.auth.enabled (ne .Values.architecture "standalone") }}
+              # IMPORTANT: Always add masterauth for non-standalone architectures
+              # Even if this pod starts as master, it may become a replica after failover
+              # Without masterauth, REPLICAOF commands from sentinel will fail with NOAUTH
+              echo "" >> /tmp/valkey/valkey.conf
+              echo "# Authentication for replication (required for failover scenarios)" >> /tmp/valkey/valkey.conf
+              echo "masterauth ${VALKEY_PASSWORD}" >> /tmp/valkey/valkey.conf
+              {{- end }}
+
               # Add user provided settings at the end of file to ensure their precedence
               echo "" >> /tmp/valkey/valkey.conf
               # If there is existing config map or .Values.config value provided - use it


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change
Previously, masterauth was only added when a pod was initially configured as a replica, causing NOAUTH errors when a former master is demoted to replica after Sentinel failover. This same issue was already fixed for the redis chart in #750; this applies the same fix to valkey.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Replication continues to work after a Sentinel failover.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None
<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information
Mirrors the redis chart fix in #750.
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
