### PR TITLE
[rabbitmq-cluster-operator] Bump images to latest versions, add new webhook configuration

### DIFF
--- a/charts/rabbitmq-cluster-operator/CHANGELOG.md
+++ b/charts/rabbitmq-cluster-operator/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this chart will be documented in this file.
 
+## [0.4.0] - 2026-07-06
+
+- [rabbitmq-cluster-operator] Bump cluster-operator to v2.22.1 and messaging-topology-operator to v1.19.3
+- [rabbitmq-cluster-operator] Bump default RabbitMQ image to 4.3.2-management-alpine and default-user-credential-updater to v1.0.15
+- [rabbitmq-cluster-operator] Align cluster-operator RBAC with upstream v2.22.x: add the `patch` verb on `rabbitmqclusters/status`, and add the `configmaps` rule plus the `patch` verb on `events` to the namespaced leader-election Role
+- [rabbitmq-cluster-operator] Add an optional RabbitmqCluster admission webhook (mutating + validating) for the cluster operator, introduced upstream in v2.22.0. It is **disabled by default** (`clusterOperator.webhook.enabled=false`); when disabled the operator is started with `ENABLE_WEBHOOKS=false`, preserving the chart's pre-v2.22.0 behavior. See the "RabbitmqCluster admission webhook" section of the README for enablement instructions
+- [rabbitmq-cluster-operator] Refresh CRDs from upstream cluster-operator v2.22.1 (new `status.deprecatedFeaturesUsed` field) and messaging-topology-operator v1.19.3
+
+> [!IMPORTANT]
+> Upgrading the cluster operator to v2.22.1 causes a **rolling restart of the underlying StatefulSets** of every managed RabbitmqCluster. To control the timing, pause reconciliation before upgrading and resume it once the operator is ready.
+>
+> v2.22.0 also switched the RabbitMQ startup probe from an exec check to an HTTP check, which requires RabbitMQ `4.2.4+` or `4.3.0+`. The chart default (`4.3.2-management-alpine`) satisfies this; clusters pinned to older RabbitMQ versions must set the `rabbitmq.com/legacy-startup-probe: "true"` annotation.
+
 ## [0.3.0] - 2026-05-16
 
 - [rabbitmq-cluster-operator] Move operator images to ghcr.io (rabbitmqoperator/* on Docker Hub is no longer published)

--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.3.3
-appVersion: "2.21.0"
+version: 0.4.0
+appVersion: "2.22.1"
 keywords:
   - rabbitmq-cluster-operator
   - rabbitmq
@@ -45,4 +45,12 @@ annotations:
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
     - kind: changed
-      description: "Match messaging-topology-operator roles to upstream"
+      description: "Bump cluster-operator to v2.22.1 and messaging-topology-operator to v1.19.3"
+    - kind: changed
+      description: "Bump default RabbitMQ image to 4.3.2-management-alpine and default-user-credential-updater to v1.0.15"
+    - kind: changed
+      description: "Add patch verb on rabbitmqclusters/status and align leader-election Role with upstream cluster-operator v2.22.x"
+    - kind: added
+      description: "Optional RabbitmqCluster admission webhook for the cluster operator (clusterOperator.webhook.enabled, disabled by default)"
+    - kind: changed
+      description: "Refresh rabbitmqclusters CRD from upstream cluster-operator v2.22.1"

--- a/charts/rabbitmq-cluster-operator/README.md
+++ b/charts/rabbitmq-cluster-operator/README.md
@@ -170,6 +170,11 @@ The following table lists the configurable values of the RabbitMQ chart and thei
 | `clusterOperator.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the RabbitMQ Cluster Operator container(s)                                                                                                                                           | `[]`                                             |
 | `clusterOperator.sidecars`                                          | Add additional sidecar containers to the RabbitMQ Cluster Operator pod(s)                                                                                                                                                                         | `[]`                                             |
 | `clusterOperator.initContainers`                                    | Add additional init containers to the RabbitMQ Cluster Operator pod(s)                                                                                                                                                                            | `[]`                                             |
+| `clusterOperator.webhook.enabled`                                   | Enable the RabbitmqCluster admission webhook (requires TLS serving certificates)                                                                                                                                                                  | `false`                                          |
+| `clusterOperator.webhook.existingWebhookCertSecret`                 | Name of an existing secret containing the webhook certificates (use it to avoid the chart generating one)                                                                                                                                         | `""`                                             |
+| `clusterOperator.webhook.existingWebhookCertCABundle`               | PEM-encoded CA Bundle of the existing secret provided in existingWebhookCertSecret (only if useCertManager=false)                                                                                                                                 | `""`                                             |
+| `clusterOperator.webhook.service.type`                              | RabbitMQ Cluster Operator webhook service type                                                                                                                                                                                                    | `ClusterIP`                                      |
+| `clusterOperator.webhook.service.port`                              | RabbitMQ Cluster Operator webhook service port                                                                                                                                                                                                    | `443`                                            |
 | `clusterOperator.networkPolicy.enabled`                             | Specifies whether a NetworkPolicy should be created                                                                                                                                                                                               | `true`                                           |
 | `clusterOperator.networkPolicy.kubeAPIServerPorts`                  | List of possible endpoints to kube-apiserver (limit to your cluster settings to increase security)                                                                                                                                                | `[]`                                             |
 | `clusterOperator.networkPolicy.allowExternal`                       | Don't require injector label for connections                                                                                                                                                                                                      | `true`                                           |
@@ -374,3 +379,74 @@ The following table lists the configurable values of the RabbitMQ chart and thei
 | `msgTopologyOperator.metrics.podMonitor.additionalLabels`      | Additional labels that can be used so PodMonitors will be discovered by Prometheus | `{}`                     |
 | `msgTopologyOperator.metrics.podMonitor.relabelings`           | Specify general relabeling                                                         | `[]`                     |
 | `msgTopologyOperator.metrics.podMonitor.metricRelabelings`     | Specify additional relabeling of metrics                                           | `[]`                     |
+
+## RabbitmqCluster admission webhook
+
+Starting with cluster-operator `v2.22.0`, the operator ships mutating (defaulting) and validating admission
+webhooks for `RabbitmqCluster` resources. This chart keeps them **disabled by default**: the operator is
+started with `ENABLE_WEBHOOKS=false`, which preserves the behavior of chart versions prior to `0.4.0`.
+
+Enabling the webhook adds server-side defaulting and validation (for example, rejecting unsafe
+`spec.override.statefulSet` fields such as `hostNetwork` or `serviceAccountName`). Because the webhook is
+served over TLS, enabling it requires serving certificates.
+
+### Option 1 — chart-generated self-signed certificate (default when enabled)
+
+The chart generates a self-signed CA and certificate and stores them in a `Secret`, injecting the CA into the
+webhook configurations' `caBundle`. On a subsequent `helm upgrade` the existing `Secret` is read back from the
+cluster (via Helm's `lookup`) and reused, so the certificate stays stable and the `Secret` and `caBundle`
+remain mutually consistent.
+
+```bash
+helm upgrade --install my-rabbitmq-operator \
+  oci://registry-1.docker.io/cloudpirates/rabbitmq-cluster-operator \
+  --set clusterOperator.webhook.enabled=true
+```
+
+> [!WARNING]
+> The `genCA`/`genSignedCert` template functions are **not** deterministic — they produce a new certificate on
+> every render. Stability comes solely from Helm's `lookup` reading the previously created `Secret`, which only
+> works when the render has live cluster access (a real `helm install`/`helm upgrade`). Tools that render
+> client-side without cluster access — `helm template`, or **Argo CD / Flux in their default rendering mode** —
+> cannot see the existing `Secret` and will regenerate the certificate on every sync. For GitOps workflows use
+> Option 2 (cert-manager) or Option 3 (bring your own secret) instead.
+
+### Option 2 — cert-manager
+
+If cert-manager is installed in the cluster, set `useCertManager=true`. The chart creates a self-signed
+`Issuer` and a `Certificate`, and relies on cert-manager's CA injector for the webhook `caBundle`.
+
+```bash
+helm upgrade --install my-rabbitmq-operator \
+  oci://registry-1.docker.io/cloudpirates/rabbitmq-cluster-operator \
+  --set clusterOperator.webhook.enabled=true \
+  --set useCertManager=true
+```
+
+### Option 3 — bring your own certificate
+
+Provide an existing TLS secret (and, when not using cert-manager, its CA bundle):
+
+```bash
+helm upgrade --install my-rabbitmq-operator \
+  oci://registry-1.docker.io/cloudpirates/rabbitmq-cluster-operator \
+  --set clusterOperator.webhook.enabled=true \
+  --set clusterOperator.webhook.existingWebhookCertSecret=my-webhook-cert \
+  --set-file clusterOperator.webhook.existingWebhookCertCABundle=ca.pem
+```
+
+> [!NOTE]
+> When the webhook is disabled the operator still applies the default RabbitMQ image via the
+> `DEFAULT_RABBITMQ_IMAGE` environment variable; only admission-time defaulting and validation are skipped.
+
+## Upgrading
+
+### To 0.4.0
+
+Upgrading the cluster operator to `v2.22.1` triggers a **rolling restart of the StatefulSets** of every
+managed `RabbitmqCluster`. To control the timing, pause reconciliation before upgrading and resume it once
+the operator is ready.
+
+`v2.22.0` also switched the RabbitMQ startup probe from an exec check to an HTTP check, which requires
+RabbitMQ `4.2.4+` or `4.3.0+`. The chart default (`4.3.2-management-alpine`) satisfies this; clusters pinned
+to older RabbitMQ versions must set the `rabbitmq.com/legacy-startup-probe: "true"` annotation.

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_bindings.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_bindings.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_bindings.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_bindings.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: bindings.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_exchanges.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_exchanges.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_exchanges.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_exchanges.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: exchanges.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_federations.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_federations.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_federations.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_federations.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: federations.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_operatorpolicies.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_operatorpolicies.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_operatorpolicies.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_operatorpolicies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: operatorpolicies.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_permissions.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_permissions.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_permissions.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_permissions.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: permissions.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_policies.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_policies.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_policies.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_policies.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: policies.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_queues.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_queues.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_queues.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_queues.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: queues.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_schemareplications.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_schemareplications.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_schemareplications.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_schemareplications.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: schemareplications.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_shovels.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_shovels.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_shovels.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_shovels.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: shovels.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_superstreams.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_superstreams.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_superstreams.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_superstreams.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: superstreams.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_topicpermissions.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_topicpermissions.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_topicpermissions.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_topicpermissions.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: topicpermissions.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_users.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_users.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_users.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_users.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: users.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_vhosts.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/messaging-topology-operator/rabbitmq.com_vhosts.yaml
@@ -1,9 +1,9 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.2/config/crd/bases/rabbitmq.com_vhosts.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/messaging-topology-operator/v1.19.3/config/crd/bases/rabbitmq.com_vhosts.yaml
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: vhosts.rabbitmq.com
 spec:
   group: rabbitmq.com

--- a/charts/rabbitmq-cluster-operator/crds/rabbitmq-cluster/rabbitmq.com_rabbitmqclusters.yaml
+++ b/charts/rabbitmq-cluster-operator/crds/rabbitmq-cluster/rabbitmq.com_rabbitmqclusters.yaml
@@ -1,4 +1,4 @@
-# Generated from: https://raw.githubusercontent.com/rabbitmq/cluster-operator/v2.21.0/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
+# Generated from: https://raw.githubusercontent.com/rabbitmq/cluster-operator/v2.22.1/config/crd/bases/rabbitmq.com_rabbitmqclusters.yaml
 # RabbitMQ Cluster Operator
 #
 # Copyright 2020 VMware, Inc. All Rights Reserved.
@@ -5509,6 +5509,11 @@ spec:
                         - namespace
                       type: object
                   type: object
+                deprecatedFeaturesUsed:
+                  description: DeprecatedFeaturesUsed exposes whether there are deprecated features in-use in a RabbitMQ server.
+                  items:
+                    type: string
+                  type: array
                 observedGeneration:
                   description: |-
                     observedGeneration is the most recent successful generation observed for this RabbitmqCluster. It corresponds to the

--- a/charts/rabbitmq-cluster-operator/templates/_helpers.tpl
+++ b/charts/rabbitmq-cluster-operator/templates/_helpers.tpl
@@ -29,6 +29,31 @@ Common labels for rmq-cluster-operator
 {{- end }}
 
 {{/*
+Return the proper RabbitMQ Cluster Operator webhook fullname
+*/}}
+{{- define "rmqco.clusterOperator.webhook.fullname" -}}
+{{- printf "%s-%s" (include "rmqco.clusterOperator.fullname" .) "webhook" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper RabbitMQ Cluster Operator webhook fullname adding the installation's namespace.
+*/}}
+{{- define "rmqco.clusterOperator.webhook.fullname.namespace" -}}
+{{- printf "%s-%s" (include "rmqco.clusterOperator.webhook.fullname" .) (include "cloudpirates.namespace" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the name of the secret holding the RabbitMQ Cluster Operator webhook certificates.
+*/}}
+{{- define "rmqco.clusterOperator.webhook.secretName" -}}
+{{- if .Values.clusterOperator.webhook.existingWebhookCertSecret -}}
+    {{- .Values.clusterOperator.webhook.existingWebhookCertSecret -}}
+{{- else -}}
+    {{- include "rmqco.clusterOperator.webhook.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common labels for rmq-messaging-topology-operator
 */}}
 {{- define "rmqmto.labels" -}}

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/certificate.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/certificate.yaml
@@ -1,0 +1,21 @@
+{{- if and (.Values.clusterOperator.webhook.enabled) (.Values.useCertManager) (not .Values.clusterOperator.webhook.existingWebhookCertSecret) }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "rmqco.labels" . | nindent 4 }}
+  name: {{ template "rmqco.clusterOperator.webhook.fullname" . }}
+  namespace: {{ include "cloudpirates.namespace" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  commonName: {{ template "rmqco.clusterOperator.webhook.fullname" . }}
+  dnsNames:
+    - {{ printf "%s.%s.svc" (include "rmqco.clusterOperator.webhook.fullname" .) (include "cloudpirates.namespace" .) }}
+    - {{ printf "%s.%s.svc.%s" (include "rmqco.clusterOperator.webhook.fullname" .) (include "cloudpirates.namespace" .) .Values.clusterDomain }}
+  issuerRef:
+    kind: Issuer
+    name: {{ template "cloudpirates.fullname" . }}
+  secretName: {{ template "rmqco.clusterOperator.webhook.fullname" . }}
+{{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
@@ -145,6 +145,7 @@ rules:
       - rabbitmqclusters/status
     verbs:
       - get
+      - patch
       - update
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -93,6 +93,10 @@ spec:
             - name: OPERATOR_SCOPE_NAMESPACE
               value: {{ join "," $watchNamespaces | quote }}
             {{- end }}
+            {{- if not .Values.clusterOperator.webhook.enabled }}
+            - name: ENABLE_WEBHOOKS
+              value: "false"
+            {{- end }}
             - name: DEFAULT_RABBITMQ_IMAGE
               value: {{ include "rmqco.rabbitmq.image" . }}
             - name: DEFAULT_USER_UPDATER_IMAGE
@@ -145,8 +149,16 @@ spec:
           {{- if .Values.clusterOperator.lifecycleHooks }}
           lifecycle: {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.clusterOperator.extraVolumeMounts }}
-          volumeMounts: {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- if or .Values.clusterOperator.webhook.enabled .Values.clusterOperator.extraVolumeMounts }}
+          volumeMounts:
+            {{- if .Values.clusterOperator.webhook.enabled }}
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+            {{- end }}
+            {{- if .Values.clusterOperator.extraVolumeMounts }}
+            {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -155,9 +167,23 @@ spec:
             - name: health
               containerPort: {{ .Values.clusterOperator.containerPorts.health }}
               protocol: TCP
+            {{- if .Values.clusterOperator.webhook.enabled }}
+            - name: webhook-server
+              containerPort: 9443
+              protocol: TCP
+            {{- end }}
         {{- if .Values.clusterOperator.sidecars }}
         {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.clusterOperator.sidecars "context" $) | nindent 8 }}
         {{- end }}
-      {{- if .Values.clusterOperator.extraVolumes }}
-      volumes: {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.extraVolumes "context" $) | nindent 8 }}
+      {{- if or .Values.clusterOperator.webhook.enabled .Values.clusterOperator.extraVolumes }}
+      volumes:
+        {{- if .Values.clusterOperator.webhook.enabled }}
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: {{ template "rmqco.clusterOperator.webhook.secretName" . }}
+        {{- end }}
+        {{- if .Values.clusterOperator.extraVolumes }}
+        {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/networkpolicy.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/networkpolicy.yaml
@@ -57,6 +57,11 @@ spec:
   ingress:
     - ports:
         - port: {{ .Values.clusterOperator.containerPorts.health }}
+    {{- if .Values.clusterOperator.webhook.enabled }}
+    # Allow the kube-apiserver to reach the admission webhook server
+    - ports:
+        - port: 9443
+    {{- end }}
     {{- if .Values.clusterOperator.metrics.service.enabled }}
     - ports:
         - port: {{ .Values.clusterOperator.containerPorts.metrics }}

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/role.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/role.yaml
@@ -11,6 +11,18 @@ metadata:
   {{- end }}
 rules:
   - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
@@ -28,4 +40,5 @@ rules:
       - events
     verbs:
       - create
+      - patch
 {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/webhook-configuration.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/webhook-configuration.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.clusterOperator.webhook.enabled }}
