### PR TITLE
[valkey] Update Valkey image to 9.1.0-alpine3.23

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.22.1
-appVersion: "9.0.0"
+version: 0.23.0
+appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:
   - https://github.com/CloudPirates-io/helm-charts/tree/main/charts/valkey

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -80,7 +80,7 @@ The following table lists the configurable parameters of the Valkey chart and th
 | ------------------ | ------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `image.registry`   | Valkey image registry                             | `docker.io`                                                                                  |
 | `image.repository` | Valkey image repository                           | `valkey/valkey`                                                                              |
-| `image.tag`        | Valkey image tag (immutable tags are recommended) | `"9.0.0-alpine3.22@sha256:b4ee67d73e00393e712accc72cfd7003b87d0fcd63f0eba798b23251bfc9c394"` |
+| `image.tag`        | Valkey image tag (immutable tags are recommended) | `"9.1.0-alpine3.23@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd"` |
 | `image.pullPolicy` | Valkey image pull policy                          | `IfNotPresent`                                                                               |
 
 ### Common configuration
@@ -284,7 +284,7 @@ Sentinel provides high availability for Valkey replication. When enabled, Sentin
 | `sentinel.enabled`                   | Enable Valkey Sentinel for high availability                                        | `false`                                                                                      |
 | `sentinel.image.registry`            | Valkey Sentinel image registry                                                      | `docker.io`                                                                                  |
 | `sentinel.image.repository`          | Valkey Sentinel image repository                                                    | `valkey/valkey`                                                                              |
-| `sentinel.image.tag`                 | Valkey Sentinel image tag                                                           | `"9.0.0-alpine3.22@sha256:b4ee67d73e00393e712accc72cfd7003b87d0fcd63f0eba798b23251bfc9c394"` |
+| `sentinel.image.tag`                 | Valkey Sentinel image tag                                                           | `"9.1.0-alpine3.23@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd"` |
 | `sentinel.image.pullPolicy`          | Valkey Sentinel image pull policy                                                   | `Always`                                                                                     |
 | `sentinel.config.announceHostnames`  | Use the hostnames instead of the IP in "announce-ip" commands                       | `true`                                                                                       |
 | `sentinel.masterName`                | Name of the master server                                                           | `mymaster`                                                                                   |
@@ -488,7 +488,7 @@ When Sentinel is enabled, your application should use a Sentinel-aware client to
 
 ```bash
 # Get the current master from Sentinel
-kubectl run -it --rm valkey-client --image=valkey/valkey:9.0.0-alpine3.22 --restart=Never -- sh
+kubectl run -it --rm valkey-client --image=valkey/valkey:9.1.0-alpine3.23 --restart=Never -- sh
 valkey-cli -h my-valkey-sentinel -p 26379 SENTINEL get-master-addr-by-name mymaster
 ```
 

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -27,7 +27,7 @@ image:
   ## @param image.repository Valkey image repository
   repository: valkey/valkey
   ## @param image.tag Valkey image tag (immutable tags are recommended)
-  tag: "9.0.0-alpine3.22@sha256:bef37d06d4856710973ee31dd1eac1482e4c8e6e7b847f999ad25433e646587b"
+  tag: "9.1.0-alpine3.23@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd"
   ## @param image.imagePullPolicy Valkey image pull policy
   imagePullPolicy: Always
 
@@ -423,7 +423,7 @@ sentinel:
     ## @param sentinel.image.repository Valkey Sentinel image repository
     repository: valkey/valkey
     ## @param sentinel.image.tag Valkey Sentinel image tag
-    tag: "9.0.0-alpine3.22@sha256:bef37d06d4856710973ee31dd1eac1482e4c8e6e7b847f999ad25433e646587b"
+    tag: "9.1.0-alpine3.23@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd"
     ## @param sentinel.image.pullPolicy Valkey Sentinel image pull policy
     pullPolicy: Always
   ## @param sentinel.config.announceHostnames Use the hostnames instead of the IP in "announce-ip" commands


### PR DESCRIPTION
### Description of the change

Bumps Valkey from 9.0.0 to the latest 9.1.0 release. Updated both the main image
and the sentinel image (they share the same tag), and pinned to the new digest.
Also bumped appVersion to 9.1.0 and the chart version to 0.23.0, plus refreshed
the tags in the README.

### Benefits

Keeps the chart on the latest stable Valkey release, which should pull in the
upstream fixes and improvements from 9.1.0.

### Possible drawbacks

Shouldn't be any that I'm aware of, it's just a version bump, with no changes to
the chart templates or values. Worth a quick test to confirm nothing regresses.

### Applicable issues

N/A

### Additional information

New digest: `sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd`

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
