### PR TITLE
[redis] Allow IntOrString for pdb minAvailable/maxUnavailable

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.30.6
+version: 0.30.7
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/tests/pdb_test.yaml
+++ b/charts/redis/tests/pdb_test.yaml
@@ -1,0 +1,55 @@
+suite: test redis pod disruption budget
+templates:
+  - pdb.yaml
+tests:
+  - it: should not render PDB when disabled
+    set:
+      pdb:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render integer minAvailable
+    set:
+      pdb:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should render percentage string minAvailable
+    set:
+      pdb:
+        enabled: true
+        minAvailable: "51%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "51%"
+
+  - it: should render percentage string maxUnavailable
+    set:
+      pdb:
+        enabled: true
+        minAvailable: null
+        maxUnavailable: "51%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "51%"
+
+  - it: should render integer maxUnavailable
+    set:
+      pdb:
+        enabled: true
+        minAvailable: null
+        maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -405,10 +405,10 @@
                     "type": "boolean"
                 },
                 "maxUnavailable": {
-                    "type": "string"
+                    "type": ["integer", "string"]
                 },
                 "minAvailable": {
-                    "type": "integer"
+                    "type": ["integer", "string"]
                 }
             }
         },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

The values schema typed pdb.minAvailable as integer and pdb.maxUnavailable as string, so a percentage value such as "51%" for minAvailable (and an integer for maxUnavailable) was rejected at render time, despite the README documenting both as number/percentage. Kubernetes PodDisruptionBudget treats both fields as IntOrString.

Widen both fields to accept integer or string and add unit tests covering integer and percentage cases. Bump chart to 0.30.7.

### Benefits

Allows setting percentage for pdb fields.

### Possible drawbacks

Don't see any - backwards compatible. 

### Applicable issues

Atm we can't set percentage for pdb.minAvailable


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
