### PR TITLE
[nginx] Add clusterIP to service

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.14.0
+version: 0.15.0
 appVersion: "1.31.0"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -205,6 +205,7 @@ containerPorts:
 | ------------------------------- | -------------------------------------------------------------- | ----------- |
 | `service.type`                  | Nginx service type                                             | `ClusterIP` |
 | `service.ports`                 | Array of service ports (advanced configuration) - see examples | `[]`        |
+| `service.clusterIP`             | Kubernetes service static ClusterIP                            | `""`        |
 | `service.internalTrafficPolicy` | Kubernetes service internal traffic policy                     | `Cluster`   |
 | `service.trafficDistribution`   | Kubernetes service traffic distribution                        | `""`        |
 | `service.annotations`           | Additional annotations to add to the service                   | `{}`        |

--- a/charts/nginx/templates/service.yaml
+++ b/charts/nginx/templates/service.yaml
@@ -19,6 +19,9 @@ spec:
       protocol: {{ .protocol | default "TCP" }}
       name: {{ .name }}
     {{- end }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   selector:
     {{- include "nginx.selectorLabels" . | nindent 4 }}
   internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy | default "Cluster" }}

--- a/charts/nginx/tests/service_test.yaml
+++ b/charts/nginx/tests/service_test.yaml
@@ -18,3 +18,12 @@ tests:
       - equal:
           path: spec.trafficDistribution
           value: PreferClose
+
+  - it: should set clusterIP when configured
+    set:
+      service:
+        clusterIP: 99.99.99.99
+    asserts:
+      - equal:
+          path: spec.clusterIP
+          value: 99.99.99.99

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -538,6 +538,9 @@
                 "annotations": {
                     "type": "object"
                 },
+                "clusterIP": {
+                    "type": "string"
+                },
                 "internalTrafficPolicy": {
                     "type": "string"
                 },

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -156,33 +156,11 @@
                 }
             }
         },
+        "dnsConfig": {
+            "type": "object"
+        },
         "dnsPolicy": {
             "type": "string"
-        },
-        "dnsConfig": {
-            "type": "object",
-            "properties": {
-                "nameservers": {
-                    "type": "array"
-                },
-                "searches": {
-                    "type": "array"
-                },
-                "options": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            },
-                            "value": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
         },
         "existingConfigConfigmap": {
             "type": "string"
@@ -544,9 +522,6 @@
                 "internalTrafficPolicy": {
                     "type": "string"
                 },
-                "trafficDistribution": {
-                    "type": "string"
-                },
                 "ports": {
                     "type": "array",
                     "items": {
@@ -566,6 +541,9 @@
                             }
                         }
                     }
+                },
+                "trafficDistribution": {
+                    "type": "string"
                 },
                 "type": {
                     "type": "string"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -67,6 +67,8 @@ service:
       targetPort: http
       protocol: TCP
       name: http
+  ## @param service.clusterIP Kubernetes service static ClusterIP
+  clusterIP: ""
   ## @param service.internalTrafficPolicy Kubernetes service internal traffic policy
   internalTrafficPolicy: ""
   ## @param service.trafficDistribution Kubernetes service traffic distribution


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Add the ability to declare a static ClusterIP for the nginx Service.

### Benefits

Consumers will be able to set a static Cluster IP without patches.

As a bonus, it will make it convenient to debug e.g. with the help of https://github.com/crabique/kubectl-curl:

```sh
# export once in .zshrc
❯ export NIP=10.96.100.100
# use the var instead of copy/pasting the real IP
❯ kubectl curl $NIP:8080
```

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
