### PR TITLE
[zookeeper] Add per-pod external LoadBalancer services

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.10.3
+version: 0.11.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -156,6 +156,35 @@ zkCli.sh -server my-zookeeper:2181
 | `service.ports.admin`          | ZooKeeper admin service port                 | `8080`      |
 | `service.annotations`          | Additional annotations to add to the service | `{}`        |
 
+### External Access
+
+| Parameter                                           | Description                                                                                       | Default          |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------- |
+| `externalAccess.enabled`                            | Enable per-pod external LoadBalancer services for client access from outside the cluster          | `false`          |
+| `externalAccess.service.type`                       | Kubernetes service type for external access services                                              | `LoadBalancer`   |
+| `externalAccess.service.port`                       | External client port exposed on each LoadBalancer                                                 | `2181`           |
+| `externalAccess.service.annotations`                | Annotations applied to each external service (e.g. AWS NLB settings)                              | `{}`             |
+| `externalAccess.service.loadBalancerIPs`            | Static LoadBalancer IP per replica; list length must match `replicaCount`                         | `[]`             |
+| `externalAccess.service.loadBalancerSourceRanges`   | Source CIDR ranges allowed to reach the external LoadBalancers                                    | `[]`             |
+| `externalAccess.service.externalTrafficPolicy`      | External traffic policy for LoadBalancer/NodePort services (`Local` recommended for per-pod LBs)    | `Local`          |
+| `externalAccess.service.labels`                     | Extra labels applied to each external service                                                     | `{}`             |
+
+When enabled, the chart creates one external service per ZooKeeper pod (e.g. `release-zookeeper-0-external`). Clients outside the cluster should use the LoadBalancer hostnames and client port in their connection string. Quorum traffic remains on the internal headless service; `zoo.cfg` server entries are not changed.
+
+**Example for AWS NLBs:**
+
+```yaml
+externalAccess:
+  enabled: true
+  service:
+    annotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "external"
+      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+      service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: "preserve_client_ip.enabled=true"
+```
+Use aws-load-balancer-scheme internal if clients are in the VPC, internet-facing if they're on the public internet.
+
 ### Persistence
 
 | Parameter                   | Description                         | Default                   |

