### PR TITLE
[zookeeper] Fix startup crash by gating secure client port behind tls.enabled

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/README.md
+++ b/charts/zookeeper/README.md
@@ -124,6 +124,25 @@ zkCli.sh -server my-zookeeper:2181
 | `zookeeperConfig.admin.commandUrl`          | Admin server command URL                            | `/commands` |
 | `zookeeperConfig.extraConfigs`              | Extra ZooKeeper configuration lines appended to zoo.cfg | `[]`    |
 
+### TLS Configuration
+
+| Parameter     | Description                                                | Default |
+| ------------- | ---------------------------------------------------------- | ------- |
+| `tls.enabled` | Expose the ZooKeeper secure client port for TLS connections | `false` |
+
+Enabling TLS opens the secure client port (`service.ports.secureClient`) and switches ZooKeeper to the Netty connection factory, which is required for TLS. Supply the certificate configuration via `zookeeperConfig.extraConfigs` and mount the keystore files with `extraVolumes` / `extraVolumeMounts`, for example:
+
+```yaml
+tls:
+  enabled: true
+zookeeperConfig:
+  extraConfigs:
+    - "ssl.keyStore.location=/certs/keystore.jks"
+    - "ssl.keyStore.password=changeit"
+    - "ssl.trustStore.location=/certs/truststore.jks"
+    - "ssl.trustStore.password=changeit"
+```
+
 ### Metrics
 
 | Parameter                                  | Description                                                                      | Default     |
@@ -150,7 +169,7 @@ zkCli.sh -server my-zookeeper:2181
 | ------------------------------ | -------------------------------------------- | ----------- |
 | `service.type`                 | Kubernetes service type                      | `ClusterIP` |
 | `service.ports.client`         | ZooKeeper client service port                | `2181`      |
-| `service.ports.secureClient`   | ZooKeeper secure client service port         | `2281`      |
+| `service.ports.secureClient`   | ZooKeeper secure client service port (exposed only when `tls.enabled` is set) | `2281`      |
 | `service.ports.quorum`         | ZooKeeper quorum service port                | `2888`      |
 | `service.ports.leaderElection` | ZooKeeper leader election service port       | `3888`      |
 | `service.ports.admin`          | ZooKeeper admin service port                 | `8080`      |

--- a/charts/zookeeper/templates/configmap.yaml
+++ b/charts/zookeeper/templates/configmap.yaml
@@ -16,7 +16,11 @@ data:
     initLimit={{ .Values.zookeeperConfig.initLimit | default 10 }}
     syncLimit={{ .Values.zookeeperConfig.syncLimit | default 5 }}
     clientPort={{ .Values.service.ports.client | default 2181 }}
+    {{- if .Values.tls.enabled }}
     secureClientPort={{ .Values.service.ports.secureClient | default 2281 }}
+    {{- /* TLS requires the Netty connection factory; the default NIO factory refuses to start with a secure port */}}
+    serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory
+    {{- end }}
     electionPortBindRetry={{ .Values.zookeeperConfig.electionPortBindRetry | default 10 }}
     maxClientCnxns={{ .Values.zookeeperConfig.maxClientCnxns | default 60 }}
     #standaloneEnabled={{ .Values.zookeeperConfig.standaloneEnabled | default "false" }}

--- a/charts/zookeeper/templates/networkpolicy.yaml
+++ b/charts/zookeeper/templates/networkpolicy.yaml
@@ -29,7 +29,9 @@ spec:
     # Allow inbound connections to ZooKeeper
     - ports:
         - port: {{ .Values.service.ports.client | default 2181 }}
+        {{- if .Values.tls.enabled }}
         - port: {{ .Values.service.ports.secureClient | default 2281 }}
+        {{- end }}
     # Allow internal communications between nodes
     - ports:
         - port: {{ .Values.service.ports.quorum | default 2888 }}

--- a/charts/zookeeper/templates/service.yaml
+++ b/charts/zookeeper/templates/service.yaml
@@ -17,10 +17,12 @@ spec:
       targetPort: client
       protocol: TCP
       name: client
+    {{- if .Values.tls.enabled }}
     - port: {{ .Values.service.ports.secureClient | default 2281 }}
       targetPort: secure-client
       protocol: TCP
       name: secure-client
+    {{- end }}
     - port: {{ .Values.service.ports.admin | default 8080 }}
       targetPort: admin
       protocol: TCP
@@ -44,10 +46,12 @@ spec:
       targetPort: client
       protocol: TCP
       name: client
+    {{- if .Values.tls.enabled }}
     - port: {{ .Values.service.ports.secureClient | default 2281 }}
       targetPort: secure-client
       protocol: TCP
       name: secure-client
+    {{- end }}
     - port: {{ .Values.service.ports.quorum | default 2888 }}
       targetPort: quorum
       protocol: TCP

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -43,9 +43,11 @@ spec:
             - name: client
               containerPort: {{ .Values.service.ports.client | default 2181 }}
               protocol: TCP
+            {{- if .Values.tls.enabled }}
             - name: secure-client
               containerPort: {{ .Values.service.ports.secureClient | default 2281 }}
               protocol: TCP
+            {{- end }}
             - name: quorum
               containerPort: {{ .Values.service.ports.quorum | default 2888 }}
               protocol: TCP

