### PR TITLE
[redis] Metrics-Sidecar now also supports Redis-TLS and Client-Certs

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.30.4
+version: 0.30.5
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -138,6 +138,7 @@ cosign verify --key cosign.pub registry-1.docker.io/cloudpirates/redis:<version>
 | -------------------------------- | ------------------------------------------------------------ | ------- |
 | `auth.enabled`                   | Enable Redis authentication                                  | `true`  |
 | `auth.sentinel`                  | Enable authentication for Redis sentinels                    | `true`  |
+| `auth.metrics`                   | Enable authentication for Redis metrics sidecar              | `true`  |
 | `auth.password`                  | Redis password (if empty, random password will be generated) | `""`    |
 | `auth.existingSecret`            | Name of existing secret containing Redis password            | `""`    |
 | `auth.existingSecretPasswordKey` | Key in existing secret containing Redis password             | `""`    |
@@ -231,6 +232,9 @@ user sentinel >sentinelpassword ~* +client +info +ping +publish +subscribe +psub
 | `metrics.image.pullPolicy`                 | Redis exporter image pull policy                                                        | `Always`                   |
 | `metrics.resources`                        | Resource limits and requests for metrics container                                      | `{}`                       |
 | `metrics.extraArgs`                        | Extra arguments for Redis exporter (e.g. `--redis.addr`, `--web.listen-address`)        | `[]`                       |
+| `metrics.tls`                              | Enable TLS for Redis metrics exporter endpoints                                         | `false`                    |
+| `metrics.port`                             | Port that the metrics server and endpoint is running on                                 | `9121`                     |
+| `metrics.service.enabled`                  | Enable the dedicated metrics service                                                    | `true`                     |
 | `metrics.service.type`                     | Metrics service type                                                                    | `ClusterIP`                |
 | `metrics.service.port`                     | Metrics service port                                                                    | `9121`                     |
 | `metrics.service.annotations`              | Additional custom annotations for Metrics service                                       | `{}`                       |

--- a/charts/redis/templates/metrics-service.yaml
+++ b/charts/redis/templates/metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1157,12 +1157,39 @@ spec:
           resources: {{- toYaml .Values.sentinel.resources | nindent 12 }}
         {{- end }}
         {{- if .Values.metrics.enabled }}
+        {{- $hasTLS := .Values.tls.enabled }}
         - name: metrics
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "redis.metrics.image" . | quote }}
           imagePullPolicy: {{ include "cloudpirates.imagePullPolicy" (dict "image" .Values.metrics.image) }}
-          {{- if and .Values.auth.enabled (not .Values.auth.acl.enabled) }}
           env:
+            - name: REDIS_EXPORTER_WEB_LISTEN_ADDRESS
+              value: "0.0.0.0:{{ .Values.metrics.port }}"
+            - name: REDIS_ADDR
+            {{- if $hasTLS }}
+              value: "rediss://localhost:{{ .Values.tls.port }}"
+            {{- else }}
+              value: "redis://localhost:{{ .Values.service.port }}"
+            {{- end }}
+            {{- if $hasTLS }}
+            - name: REDIS_EXPORTER_TLS_CA_CERT_FILE
+              value: /etc/redis/tls/{{ .Values.tls.certCAFilename }}
+            {{- if .Values.metrics.tls }}
+            - name: REDIS_EXPORTER_TLS_SERVER_CERT_FILE
+              value: /etc/redis/tls/{{ .Values.tls.certFilename }}
+            - name: REDIS_EXPORTER_TLS_SERVER_KEY_FILE
+              value: /etc/redis/tls/{{ .Values.tls.certKeyFilename }}
+            - name: REDIS_EXPORTER_TLS_SERVER_CA_CERT_FILE
+              value: /etc/redis/tls/{{ .Values.tls.certCAFilename }}
+            {{- end }}
+            {{- if .Values.tls.client.existingSecret }}
+            - name: REDIS_EXPORTER_TLS_CLIENT_CERT_FILE
+              value: /etc/redis/tls-client/{{ .Values.tls.client.certFilename }}
+            - name: REDIS_EXPORTER_TLS_CLIENT_KEY_FILE
+              value: /etc/redis/tls-client/{{ .Values.tls.client.certKeyFilename }}
+            {{- end }}
+            {{- end }}
+            {{- if and (or .Values.auth.enabled .Values.auth.metrics) (not .Values.auth.acl.enabled) }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -1186,7 +1213,7 @@ spec:
           {{- end }}
           ports:
             - name: metrics
-              containerPort: 9121
+              containerPort: {{ .Values.metrics.port }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -1207,12 +1234,25 @@ spec:
             failureThreshold: 3
             successThreshold: 1
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
-          {{- if and .Values.auth.acl.enabled .Values.auth.acl.existingSecret }}
+          {{- $hasACLs := and .Values.auth.acl.enabled .Values.auth.acl.existingSecret }}
+          {{- if or $hasTLS $hasACLs }}
           volumeMounts:
+            {{- if $hasTLS }}
+            - name: tls-certs
+              mountPath: /etc/redis/tls
+              readOnly: true
+            {{- if .Values.tls.client.existingSecret }}
+            - name: tls-client-certs
+              mountPath: /etc/redis/tls-client
+              readOnly: true
+            {{- end }}
+            {{- end }}
+          {{- if $hasACLs }}
             - name: acl-file
               mountPath: {{ include "redis.auth.acl.path" . }}
               subPath: {{ include "redis.auth.acl.file" . }}
               readOnly: true
+          {{- end }}
           {{- end }}
         {{- end }}
       volumes:

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -297,6 +297,9 @@
                         "clusterIP": {
                             "type": "string"
                         },
+                        "enabled": {
+                            "type": "boolean"
+                        },
                         "ipFamilies": {
                             "type": "array"
                         },

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -37,6 +37,9 @@
                 "existingSecretPasswordKey": {
                     "type": "string"
                 },
+                "metrics": {
+                    "type": "boolean"
+                },
                 "password": {
                     "type": "string"
                 },
@@ -285,6 +288,9 @@
                         }
                     }
                 },