--- a/charts/zookeeper/templates/svc-external-access.yaml
+++ b/charts/zookeeper/templates/svc-external-access.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.externalAccess.enabled }}
+{{- $fullname := include "zookeeper.fullname" . }}
+{{- $replicaCount := int .Values.replicaCount }}
+{{- range $i := until $replicaCount }}
+{{- $targetPod := printf "%s-%d" $fullname $i }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-%d-external" $fullname $i | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "cloudpirates.namespace" $ }}
+  labels:
+    {{- include "zookeeper.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: external-access
+    pod: {{ $targetPod }}
+    {{- with $.Values.externalAccess.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $annotations := merge $.Values.externalAccess.service.annotations $.Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $.Values.externalAccess.service.type }}
+  {{- if and (eq $.Values.externalAccess.service.type "LoadBalancer") (not (empty $.Values.externalAccess.service.loadBalancerIPs)) (eq (len $.Values.externalAccess.service.loadBalancerIPs) $replicaCount) }}
+  loadBalancerIP: {{ index $.Values.externalAccess.service.loadBalancerIPs $i }}
+  {{- end }}
+  {{- if $.Values.externalAccess.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml $.Values.externalAccess.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if and (or (eq $.Values.externalAccess.service.type "LoadBalancer") (eq $.Values.externalAccess.service.type "NodePort")) $.Values.externalAccess.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $.Values.externalAccess.service.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - name: client
+      port: {{ $.Values.externalAccess.service.port | default $.Values.service.ports.client | default 2181 }}
+      targetPort: client
+      protocol: TCP
+  selector:
+    {{- include "zookeeper.selectorLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ $targetPod }}
+---
+{{- end }}
+{{- end }}

--- a/charts/zookeeper/tests/external-access_test.yaml
+++ b/charts/zookeeper/tests/external-access_test.yaml
@@ -1,0 +1,47 @@
+suite: test zookeeper external access
+
+tests:
+  - it: should not create external access services by default
+    template: svc-external-access.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create one external service per replica
+    template: svc-external-access.yaml
+    set:
+      replicaCount: 3
+      externalAccess:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: should target a single pod per external service
+    template: svc-external-access.yaml
+    documentIndex: 0
+    set:
+      externalAccess:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.selector["statefulset.kubernetes.io/pod-name"]
+          value: RELEASE-NAME-zookeeper-0
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].targetPort
+          value: client
+
+  - it: should apply external traffic policy for LoadBalancer
+    template: svc-external-access.yaml
+    set:
+      externalAccess:
+        enabled: true
+        service:
+          externalTrafficPolicy: Local
+    asserts:
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -60,22 +60,38 @@
             }
         },
         "externalAccess": {
-        "type": "object",
-        "properties": {
-            "enabled": { "type": "boolean" },
-            "service": {
             "type": "object",
             "properties": {
-                "annotations": { "type": "object" },
-                "externalTrafficPolicy": { "type": "string" },
-                "labels": { "type": "object" },
-                "loadBalancerIPs": { "type": "array" },
-                "loadBalancerSourceRanges": { "type": "array" },
-                "port": { "type": "integer" },
-                "type": { "type": "string" }
+                "enabled": {
+                    "type": "boolean"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "loadBalancerIPs": {
+                            "type": "array"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
-            }
-        }
         },
         "extraEnvVars": {
             "type": "array"

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -59,6 +59,24 @@
                 }
             }
         },
+        "externalAccess": {
+        "type": "object",
+        "properties": {
+            "enabled": { "type": "boolean" },
+            "service": {
+            "type": "object",
+            "properties": {
+                "annotations": { "type": "object" },
+                "externalTrafficPolicy": { "type": "string" },
+                "labels": { "type": "object" },
+                "loadBalancerIPs": { "type": "array" },
+                "loadBalancerSourceRanges": { "type": "array" },
+                "port": { "type": "integer" },
+                "type": { "type": "string" }
+            }
+            }
+        }
+        },
         "extraEnvVars": {
             "type": "array"
         },

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -292,6 +292,28 @@ startupProbe:
   ## @param startupProbe.successThreshold Success threshold for startupProbe
   successThreshold: 1
 
+externalAccess:
+  ## @param externalAccess.enabled Enable per-pod external LoadBalancer services
+  enabled: false
+  service:
+    ## @param externalAccess.service.type Service type (LoadBalancer for NLB/ELB)
+    type: LoadBalancer
+    ## @param externalAccess.service.port External client port
+    port: 2181
+    ## @param externalAccess.service.annotations Annotations per service (e.g. AWS NLB)
+    annotations: {}
+    #  service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    #  service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    #  service.beta.kubernetes.io/aws-load-balancer-scheme: "internal" # or "internet-facing"
+    #  service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: "preserve_client_ip.enabled=true"
+    ## @param externalAccess.service.loadBalancerIPs Static LB IPs/hostnames per replica (length must match replicaCount)
+    loadBalancerIPs: []
+    ## @param externalAccess.service.loadBalancerSourceRanges Restrict source CIDRs
+    loadBalancerSourceRanges: []
+    ## @param externalAccess.service.externalTrafficPolicy External traffic policy (Local recommended for per-pod LBs)
+    externalTrafficPolicy: Local
+    ## @param externalAccess.service.labels Extra labels for external services
+    labels: {}
 
 ## @param command Override default container command (useful when the default entrypoint needs to be replaced)
 command: []


### PR DESCRIPTION
### Description of the change

Adds optional per-replica external access for ZooKeeper client traffic (`:2181`) via a new `externalAccess` values block.

When `externalAccess.enabled` is `true`, the chart creates one `LoadBalancer` Service per pod (e.g. `release-zookeeper-0-external`, `release-zookeeper-1-external`, …). 
Each Service selects a single StatefulSet pod using `statefulset.kubernetes.io/pod-name`, which is the correct pattern for exposing a ZooKeeper ensemble to clients outside Kubernetes (e.g. Spark), one endpoint per broker.

- New template: `templates/svc-external-access.yaml`
- Main `zookeeper` Service remains `ClusterIP`, quorum traffic stays on the headless service
- `zoo.cfg` `server.N` entries are unchanged
- Supports provider annotations, `loadBalancerIPs`, `loadBalancerSourceRanges`, and `externalTrafficPolicy` (default `Local`)
- Documented in `values.yaml`, `README.md`, and `values.schema.json`
- Unit tests in `tests/external-access_test.yaml`

**Example (AWS internal NLB):**

```yaml
externalAccess:
  enabled: true
  service:
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: "external"
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
      service.beta.kubernetes.io/aws-load-balancer-target-group-attributes: "preserve_client_ip.enabled=true"
```

Clients should use all external LoadBalancer hostnames in their connection string, e.g. host0:2181,host1:2181,host2:2181.

### Benefits

- Enables external client access without changing the main Service to LoadBalancer (which would incorrectly front all pods with a single LB)
- Works with cloud load balancers (AWS NLB/ELB, etc.) via standard Service annotations
- Disabled by default, no behavior change for existing deployments
- Per-pod targeting preserves correct ZooKeeper ensemble client semantics

### Possible drawbacks

- Annotations are shared across all per-replica Services, per-replica NLB names (e.g. aws-load-balancer-name) require unique values per Service and are not supported, use cloud-assigned DNS or External-DNS for stable names
- DNS is out of chart scope, predictable hostnames are typically handled by External-DNS, Route53, or client-side config, the chart only creates the Kubernetes Services
- loadBalancerIPs must have length equal to replicaCount when set
- Creates N LoadBalancers for an N-node ensemble, expected cost/ops overhead

### Additional information

- Tested manually on EKS: 3 internal NLBs provisioned (zookeeper-2-{0,1,2}-external), client port 2181 reachable from VPC clients.

- unittests results:
```
### Chart [ zookeeper ] charts/zookeeper

 PASS  test zookeeper common parameters charts/zookeeper/tests/common-parameters_test.yaml
 PASS  test zookeeper external access   charts/zookeeper/tests/external-access_test.yaml
 PASS  test openshift related settings  charts/zookeeper/tests/openshift_test.yaml
 PASS  test zookeeper specific parameters       charts/zookeeper/tests/unittest-defaults_test.yaml

Charts:      1 passed, 1 total
Test Suites: 4 passed, 4 total
Tests:       31 passed, 31 total
Snapshot:    0 passed, 0 total
Time:        187.197125ms
```

- Version note: Chart bumped to 0.11.0. If #1390 merges first with the same version, this PR should be rebased and bumped to 0.12.0.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))