--- a/charts/zookeeper/tests/unittest-defaults_test.yaml
+++ b/charts/zookeeper/tests/unittest-defaults_test.yaml
@@ -45,6 +45,71 @@ tests:
           path: data["zoo.cfg"]
           pattern: "tickTime=2000"
 
+  - it: should not configure the secure client port by default
+    templates:
+      - configmap.yaml
+      - service.yaml
+      - statefulset.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["zoo.cfg"]
+          pattern: "secureClientPort"
+        template: configmap.yaml
+      - notMatchRegex:
+          path: data["zoo.cfg"]
+          pattern: "serverCnxnFactory"
+        template: configmap.yaml
+      - notContains:
+          path: spec.ports
+          content:
+            port: 2281
+            targetPort: secure-client
+            protocol: TCP
+            name: secure-client
+        template: service.yaml
+        documentIndex: 0
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: secure-client
+            containerPort: 2281
+            protocol: TCP
+        template: statefulset.yaml
+
+  - it: should configure the secure client port and Netty factory when TLS is enabled
+    templates:
+      - configmap.yaml
+      - service.yaml
+      - statefulset.yaml
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["zoo.cfg"]
+          pattern: "secureClientPort=2281"
+        template: configmap.yaml
+      - matchRegex:
+          path: data["zoo.cfg"]
+          pattern: "serverCnxnFactory=org\\.apache\\.zookeeper\\.server\\.NettyServerCnxnFactory"
+        template: configmap.yaml
+      - contains:
+          path: spec.ports
+          content:
+            port: 2281
+            targetPort: secure-client
+            protocol: TCP
+            name: secure-client
+        template: service.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: secure-client
+            containerPort: 2281
+            protocol: TCP
+        template: statefulset.yaml
+
   - it: should append extraConfigs to zoo.cfg
     template: configmap.yaml
     set:

--- a/charts/zookeeper/values.yaml
+++ b/charts/zookeeper/values.yaml
@@ -110,9 +110,17 @@ zookeeperConfig:
     commandUrl: "/commands"
   ## @param zookeeperConfig.extraConfigs Extra ZooKeeper configuration lines to append to zoo.cfg
   extraConfigs: []
-  #  - "secureClientPort=2281"
+  #  - "ssl.keyStore.location=/certs/keystore.jks"
   #  - "authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider"
 
+## @section TLS configuration
+## Enabling TLS opens the secure client port (service.ports.secureClient) and switches
+## ZooKeeper to the Netty connection factory, which is required for TLS.
+## Supply the certificate configuration (ssl.keyStore.location, ssl.trustStore.location, ...)
+## via zookeeperConfig.extraConfigs and mount the keystore files with extraVolumes/extraVolumeMounts.
+tls:
+  ## @param tls.enabled Expose the ZooKeeper secure client port for TLS connections
+  enabled: false
 
 ## @section Zookeeper Metrics configuration
 metrics:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Since chart version 0.9.0 (#1212), secureClientPort is rendered unconditionally into zoo.cfg. ZooKeeper only supports a secure client port with the Netty connection factory, which the chart never configures, so every install with default values crashes on startup with:

```
java.lang.UnsupportedOperationException: SSL isn't supported in NIOServerCnxn
	at org.apache.zookeeper.server.NIOServerCnxnFactory.configure(NIOServerCnxnFactory.java:621)
```
There is also no values-level escape hatch, since
`secureClientPort={{ .Values.service.ports.secureClient | default 2281 }}` re-applies the
default even when the value is nulled out.

This PR makes the secure client port opt-in via a new `tls.enabled` value (default `false`,
matching the convention used by other charts in this repo):

- `zoo.cfg` only contains `secureClientPort` when `tls.enabled=true`, and then also sets
  `serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory`, which TLS requires
- The `secure-client` port on the client service, headless service, StatefulSet container,
  and NetworkPolicy ingress rule is now rendered only when `tls.enabled=true`
- Certificate configuration (keystore/truststore) is supplied via
  `zookeeperConfig.extraConfigs` and `extraVolumes`/`extraVolumeMounts`, documented with an
  example in the README
- Unit tests cover both the default (no secure port rendered) and the `tls.enabled=true` case

### Benefits

<!-- What benefits will be realized by the code change? -->
- The chart works again with default values — currently every fresh install of
  chart >= 0.9.0 crashloops
- TLS remains fully usable: enabling `tls.enabled` now actually works, because the Netty
  connection factory is set alongside the secure port (previously TLS via `extraConfigs`
  alone would still crash on the NIO factory)

### Possible drawbacks

<!-- Describe any known limitations with your change -->
- Deployments that set `serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory`
  via `zookeeperConfig.extraConfigs` as a workaround must now set `tls.enabled=true` to keep
  the secure port exposed. Setting both keeps working (the duplicated `serverCnxnFactory`
  line is harmless but can be removed from `extraConfigs`).
- Services and NetworkPolicies no longer expose port 2281 by default. Since the pod never
  started with the previous defaults, no working deployment can depend on it.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes https://github.com/CloudPirates-io/helm-charts/issues/1369

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
The original intent of #1212 is preserved: `secureClientPort=2281` was documented as an
opt-in `extraConfigs` example in `values.yaml` before it was hard-coded into the ConfigMap.
Chart version is bumped to 0.12.0 (minor, new `tls.enabled` value plus changed default
rendering).
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
