### PR TITLE
[memcached] Add headless service support for StatefulSet

### DIFF
--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.13.3
+version: 0.14.0
 appVersion: "1.6.42"
 keywords:
   - memcached

--- a/charts/memcached/README.md
+++ b/charts/memcached/README.md
@@ -112,6 +112,7 @@ The following table lists the configurable parameters of the Memcached chart and
 | `service.port`        | Memcached service port                              | `11211`     |
 | `service.nodePort`    | Node port for Memcached service                     | `""`        |
 | `service.clusterIP`   | Static cluster IP or "None" for headless service    | `""`        |
+| `service.publishNotReadyAddresses` | Publish pod DNS names before pods are ready (StatefulSet peer discovery) | `false` |
 | `service.annotations` | Additional custom annotations for Memcached service | `{}`        |
 
 ### Security Context Parameters

--- a/charts/memcached/templates/service.yaml
+++ b/charts/memcached/templates/service.yaml
@@ -11,6 +11,12 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.clusterIP }}
+  clusterIP: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.service.publishNotReadyAddresses }}
+  publishNotReadyAddresses: true
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: memcached

--- a/charts/memcached/values.schema.json
+++ b/charts/memcached/values.schema.json
@@ -382,8 +382,14 @@
         "service": {
             "type": "object",
             "properties": {
+                "clusterIP": {
+                    "type": "string"
+                },
                 "port": {
                     "type": "integer"
+                },
+                "publishNotReadyAddresses": {
+                    "type": "boolean"
                 },
                 "type": {
                     "type": "string"

--- a/charts/memcached/values.yaml
+++ b/charts/memcached/values.yaml
@@ -43,6 +43,10 @@ deploymentType: Deployment
 service:
   ## @param service.type Kubernetes service type
   type: ClusterIP
+  ## @param service.clusterIP Static cluster IP or "None" for a headless service (recommended when deploymentType is StatefulSet)
+  clusterIP: ""
+  ## @param service.publishNotReadyAddresses Publish pod DNS names before pods are ready (recommended for StatefulSet peer discovery)
+  publishNotReadyAddresses: false
   ## @param service.port Memcached service port
   port: 11211
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Add headless service support for StatefulSet

### Benefits

<!-- What benefits will be realized by the code change? -->
A StatefulSet's governing service should be headless so each pod gets a stable per-pod DNS record. The service template hardcoded a ClusterIP (VIP) with no way to request clusterIP: None, so StatefulSet deployments could not expose proper headless pod DNS.

Add two opt-in service options:
- service.clusterIP: set to "None" for a headless service (or a static IP)
- service.publishNotReadyAddresses: publish pod DNS before pods are Ready, which StatefulSet peers need during rollout

### Possible drawbacks

<!-- Describe any known limitations with your change -->
N/A

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
Both are guarded, so default renders are unchanged. Update values.yaml, values.schema.json and the README, and bump chart 0.13.3 -> 0.14.0.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
