### PR TITLE
[etcd] Add apiVersion and kind to the volumeClaimTemplates section to…

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: "3.6.12"
 keywords:
   - etcd

--- a/charts/etcd/templates/statefulset.yaml
+++ b/charts/etcd/templates/statefulset.yaml
@@ -211,7 +211,9 @@ spec:
       {{- end }}
   {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- with $labels := merge (include "etcd.selectorLabels" . | fromYaml) .Values.persistence.labels .Values.podLabels }}
         labels:


### PR DESCRIPTION
… automatically match the diff generated by ArgoCD

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

I would like to add a `apiVersion` and `kind` field to the StatefulSet's `volumeClaimTemplates` section to fix the behaviour with ArgoCD. It shows always an OutOfSync.

### Benefits

The helm deployment is not anymore shown as OutOfSync

### Possible drawbacks

None to my knowledge

### Applicable issues

- fixes #1413 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
