### PR TITLE
[zookeeper] Make secureClientPort optional

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -150,7 +150,7 @@ zkCli.sh -server my-zookeeper:2181
 | ------------------------------ | -------------------------------------------- | ----------- |
 | `service.type`                 | Kubernetes service type                      | `ClusterIP` |
 | `service.ports.client`         | ZooKeeper client service port                | `2181`      |
-| `service.ports.secureClient`   | ZooKeeper secure client service port         | `2281`      |
+| `service.ports.secureClient`   | TLS client port. Set to null to disable (default). When set, also configure SSL via zookeeperConfig.extraConfigs and mount keystore files with extraVolumes/extraVolumeMounts. Setting the port without SSL config will cause startup failure.     | `null`      |
 | `service.ports.quorum`         | ZooKeeper quorum service port                | `2888`      |
 | `service.ports.leaderElection` | ZooKeeper leader election service port       | `3888`      |
 | `service.ports.admin`          | ZooKeeper admin service port                 | `8080`      |

--- a/charts/zookeeper/templates/configmap.yaml
+++ b/charts/zookeeper/templates/configmap.yaml
@@ -16,7 +16,9 @@ data:
     initLimit={{ .Values.zookeeperConfig.initLimit | default 10 }}
     syncLimit={{ .Values.zookeeperConfig.syncLimit | default 5 }}
     clientPort={{ .Values.service.ports.client | default 2181 }}
-    secureClientPort={{ .Values.service.ports.secureClient | default 2281 }}
+    {{- if .Values.service.ports.secureClient }}
+    secureClientPort={{ .Values.service.ports.secureClient }}
+    {{- end }}
     electionPortBindRetry={{ .Values.zookeeperConfig.electionPortBindRetry | default 10 }}
     maxClientCnxns={{ .Values.zookeeperConfig.maxClientCnxns | default 60 }}
     #standaloneEnabled={{ .Values.zookeeperConfig.standaloneEnabled | default "false" }}

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -29,7 +29,9 @@ spec:
     # Allow inbound connections to ZooKeeper
     - ports:
         - port: {{ .Values.service.ports.client | default 2181 }}
-        - port: {{ .Values.service.ports.secureClient | default 2281 }}
+        {{- if .Values.service.ports.secureClient }}
+        - port: {{ .Values.service.ports.secureClient }}
+        {{- end }}
     # Allow internal communications between nodes
     - ports:
         - port: {{ .Values.service.ports.quorum | default 2888 }}

--- a/charts/zookeeper/templates/service.yaml
+++ b/charts/zookeeper/templates/service.yaml
@@ -17,10 +17,12 @@ spec:
       targetPort: client
       protocol: TCP
       name: client
-    - port: {{ .Values.service.ports.secureClient | default 2281 }}
+    {{- if .Values.service.ports.secureClient }}
+    - port: {{ .Values.service.ports.secureClient }}
       targetPort: secure-client
       protocol: TCP
       name: secure-client
+    {{- end }}
     - port: {{ .Values.service.ports.admin | default 8080 }}
       targetPort: admin
       protocol: TCP
@@ -44,10 +46,12 @@ spec:
       targetPort: client
       protocol: TCP
       name: client
-    - port: {{ .Values.service.ports.secureClient | default 2281 }}
+    {{- if .Values.service.ports.secureClient }}
+    - port: {{ .Values.service.ports.secureClient }}
       targetPort: secure-client
       protocol: TCP
       name: secure-client
+    {{- end }}
     - port: {{ .Values.service.ports.quorum | default 2888 }}
       targetPort: quorum
       protocol: TCP

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -43,9 +43,11 @@ spec:
             - name: client
               containerPort: {{ .Values.service.ports.client | default 2181 }}
               protocol: TCP
+            {{- if .Values.service.ports.secureClient }}
             - name: secure-client
-              containerPort: {{ .Values.service.ports.secureClient | default 2281 }}
+              containerPort: {{ .Values.service.ports.secureClient }}
               protocol: TCP
+            {{- end }}
             - name: quorum
               containerPort: {{ .Values.service.ports.quorum | default 2888 }}
               protocol: TCP

--- a/charts/zookeeper/tests/unittest-defaults_test.yaml
+++ b/charts/zookeeper/tests/unittest-defaults_test.yaml
@@ -45,6 +45,69 @@ tests:
           path: data["zoo.cfg"]
           pattern: "tickTime=2000"
 
