### PR TITLE
[nginx] Add dnsPolicy and dnsConfig

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.13.0
+version: 0.14.0
 appVersion: "1.31.0"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -456,6 +456,8 @@ All containers in `sidecars` will be added to the pod and run alongside the main
 | `priorityClassName` | Priority class for pod eviction   | `""`    |
 | `tolerations`       | Tolerations for pod assignment    | `[]`    |
 | `affinity`          | Affinity rules for pod assignment | `{}`    |
+| `dnsPolicy`         | DNS policy for the pod            | `""`    |
+| `dnsConfig`         | DNS configuration for the pod     | `{}`    |
 
 ### DaemonSet Configuration Parameters
 

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -319,3 +319,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -156,6 +156,34 @@
                 }
             }
         },
+        "dnsPolicy": {
+            "type": "string"
+        },
+        "dnsConfig": {
+            "type": "object",
+            "properties": {
+                "nameservers": {
+                    "type": "array"
+                },
+                "searches": {
+                    "type": "array"
+                },
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "existingConfigConfigmap": {
             "type": "string"
         },

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -228,6 +228,12 @@ tolerations: []
 ## @param affinity Affinity rules for pod assignment
 affinity: {}
 
+## @param dnsPolicy DNS policy for the pod
+dnsPolicy: ""
+
+## @param dnsConfig DNS configuration for the pod
+dnsConfig: {}
+
 containerSecurityContext:
   ## @param containerSecurityContext.runAsUser User ID to run the container
   runAsUser: 101


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Expose optional `dnsPolicy` https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy and `dnsConfig` https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config keys to render in pod template.

### Benefits

Consumers will get more control over pod DNS configuration.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
