### PR TITLE
[valkey] Fix broken Sentinel preStop failover hook on Alpine image

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/prestop-configmap.yaml
+++ b/charts/valkey/templates/prestop-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 data:
   prestop.sh: |
-    #!/bin/bash
+    #!/bin/sh
 
     # Valkey master failover script for graceful shutdown
     # Based on Redis/Bitnami charts failover handling
@@ -24,7 +24,6 @@ data:
     SENTINEL_PORT="{{ .Values.sentinel.port }}"
     MASTER_NAME="{{ .Values.sentinel.masterName }}"
     HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
-    VALKEY_SERVICE="{{ include "valkey.fullname" . }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
 
     # Set authentication if enabled
     {{- if .Values.auth.enabled }}
@@ -40,14 +39,13 @@ data:
 
     # Function to run Valkey commands
     run_valkey_command() {
-        local args=("-h" "$VALKEY_LOOPBACK" "-p" "$VALKEY_PORT")
-        valkey-cli "${args[@]}" "$@"
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT" "$@"
     }
 
     # Function to check if current instance is master
     is_master() {
         VALKEY_ROLE=$(run_valkey_command role | head -1)
-        [[ "$VALKEY_ROLE" == "master" ]]
+        [ "$VALKEY_ROLE" = "master" ]
     }
 
     # Function to get full hostname for a pod
@@ -57,17 +55,16 @@ data:
         echo "${full_hostname}"
     }
 
-    # Function to run Sentinel commands
+    # Function to run Sentinel commands against the local Sentinel sidecar
     run_sentinel_command() {
-        valkey-cli -h "$VALKEY_SERVICE" -p "$SENTINEL_PORT" {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} sentinel "$@"
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$SENTINEL_PORT" {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} sentinel "$@"
     }
 
     # Function to check if sentinel failover has finished
     sentinel_failover_finished() {
-        VALKEY_SENTINEL_INFO=($(run_sentinel_command get-master-addr-by-name "$MASTER_NAME" 2>/dev/null || echo ""))
-        if [ ${#VALKEY_SENTINEL_INFO[@]} -ge 1 ]; then
-            VALKEY_MASTER_HOST="${VALKEY_SENTINEL_INFO[0]}"
-            [[ "$VALKEY_MASTER_HOST" != "$(get_full_hostname $HOSTNAME)" ]]
+        VALKEY_MASTER_HOST=$(run_sentinel_command get-master-addr-by-name "$MASTER_NAME" 2>/dev/null | head -1 || echo "")
+        if [ -n "$VALKEY_MASTER_HOST" ]; then
+            [ "$VALKEY_MASTER_HOST" != "$(get_full_hostname "$HOSTNAME")" ]
         else
             # If we can't get master info, assume failover is complete
             return 0
@@ -76,17 +73,17 @@ data:
 
     # Function to wait with retries
     retry_while() {
-        local condition="$1"
-        local max_attempts="$2"
-        local sleep_time="$3"
-        local attempt=0
+        condition="$1"
+        max_attempts="$2"
+        sleep_time="$3"
+        attempt=0
 
-        while [ $attempt -lt $max_attempts ]; do
+        while [ "$attempt" -lt "$max_attempts" ]; do
             if $condition; then
                 return 0
             fi
             sleep "$sleep_time"
-            ((attempt++))
+            attempt=$((attempt + 1))
         done
         return 1
     }

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -315,7 +315,7 @@ spec:
             preStop:
               exec:
                 command:
-                  - /bin/bash
+                  - /bin/sh
                   - /scripts/prestop.sh
           {{- end }}
           resources:


### PR DESCRIPTION
### Description of the change

The Sentinel `preStop` hook in the valkey chart is supposed to gracefully hand
off the master on shutdown (`CLIENT PAUSE` → `SENTINEL FAILOVER` → wait), but on
the default Alpine image it never actually runs. There are two separate problems
(both reported in #1411):

First, the hook is invoked with `/bin/bash`, and the default
`valkey/valkey:*-alpine` image doesn't have bash, only `/bin/sh` (BusyBox ash).
So kubelet just fails the hook with `exec: "/bin/bash": no such file or
directory`. On top of that, `prestop.sh` itself was written in bash (arrays,
`[[ ]]`, `(( ))`), so pointing it at `/bin/sh` wasn't enough on its own, the
script is rewritten to be POSIX sh.

Second, even once the script runs, the Sentinel calls go to the main Service on
port 26379, but that Service only exposes the Valkey port. 26379 only lives on
the `-headless` and `-sentinel` Services, so `SENTINEL FAILOVER` and
`get-master-addr-by-name` were talking to nothing. Those calls now go to the
local Sentinel sidecar (`127.0.0.1`/`::1`), which is always in the same pod and
actually serves 26379.

Also bumps the chart `0.23.0` → `0.23.1`.

### Benefits

Graceful master handoff on a planned shutdown finally works on a default Alpine +
Sentinel install. No more `FailedPreStopHook` events on every master rollout, and
no more write outage while Sentinel waits to notice the master is gone on its own.

### Possible drawbacks

Nothing for a default install, the hook and configmap still only render with
`architecture: replication` and `sentinel.enabled: true`, and no defaults change.

### Applicable issues

- fixes #1411

### Additional information

Checked a few ways before opening: `helm template`/`helm lint` are clean and the
rendered command is `/bin/sh /scripts/prestop.sh`; the rendered `prestop.sh`
passes both `sh -n` and strict-POSIX `dash -n`; and the whole script was run under
`dash` with a stubbed `valkey-cli` to confirm the
detect-master → pause → failover → wait-for-new-master flow runs end to end.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified
