### PR TITLE
[zookeeper] Add optional External-DNS hostname for external access

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.11.0
+version: 0.13.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -168,6 +168,7 @@ zkCli.sh -server my-zookeeper:2181
 | `externalAccess.service.loadBalancerSourceRanges`   | Source CIDR ranges allowed to reach the external LoadBalancers                                    | `[]`             |
 | `externalAccess.service.externalTrafficPolicy`      | External traffic policy for LoadBalancer/NodePort services (`Local` recommended for per-pod LBs)    | `Local`          |
 | `externalAccess.service.labels`                     | Extra labels applied to each external service                                                     | `{}`             |
+| `externalAccess.service.hostnameDomain` | Extra annotation `external-dns.alpha.kubernetes.io/hostname` per replica: `{release}-{ordinal}.{domain}`. Requires External-DNS with that zone in domainFilters  | `""`             |
 
 When enabled, the chart creates one external service per ZooKeeper pod (e.g. `release-zookeeper-0-external`). Clients outside the cluster should use the LoadBalancer hostnames and client port in their connection string. Quorum traffic remains on the internal headless service; `zoo.cfg` server entries are not changed.
 
@@ -177,6 +178,7 @@ When enabled, the chart creates one external service per ZooKeeper pod (e.g. `re
 externalAccess:
   enabled: true
   service:
+    hostnameDomain: int.example.com
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-type: "external"
       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"

--- a/charts/zookeeper/templates/svc-external-access.yaml
+++ b/charts/zookeeper/templates/svc-external-access.yaml
@@ -16,6 +16,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- $annotations := merge $.Values.externalAccess.service.annotations $.Values.commonAnnotations }}
+  {{- if $.Values.externalAccess.service.hostnameDomain }}
+  {{- $hostname := printf "%s-%d.%s" $fullname $i $.Values.externalAccess.service.hostnameDomain }}
+  {{- $annotations = merge (dict "external-dns.alpha.kubernetes.io/hostname" $hostname) $annotations }}
+  {{- end }}
   {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/zookeeper/tests/external-access_test.yaml
+++ b/charts/zookeeper/tests/external-access_test.yaml
@@ -45,3 +45,40 @@ tests:
       - equal:
           path: spec.externalTrafficPolicy
           value: Local
+
+  - it: should set external-dns hostname when hostnameDomain is set
+    template: svc-external-access.yaml
+    documentIndex: 0
+    set:
+      externalAccess:
+        enabled: true
+        service:
+          hostnameDomain: int.example.com
+    asserts:
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+          value: RELEASE-NAME-zookeeper-0.int.example.com
+
+  - it: should set distinct hostnames per replica
+    template: svc-external-access.yaml
+    documentIndex: 2
+    set:
+      replicaCount: 3
+      externalAccess:
+        enabled: true
+        service:
+          hostnameDomain: int.example.com
+    asserts:
+      - equal:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]
+          value: RELEASE-NAME-zookeeper-2.int.example.com
+
+  - it: should not set external-dns hostname when hostnameDomain is empty
+    template: svc-external-access.yaml
+    documentIndex: 0
+    set:
+      externalAccess:
+        enabled: true
+    asserts:
+      - isNull:
+          path: metadata.annotations["external-dns.alpha.kubernetes.io/hostname"]

--- a/charts/zookeeper/values.schema.json
+++ b/charts/zookeeper/values.schema.json
@@ -88,6 +88,9 @@
                         },
                         "type": {
                             "type": "string"
+                        },
+                        "hostnameDomain": {
+                            "type": "string"
                         }
                     }
                 }

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -314,6 +314,9 @@ externalAccess:
     externalTrafficPolicy: Local
     ## @param externalAccess.service.labels Extra labels for external services
     labels: {}
+    ## @param externalAccess.service.hostnameDomain DNS suffix for External-DNS hostname annotation per replica (e.g. int.example.com).
+    ## When set, each external service gets external-dns.alpha.kubernetes.io/hostname: {release}-{ordinal}.{hostnameDomain}
+    hostnameDomain: ""    
 
 ## @param command Override default container command (useful when the default entrypoint needs to be replaced)
 command: []


### PR DESCRIPTION
### Description of the change

Adds an optional externalAccess.service.hostnameDomain value to the ZooKeeper chart.

When set (and externalAccess.enabled is true), each per-pod external LoadBalancer Service gets an external-dns.alpha.kubernetes.io/hostname annotation with a stable, predictable hostname:

`{release-fullname}-{ordinal}.{hostnameDomain}`

Example with `releaseName: my-zk`, `replicaCount: 3`, and `hostnameDomain: int.example.com`:

`my-zk-0.int.example.com`
`my-zk-1.int.example.com`
`my-zk-2.int.example.com`

When hostnameDomain is empty (default), behaviour is unchanged, no External-DNS annotation is added.

**Files changed:**

- templates/svc-external-access.yaml - merge hostname annotation into service annotations
- values.yaml - new parameter with @param documentation
- values.schema.json - schema entry for hostnameDomain
- README.md - parameter table and AWS NLB example updated
- tests/external-access_test.yaml - unit tests for hostname set, per-replica hostnames, and empty default

### Benefits

Problem: Per-pod external access ( https://github.com/CloudPirates-io/helm-charts/pull/1391 ) exposes each ZooKeeper pod via its own LoadBalancer (e.g. AWS NLB). NLB hostnames are provider-generated, opaque, and change when a Service or load balancer is recreated. That makes it hard to build a stable ZooKeeper connection string for clients outside the cluster (Spark, custom apps, etc.).

Solution: Many clusters already run [External-DNS](https://github.com/kubernetes-sigs/external-dns), which creates DNS records from the external-dns.alpha.kubernetes.io/hostname Service annotation.

Why per-replica hostnames matter: ZooKeeper clients typically connect to a comma-separated list of ensemble members (`host1:2181,host2:2181,host3:2181`). With one LoadBalancer per pod, each member needs its own stable DNS name. 

Setting hostnameDomain gives predictable names that External-DNS can manage in a configured zone (e.g. domainFilters). 

**Example use case:**

```
externalAccess:
  enabled: true
  service:
    hostnameDomain: int.example.com
    annotations:
      service.beta.kubernetes.io/aws-load-balancer-type: "external"
      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
      service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
```

DNS records get created by External-DNS and **Clients connect with:**
`my-zk-0.int.example.com:2181,my-zk-1.int.example.com:2181,my-zk-2.int.example.com:2181`

### Possible drawbacks

- Requires External-DNS to work: The annotation has no effect unless External-DNS (or another controller that reads the same annotation) is installed and the zone is in domainFilters.
- DNS propagation delay: Records appear after External-DNS reconciles, NLB provisioning may still take time.

### Applicable issues
Related to #1391  (per-pod external LoadBalancer services)

### Additional information

**Testing:**

```
### Chart [ zookeeper ] .

 PASS  test zookeeper common parameters tests/common-parameters_test.yaml
 PASS  test zookeeper external access   tests/external-access_test.yaml
 PASS  test openshift related settings  tests/openshift_test.yaml
 PASS  test zookeeper specific parameters       tests/unittest-defaults_test.yaml

Charts:      1 passed, 1 total
Test Suites: 4 passed, 4 total
Tests:       34 passed, 34 total
Snapshot:    0 passed, 0 total
Time:        164.733792ms
```

**Note for reviewers:**

- This builds on the external access feature merged in #1391. It is fully backward compatible, default hostnameDomain: "" preserves existing behavior.
- This was successfully tested on an EKS cluster with route53 records created, the tested branch combined also the fix from #1390.
- Chart version bumped in Chart.yaml according to semver (depends on this fix merge first #1390 )

### Checklist

- [x]  Chart version bumped in Chart.yaml according to semver (depends on this fix merge first #1390 )
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows [zookeeper] Descriptive title
- [x] All commits are signed and verified