### PR TITLE
[postgres] Use shared helper for metrics container securityContext

### DIFF
--- a/charts/postgres/CHANGELOG.md
+++ b/charts/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this chart will be documented in this file.
 
+## [0.19.6] - 2026-06-25
+
+- [postgres] Use shared helper for metrics container securityContext on OpenShift (#1399)
+
 ## [0.18.3] - 2026-03-18
 
 - Update image.repository to a9abf42 (#1164) ([3d4a6b9b](https://github.com/CloudPirates-io/helm-charts/commit/3d4a6b9b))

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.19.5
+version: 0.19.6
 appVersion: "18.4.0"
 keywords:
   - postgres
@@ -42,10 +42,10 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
-    - kind: added
-      description: "Add namespaceOverride Value to all Charts that missing it"
+    - kind: fixed
+      description: "Use shared security context helper for metrics sidecar on OpenShift"
       links:
-        - name: "Pull Request"
-          url: "https://github.com/CloudPirates-io/helm-charts/pull/1214"
+        - name: "Issue"
+          url: "https://github.com/CloudPirates-io/helm-charts/issues/1399"
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres/CHANGELOG.md"

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -234,16 +234,7 @@ spec:
         - name: metrics
           image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            privileged: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           env:
             - name: POSTGRES_PASSWORD
               valueFrom:

--- a/charts/postgres/tests/openshift_test.yaml
+++ b/charts/postgres/tests/openshift_test.yaml
@@ -86,4 +86,17 @@ tests:
           path: spec.template.spec.containers[0].securityContext.runAsGroup
       - isNull:
           path: spec.template.spec.containers[0].securityContext.seLinuxOptions
+
+  - it: should configure OpenShift restricted metrics container security context
+    set:
+      targetPlatform: openshift
+      metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: metrics
+      - isNull:
+          path: spec.template.spec.containers[1].securityContext.runAsUser
+      - isNull:
+          path: spec.template.spec.containers[1].securityContext.runAsGroup
           


### PR DESCRIPTION
### Description of the change

The `metrics` (postgres-exporter) container in the postgres StatefulSet defined its `securityContext` as a hardcoded inline block with `runAsUser: 65534` / `runAsGroup: 65534`, while the postgres container renders through the shared `cloudpirates.renderContainerSecurityContext` helper. This change switches the metrics container to use the same helper.

This is the same convention already followed by the `redis` chart and was applied to `valkey` in #1355.

### Benefits

- Consistency: a single source of truth for container security context across all containers in the chart.
- The metrics container now honors `targetPlatform: openshift` and omits fixed UIDs so OpenShift restricted SCC can assign namespace UIDs.
- Fixes pod creation failures when `metrics.enabled: true` on OpenShift clusters.

### Possible drawbacks

The metrics container previously hardcoded `runAsUser: 65534` / `runAsGroup: 65534` (nobody). It now inherits the chart's standard container security context (`runAsUser: 999` / `runAsGroup: 999` by default on vanilla Kubernetes). The postgres-exporter image runs fine as non-root, but anyone relying on the metrics container running specifically as `65534` should set `.Values.containerSecurityContext` accordingly.

### Applicable issues

Fixes #1399

### Additional information

Verified with:

```bash
helm template test . --set metrics.enabled=true --set targetPlatform=openshift
```

The metrics container renders without `runAsUser` / `runAsGroup` on OpenShift.

Added a unit test in `tests/openshift_test.yaml` for metrics + `targetPlatform: openshift`.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title


Made with [Cursor](https://cursor.com)