+  - it: should not set secureClientPort in configmap by default
+    template: configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["zoo.cfg"]
+          pattern: "secureClientPort="
+
+  - it: should set secureClientPort when secureClient is configured
+    template: configmap.yaml
+    set:
+      service:
+        ports:
+          secureClient: 2281
+    asserts:
+      - matchRegex:
+          path: data["zoo.cfg"]
+          pattern: "secureClientPort=2281"
+
+  - it: should not expose secure-client port on service by default
+    template: service.yaml
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: secure-client
+  - it: should not expose secure-client port on statefulset by default
+    template: statefulset.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: secure-client
+
+  - it: should expose secure-client port when configured
+    template: service.yaml
+    documentIndex: 0
+    set:
+      service:
+        ports:
+          secureClient: 2281
+    asserts:
+      - equal:
+          path: spec.ports[1].name
+          value: secure-client
+      - equal:
+          path: spec.ports[1].port
+          value: 2281
+
+  - it: should expose secure-client container port when configured
+    template: statefulset.yaml
+    set:
+      service:
+        ports:
+          secureClient: 2281
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: secure-client
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 2281
+
   - it: should append extraConfigs to zoo.cfg
     template: configmap.yaml
     set:

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -367,7 +367,7 @@
                             "type": "integer"
                         },
                         "secureClient": {
-                            "type": "integer"
+                            "type": ["integer", "null"]
                         }
                     }
                 },

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -188,8 +188,8 @@ service:
   ports:
     ## @param service.ports.client Zookeeper client service port
     client: 2181
-    ## @param service.ports.secureClient Zookeeper secure client service port
-    secureClient: 2281
+    ## @param service.ports.secureClient TLS client port (e.g. 2281). Set to null to disable.
+    secureClient: null
     ## @param service.ports.quorum Zookeeper quorum service port
     quorum: 2888
     ## @param service.ports.leaderElection Zookeeper leader election service port


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

The chart currently always writes `secureClientPort=2281` to `zoo.cfg` and exposes port 2281 on the StatefulSet, Services, and NetworkPolicy, even when TLS is not configured. Once `secureClientPort` is set, ZooKeeper expects SSL keystore configuration and the pod fails to start without it. More info in this issue: https://github.com/CloudPirates-io/helm-charts/issues/1369

This change makes the TLS client port opt-in:
- Default `service.ports.secureClient` to `null` (disabled)
- Only emit `secureClientPort` in `zoo.cfg` when `service.ports.secureClient` is set
- Conditionally expose the `secure-client` port in the StatefulSet, Services, and NetworkPolicy to match

### Benefits
- Plain TCP deployments (port 2181 only) work out of the box without TLS configuration
- Follows the same optional pattern already used for the admin server block in `configmap.yaml`
- Users who need TLS can explicitly set `service.ports.secureClient: 2281` and configure SSL via `zookeeperConfig.extraConfigs` + volume mounts

### Possible drawbacks
**Breaking change:** Upgrades with default values will no longer set `secureClientPort` in `zoo.cfg` or expose port 2281 in Kubernetes. Deployments that relied on the implicit default (without setting `service.ports.secureClient` in values) but had TLS configured via `extraConfigs` will need to explicitly set:
```yaml
service:
  ports:
    secureClient: 2281
```

Setting the port without SSL configuration in zoo.cfg will still cause startup failure, this is expected ZooKeeper behavior, not introduced by this change.

### Applicable issues

- fixes #1369 

### Additional information

Tested locally:

helm dependency update charts/zookeeper
helm unittest charts/zookeeper   # 33/33 passed

```
### Chart [ zookeeper ] charts/zookeeper

 PASS  test zookeeper common parameters charts/zookeeper/tests/common-parameters_test.yaml
 PASS  test openshift related settings  charts/zookeeper/tests/openshift_test.yaml
 PASS  test zookeeper specific parameters       charts/zookeeper/tests/unittest-defaults_test.yaml

Charts:      1 passed, 1 total
Test Suites: 3 passed, 3 total
Tests:       33 passed, 33 total
Snapshot:    0 passed, 0 total
Time:        180.711416ms
```

**Chart version (`0.11.0`):** Bumped as a **minor** release (from `0.10.3`) rather than a patch because the default behavior changes: `secureClientPort` and the `secure-client` K8s port are no longer enabled by default. Per [semver](http://semver.org/), that is not fully backwards compatible for users who relied on the implicit `2281` default without setting `service.ports.secureClient` in values. A patch bump would imply no behavior change for existing installs with default values.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))

