### PR TITLE
[redis]: ensure servicemonitor has no diff compared to actual object

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.30.5
+version: 0.30.6
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -33,7 +33,8 @@ spec:
       honorLabels: {{ . }}
       {{- end }}
       relabelings:
-        - targetLabel: scrape_target
+        - action: replace
+          targetLabel: scrape_target
           replacement: redis
       {{- with .Values.metrics.serviceMonitor.relabelings }}
         {{- toYaml . | nindent 8 }}
@@ -55,7 +56,8 @@ spec:
       honorLabels: {{ . }}
       {{- end }}
       relabelings:
-        - targetLabel: scrape_target
+        - action: replace
+          targetLabel: scrape_target
           replacement: sentinel
       {{- with .Values.metrics.serviceMonitor.relabelings }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

It adds the `action` parameter to the servicemonitor.

### Benefits

Without it argocd will always see a diff compared to the actual object.

<img width="1312" height="706" alt="image" src="https://github.com/user-attachments/assets/60a42aa5-4076-4b70-abd5-1cb19a0d9101" />


### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