+                "port": {
+                    "type": "integer"
+                },
                 "resources": {
                     "type": "object"
                 },
@@ -357,6 +363,9 @@
                             "type": "object"
                         }
                     }
+                },
+                "tls": {
+                    "type": "boolean"
                 }
             }
         },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -108,8 +108,10 @@ service:
 auth:
   ## @param auth.enabled Enable Redis authentication
   enabled: true
-  ## @param auth.enabled Enable Sentinel authentication
+  ## @param auth.sentinel Enable Sentinel authentication
   sentinel: true
+  ## @param auth.metrics Enable Metrics authentication
+  metrics: true
   ## @param auth.password Redis password (if empty, random password will be generated)
   password: ""
   ## @param auth.existingSecret Name of existing secret containing Redis password
@@ -556,6 +558,8 @@ initContainer:
 metrics:
   ## @param metrics.enabled Start a sidecar prometheus exporter to expose Redis metrics
   enabled: false
+  ## @param metrics.tls.enabled Enable TLS for the metrics exporter endpoint
+  tls: false
   ## @param metrics.image.registry Redis exporter image registry
   ## @param metrics.image.repository Redis exporter image repository
   ## @param metrics.image.tag Redis exporter image tag
@@ -565,6 +569,8 @@ metrics:
     repository: oliver006/redis_exporter
     tag: "v1.82.0-alpine@sha256:da9e89ee4e755bfa1b6a6b2ed345c2de63ca3976f95c9f1e9538882bc1414cb8"
     pullPolicy: Always
+  ## @param metrics.port Metrics exporter port
+  port: 9121
   ## @param metrics.resources Resource limits and requests for metrics container
   resources: {}
     # limits:
@@ -575,8 +581,7 @@ metrics:
     #   memory: 64Mi
   ## @param metrics.extraArgs Extra arguments for redis exporter, for example:
   ## extraArgs:
-  ##   - --redis.addr=redis://localhost:6379
-  ##   - --web.listen-address=0.0.0.0:9121
+  ##   can be found on https://github.com/oliver006/redis_exporter
   extraArgs: []
   ## Metrics service configuration
   service:

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -580,6 +580,7 @@ metrics:
   extraArgs: []
   ## Metrics service configuration
   service:
+    enabled: true
     ## @param metrics.service.type Metrics service type
     type: ClusterIP
     ## @param metrics.service.port Metrics service port


### PR DESCRIPTION
### Description of the change

The optional metrics sidecar container can now also be used if Redis is setup to use TLS only.
It also now automatically includes the client-certs if they are enabled.
The Metrics-Endpoint can also optionally be secured via TLS.

### Benefits
Metrics can be used if the Redis-Server uses TLS


### Checklist
- [ x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [ x ] Variables are documented in the values.yaml and added to the `README.md`
- [ x ] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [ x ] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