+{{/*
+    If the user does not have cert-manager and is not providing a secret with the certificates, the chart needs to generate the secret
+  */}}
+{{- $secretName := printf "%s" (include "rmqco.clusterOperator.webhook.secretName" .) }}
+{{- $ca := genCA "rmq-cluster-operator-ca" 365 }}
+{{- $cert := genSignedCert (include "rmqco.clusterOperator.webhook.fullname" .) nil (list (printf "%s.%s.svc" (include "rmqco.clusterOperator.webhook.fullname" .) (include "cloudpirates.namespace" .)) (printf "%s.%s.svc.%s" (include "rmqco.clusterOperator.webhook.fullname" .) (include "cloudpirates.namespace" .) .Values.clusterDomain)) 365 $ca }}
+{{- if and (not .Values.useCertManager) (not .Values.clusterOperator.webhook.existingWebhookCertSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ include "cloudpirates.namespace" . }}
+  labels:
+    {{- include "rmqco.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ include "cloudpirates.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "cloudpirates.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "cloudpirates.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
+{{- end }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "rmqco.labels" . | nindent 4 }}
+  annotations:
+    {{- if and (.Values.useCertManager) (not .Values.clusterOperator.webhook.existingWebhookCertSecret) }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" (include "cloudpirates.namespace" .) ( include "rmqco.clusterOperator.webhook.secretName" . ) }}
+    {{- else if and (.Values.useCertManager) (.Values.clusterOperator.webhook.existingWebhookCertSecret) }}
+    cert-manager.io/inject-ca-from-secret: {{ printf "%s/%s" (include "cloudpirates.namespace" .) ( include "rmqco.clusterOperator.webhook.secretName" . ) }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ printf "%s-mutating" (include "rmqco.clusterOperator.webhook.fullname.namespace" .) }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      {{- if not .Values.useCertManager }}
+      caBundle: {{ include "cloudpirates.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.clusterOperator.webhook.existingWebhookCertCABundle) "context" $) }}
+      {{- end }}
+      service:
+        name: {{ template "rmqco.clusterOperator.webhook.fullname" . }}
+        namespace: {{ include "cloudpirates.namespace" . }}
+        path: /mutate-rabbitmq-com-v1beta1-rabbitmqcluster
+        port: {{ .Values.clusterOperator.webhook.service.port }}
+    failurePolicy: Fail
+    name: mrabbitmqcluster-v1beta1.kb.io
+    rules:
+      - apiGroups:
+          - rabbitmq.com
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - rabbitmqclusters
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "rmqco.labels" . | nindent 4 }}
+  annotations:
+    {{- if and (.Values.useCertManager) (not .Values.clusterOperator.webhook.existingWebhookCertSecret) }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" (include "cloudpirates.namespace" .) ( include "rmqco.clusterOperator.webhook.secretName" . ) }}
+    {{- else if and (.Values.useCertManager) (.Values.clusterOperator.webhook.existingWebhookCertSecret) }}
+    cert-manager.io/inject-ca-from-secret: {{ printf "%s/%s" (include "cloudpirates.namespace" .) ( include "rmqco.clusterOperator.webhook.secretName" . ) }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ printf "%s-validating" (include "rmqco.clusterOperator.webhook.fullname.namespace" .) }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      {{- if not .Values.useCertManager }}
+      caBundle: {{ include "cloudpirates.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.clusterOperator.webhook.existingWebhookCertCABundle) "context" $) }}
+      {{- end }}
+      service:
+        name: {{ template "rmqco.clusterOperator.webhook.fullname" . }}
+        namespace: {{ include "cloudpirates.namespace" . }}
+        path: /validate-rabbitmq-com-v1beta1-rabbitmqcluster
+        port: {{ .Values.clusterOperator.webhook.service.port }}
+    failurePolicy: Fail
+    name: vrabbitmqcluster-v1beta1.kb.io
+    rules:
+      - apiGroups:
+          - rabbitmq.com
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - rabbitmqclusters
+    sideEffects: None
+{{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/webhook-service.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/webhook-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.clusterOperator.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "rmqco.labels" . | nindent 4 }}
+  name: {{ template "rmqco.clusterOperator.webhook.fullname" . }}
+  namespace: {{ include "cloudpirates.namespace" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.clusterOperator.webhook.service.type }}
+  ports:
+    - name: https
+      port: {{ .Values.clusterOperator.webhook.service.port }}
+      targetPort: webhook-server
+      protocol: TCP
+  selector:
+    {{- include "rmqco.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq-operator
+{{- end }}

--- a/charts/rabbitmq-cluster-operator/tests/cluster_operator_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/cluster_operator_test.yaml
@@ -11,6 +11,9 @@ templates:
   - templates/cluster-operator/metrics-service.yaml
   - templates/cluster-operator/podmonitor.yaml
   - templates/cluster-operator/servicemonitor.yaml
+  - templates/cluster-operator/webhook-service.yaml
+  - templates/cluster-operator/webhook-configuration.yaml
+  - templates/cluster-operator/certificate.yaml
 
 tests:
   - it: should render cluster operator deployment with default values
@@ -286,6 +289,85 @@ tests:
       - isNull:
           path: spec.template.spec.securityContext.enabled
         template: templates/cluster-operator/deployment.yaml
+
+  - it: should disable the webhook by default (ENABLE_WEBHOOKS=false, no webhook resources)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_WEBHOOKS
+            value: "false"
+        template: templates/cluster-operator/deployment.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: webhook-server
+            containerPort: 9443
+            protocol: TCP
+        template: templates/cluster-operator/deployment.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/cluster-operator/webhook-service.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/cluster-operator/webhook-configuration.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/cluster-operator/certificate.yaml
+
+  - it: should render the webhook when enabled
+    set:
+      clusterOperator.webhook.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENABLE_WEBHOOKS
+            value: "false"
+        template: templates/cluster-operator/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: webhook-server
+            containerPort: 9443
+            protocol: TCP
+        template: templates/cluster-operator/deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: cert
+            secret:
+              defaultMode: 420
+              secretName: RELEASE-NAME-rabbitmq-cluster-operator-webhook
+        template: templates/cluster-operator/deployment.yaml
+      - isKind:
+          of: Service
+        template: templates/cluster-operator/webhook-service.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rabbitmq-cluster-operator-webhook
+        template: templates/cluster-operator/webhook-service.yaml
+      - documentIndex: 1
+        isKind:
+          of: MutatingWebhookConfiguration
+        template: templates/cluster-operator/webhook-configuration.yaml
+      - documentIndex: 2
+        isKind:
+          of: ValidatingWebhookConfiguration
+        template: templates/cluster-operator/webhook-configuration.yaml
+
+  - it: should not generate a self-signed secret when using cert-manager
+    set:
+      clusterOperator.webhook.enabled: true
+      useCertManager: true
+    asserts:
+      - isKind:
+          of: Certificate
+        template: templates/cluster-operator/certificate.yaml
+      - documentIndex: 0
+        isKind:
+          of: MutatingWebhookConfiguration
+        template: templates/cluster-operator/webhook-configuration.yaml
 
   - it: should render cluster operator deployment with containerSecurityContext
     set:

--- a/charts/rabbitmq-cluster-operator/values.yaml
+++ b/charts/rabbitmq-cluster-operator/values.yaml
@@ -48,7 +48,7 @@ rabbitmqImage:
   ## @param rabbitmqImage.repository [default: REPOSITORY_NAME/rabbitmq] RabbitMQ Image repository
   repository: library/rabbitmq
   ## @skip rabbitmqImage.tag RabbitMQ Image tag (immutable tags are recommended)
-  tag: 4.2.6-management-alpine
+  tag: 4.3.2-management-alpine
   ## @param rabbitmqImage.digest RabbitMQ image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   digest: ""
   ## @param rabbitmqImage.pullSecrets RabbitMQ Image pull secrets
@@ -68,7 +68,7 @@ credentialUpdaterImage:
   ## @param credentialUpdaterImage.repository [default: REPOSITORY_NAME/rmq-default-credential-updater] RabbitMQ Default User Credential Updater image repository
   repository: rabbitmq/default-user-credential-updater
   ## @skip credentialUpdaterImage.tag RabbitMQ Default User Credential Updater image tag (immutable tags are recommended)
-  tag: 1.0.14
+  tag: 1.0.15
   ## @param credentialUpdaterImage.digest RabbitMQ Default User Credential Updater image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   digest: ""
   ## @param credentialUpdaterImage.pullSecrets RabbitMQ Default User Credential Updater image pull secrets
@@ -90,7 +90,7 @@ clusterOperator:
     ## @param clusterOperator.image.repository [default: REPOSITORY_NAME/rabbitmq-cluster-operator] RabbitMQ Cluster Operator image repository
     repository: rabbitmq/cluster-operator
     ## @skip clusterOperator.image.tag RabbitMQ Cluster Operator image tag (immutable tags are recommended)
-    tag: 2.21.0
+    tag: 2.22.1
     ## @param clusterOperator.image.digest RabbitMQ Cluster Operator image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     digest: ""
     ## @param clusterOperator.image.pullPolicy RabbitMQ Cluster Operator image pull policy
@@ -298,6 +298,25 @@ clusterOperator:
   ##    imagePullPolicy: Always
   ##    command: ['sh', '-c', 'echo "hello world"']
   initContainers: []
+  ## RabbitmqCluster admission webhook (cluster-operator v2.22.0+)
+  ## The cluster operator can run mutating (defaulting) and validating admission webhooks for RabbitmqCluster
+  ## resources. It is DISABLED by default: enabling it requires TLS serving certificates. When disabled, the
+  ## operator is started with ENABLE_WEBHOOKS=false (matching the chart's behavior prior to v2.22.0). When
+  ## enabled, provide certificates via a chart-generated self-signed secret (default), an existing secret, or
+  ## cert-manager (useCertManager=true). See the README for enablement instructions.
+  webhook:
+    ## @param clusterOperator.webhook.enabled Enable the RabbitmqCluster admission webhook (requires TLS serving certificates)
+    enabled: false
+    ## @param clusterOperator.webhook.existingWebhookCertSecret Name of an existing secret containing the webhook certificates (use it to avoid the chart generating one)
+    existingWebhookCertSecret: ""
+    ## @param clusterOperator.webhook.existingWebhookCertCABundle PEM-encoded CA Bundle of the existing secret provided in existingWebhookCertSecret (only if useCertManager=false)
+    existingWebhookCertCABundle: ""
+    ## Webhook service parameters
+    service:
+      ## @param clusterOperator.webhook.service.type RabbitMQ Cluster Operator webhook service type
+      type: ClusterIP
+      ## @param clusterOperator.webhook.service.port RabbitMQ Cluster Operator webhook service port
+      port: 443
   ## Network Policies
   ## Ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
   networkPolicy:
@@ -504,7 +523,7 @@ msgTopologyOperator:
     ## @param msgTopologyOperator.image.repository [default: REPOSITORY_NAME/rmq-messaging-topology-operator] RabbitMQ Messaging Topology Operator image repository
     repository: rabbitmq/messaging-topology-operator
     ## @skip msgTopologyOperator.image.tag RabbitMQ Messaging Topology Operator image tag (immutable tags are recommended)
-    tag: 1.19.2
+    tag: 1.19.3
     ## @param msgTopologyOperator.image.digest RabbitMQ Messaging Topology Operator image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     digest: ""
     ## Specify a imagePullPolicy


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change


- Bump cluster-operator to v2.22.1 and messaging-topology-operator to v1.19.3
-  Bump default RabbitMQ image to 4.3.2-management-alpine and default-user-credential-updater to v1.0.15
- Align cluster-operator RBAC with upstream v2.22.x: add the `patch` verb on `rabbitmqclusters/status`, and add the `configmaps` rule plus the `patch` verb on `events` to the namespaced leader-election Role
- Add an optional RabbitmqCluster admission webhook (mutating + validating) for the cluster operator, introduced upstream in v2.22.0. It is **disabled by default** (`clusterOperator.webhook.enabled=false`); when disabled the operator is started with `ENABLE_WEBHOOKS=false`, preserving the chart's pre-v2.22.0 behavior. See the "RabbitmqCluster admission webhook" section of the README for enablement instructions
- Refresh CRDs from upstream cluster-operator v2.22.1 (new `status.deprecatedFeaturesUsed` field) and messaging-topology-operator v1.19.3

### Benefits

Keeping up with upstream.

### Possible drawbacks

None that I'm aware of.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes N/A

### Additional information

New webhook can be set enabled by default. I don't have a strong preference here.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
