### PR TITLE
[rabbitmq] Support HTTPRoute parentRef group and kind

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.21.6
+version: 0.21.7
 appVersion: "4.3.1"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -295,6 +295,16 @@ kubectl edit configmap my-rabbitmq-definitions -n <namespace>
 | `ingress.hosts`       | Ingress hosts configuration            | `[{"host": "rabbitmq.local", "paths": [{"path": "/", "pathType": "Prefix"}]}]` |
 | `ingress.tls`         | Ingress TLS configuration              | `[]`                                                                           |
 
+### Gateway API parameters
+
+| Parameter                         | Description                                                     | Default                                      |
+| --------------------------------- | --------------------------------------------------------------- | -------------------------------------------- |
+| `gatewayAPI.httpRoute.enabled`    | Enable Gateway API HTTPRoute generation for RabbitMQ management | `false`                                      |
+| `gatewayAPI.httpRoute.annotations` | Additional annotations for the HTTPRoute resource               | `{}`                                         |
+| `gatewayAPI.httpRoute.parentRefs` | References to the parent Gateways or ListenerSets               | `[{"name": "gateway", "group": "", "kind": "", "namespace": "", "sectionName": ""}]` |
+| `gatewayAPI.httpRoute.hostnames`  | List of hostnames to match                                      | `["rabbitmq.local"]`                       |
+| `gatewayAPI.httpRoute.rules`      | HTTPRoute rules                                                 | `[{"matches": [{"path": {"type": "PathPrefix", "value": "/"}}]}]` |
+
 ### Resources
 
 | Parameter   | Description                                    | Default |

--- a/charts/rabbitmq/templates/httproute.yaml
+++ b/charts/rabbitmq/templates/httproute.yaml
@@ -25,6 +25,12 @@ spec:
   parentRefs:
     {{- range $httpRoute.parentRefs }}
     - name: {{ .name }}
+      {{- if .group }}
+      group: {{ .group }}
+      {{- end }}
+      {{- if .kind }}
+      kind: {{ .kind }}
+      {{- end }}
       {{- if .namespace }}
       namespace: {{ .namespace }}
       {{- end }}

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -278,13 +278,13 @@
                             "items": {
                                 "type": "object",
                                 "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
                                     "group": {
                                         "type": "string"
                                     },
                                     "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
                                         "type": "string"
                                     },
                                     "namespace": {

--- a/charts/rabbitmq/values.schema.json
+++ b/charts/rabbitmq/values.schema.json
@@ -281,6 +281,12 @@
                                     "name": {
                                         "type": "string"
                                     },
+                                    "group": {
+                                        "type": "string"
+                                    },
+                                    "kind": {
+                                        "type": "string"
+                                    },
                                     "namespace": {
                                         "type": "string"
                                     },

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -368,6 +368,14 @@ ingress:
 ##     - name: my-gateway
 ##       sectionName: https   # matches the HTTPS listener defined in the Gateway resource
 ##
+## To attach to another parent type, such as ListenerSet, set group and kind:
+##
+##   parentRefs:
+##     - group: gateway.networking.k8s.io
+##       kind: ListenerSet
+##       name: my-listenerset
+##       sectionName: https
+##
 ## The backend always receives plain HTTP traffic regardless of the listener protocol.
 gatewayAPI:
   httpRoute:
@@ -375,9 +383,11 @@ gatewayAPI:
     enabled: false
     ## @param gatewayAPI.httpRoute.annotations Additional annotations for the HTTPRoute resource
     annotations: {}
-    ## @param gatewayAPI.httpRoute.parentRefs References to the parent Gateways
+    ## @param gatewayAPI.httpRoute.parentRefs References to the parent Gateways or ListenerSets
     parentRefs:
       - name: gateway
+        group: ""
+        kind: ""
         namespace: ""
         sectionName: ""
     ## @param gatewayAPI.httpRoute.hostnames List of hostnames to match


### PR DESCRIPTION
### Description of the change

Adds support for optional `group` and `kind` fields on RabbitMQ Gateway API HTTPRoute `parentRefs`.

This allows the RabbitMQ chart to attach generated HTTPRoutes to parent resource types other than the default Gateway, such as `ListenerSet`.

### Benefits

Users can configure RabbitMQ HTTPRoutes for Gateway API implementations that require explicit parent reference `group` and `kind` values.

### Possible drawbacks

None known. The new fields are optional and default to empty strings, preserving the existing Gateway behavior.

### Applicable issues

- fixes #

### Additional information

Validated locally with:

- `ct lint --target-branch main --validate-maintainers=false --additional-commands 'helm unittest {{ .Path }}'`

RabbitMQ chart unit tests passed:

- 3 test suites passed
- 33 tests passed

Also verified rendering with `gatewayAPI.httpRoute.parentRefs[0].group=gateway.networking.k8s.io` and `gatewayAPI.httpRoute.parentRefs[0].kind=ListenerSet`.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))