### PR TITLE
[valkey] Add Sentinel preStop parity for zero-downtime rolling updates

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.23.1
+version: 0.24.0
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.23.0
+version: 0.23.1
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -239,6 +239,7 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 | `startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe           | `1`     |
 | `startupProbe.failureThreshold`      | Failure threshold for startupProbe         | `30`    |
 | `startupProbe.successThreshold`      | Success threshold for startupProbe         | `1`     |
+| `terminationGracePeriodSeconds`      | Seconds Kubernetes waits for the pod to terminate gracefully (raise to ~60 for Sentinel) | `30` |
 
 ### Node Selection
 
@@ -297,6 +298,8 @@ Sentinel provides high availability for Valkey replication. When enabled, Sentin
 | `sentinel.service.type`              | Kubernetes service type for Sentinel                                                | `ClusterIP`                                                                                  |
 | `sentinel.service.port`              | Sentinel service port                                                               | `26379`                                                                                      |
 | `sentinel.resources`                 | Resource limits and requests for Sentinel container                                 | `{}`                                                                                         |
+| `sentinel.valkeyShutdownWaitFailover` | Whether the Valkey container waits for Sentinel failover before shutting down       | `true`                                                                                       |
+| `sentinel.preStop.enabled`           | Enable the preStop hook on the Sentinel container                                    | `true`                                                                                       |
 
 ### Init Container Configuration
 
@@ -424,12 +427,22 @@ sentinel:
   downAfterMilliseconds: 1500
   failoverTimeout: 15000
   parallelSyncs: 1
+  # Graceful master handoff on planned shutdown / rolling updates:
+  # the Valkey container triggers a failover and waits for it, and the
+  # Sentinel container stays up until failover completes so clients can
+  # still discover the new master while the pod terminates.
+  valkeyShutdownWaitFailover: true
+  preStop:
+    enabled: true
   resources:
     limits:
       memory: 128Mi
     requests:
       cpu: 25m
       memory: 64Mi
+
+# Give the preStop failover hook enough time to finish before SIGKILL
+terminationGracePeriodSeconds: 60
 
 # Enable authentication
 auth:

--- a/charts/valkey/templates/prestop-configmap.yaml
+++ b/charts/valkey/templates/prestop-configmap.yaml
@@ -90,8 +90,11 @@ data:
 
     echo "Valkey preStop hook starting for pod: $HOSTNAME"
 
+    # Whether to wait for failover on master shutdown (sentinel.valkeyShutdownWaitFailover)
+    WAIT_FOR_FAILOVER="{{ .Values.sentinel.valkeyShutdownWaitFailover }}"
+
     # Only proceed with failover if this instance is the master
-    if is_master; then
+    if is_master && [ "$WAIT_FOR_FAILOVER" = "true" ]; then
         echo "I am the master pod and I'm being stopped. Initiating graceful failover."
 
         # Pause client write connections to prevent data loss during failover
@@ -122,10 +125,112 @@ data:
         echo "Allowing additional time for new master to stabilize..."
         sleep 3
 
+    elif is_master; then
+        echo "I am the master but sentinel.valkeyShutdownWaitFailover is disabled, skipping failover wait"
     else
         echo "I am not the master, no failover needed"
     fi
 
     echo "Valkey preStop hook completed"
     exit 0
+  {{- if .Values.sentinel.preStop.enabled }}
+  prestop-sentinel.sh: |
+    #!/bin/sh
+
+    # Valkey Sentinel preStop hook for graceful shutdown during rolling updates.
+    # Keeps the local Sentinel alive until failover completes, so clients can
+    # still use it to discover the new master while this pod is terminating.
+
+    set -e
+
+    # Configuration
+    VALKEY_PORT="{{ .Values.service.port }}"
+    SENTINEL_PORT="{{ .Values.sentinel.port }}"
+    MASTER_NAME="{{ .Values.sentinel.masterName }}"
+    HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+
+    # Set authentication if enabled
+    {{- if .Values.auth.enabled }}
+    export REDISCLI_AUTH="${VALKEY_PASSWORD}"
+    {{- end }}
+
+    # Set loopback address based on ipFamily configuration
+    {{- if eq .Values.ipFamily "ipv6" }}
+    VALKEY_LOOPBACK="::1"
+    {{- else }}
+    VALKEY_LOOPBACK="127.0.0.1"
+    {{- end }}
+
+    # Function to run Valkey commands against the local instance
+    run_valkey_command() {
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT" "$@"
+    }
+
+    # Function to run Sentinel commands against the local Sentinel sidecar
+    run_sentinel_command() {
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$SENTINEL_PORT" {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} sentinel "$@"
+    }
+
+    # Function to get full hostname for a pod
+    get_full_hostname() {
+        echo "${1}.${HEADLESS_SERVICE}"
+    }
+
+    # Function to check if the local Valkey instance is master
+    is_valkey_master() {
+        VALKEY_ROLE=$(run_valkey_command role 2>/dev/null | head -1 || echo "")
+        [ "$VALKEY_ROLE" = "master" ]
+    }
+
+    # Function to check if sentinel failover has finished
+    sentinel_failover_finished() {
+        VALKEY_MASTER_HOST=$(run_sentinel_command get-master-addr-by-name "$MASTER_NAME" 2>/dev/null | head -1 || echo "")
+        if [ -n "$VALKEY_MASTER_HOST" ]; then
+            [ "$VALKEY_MASTER_HOST" != "$(get_full_hostname "$HOSTNAME")" ]
+        else
+            # Could not verify, assume failover is not finished yet and keep waiting
+            return 1
+        fi
+    }
+
+    # Function to wait with retries
+    retry_while() {
+        condition="$1"
+        max_attempts="$2"
+        sleep_time="$3"
+        attempt=0
+
+        while [ "$attempt" -lt "$max_attempts" ]; do
+            if $condition; then
+                return 0
+            fi
+            sleep "$sleep_time"
+            attempt=$((attempt + 1))
+        done
+        return 1
+    }
+
+    echo "Valkey Sentinel preStop hook starting for pod: $HOSTNAME"
+
+    # If the local Valkey is master, keep Sentinel up until failover completes so
+    # clients can still discover the new master through it.
+    if is_valkey_master; then
+        echo "Local Valkey is master. Waiting for failover to complete before Sentinel shuts down..."
+        if retry_while "sentinel_failover_finished" "25" "1"; then
+            echo "Failover completed, new master elected"
+        else
+            echo "Warning: Failover may still be in progress"
+        fi
+
+        # Additional delay to give clients time to discover the new master
+        echo "Allowing additional time for client discovery..."
+        sleep 5
+    else
+        echo "Local Valkey is replica, waiting briefly for stability..."
+        sleep 2
+    fi
+
+    echo "Valkey Sentinel preStop hook completed"
+    exit 0
+  {{- end }}
 {{- end }}

--- a/charts/valkey/templates/prestop-configmap.yaml
+++ b/charts/valkey/templates/prestop-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 data:
   prestop.sh: |
-    #!/bin/bash
+    #!/bin/sh
 
     # Valkey master failover script for graceful shutdown
     # Based on Redis/Bitnami charts failover handling
@@ -24,7 +24,6 @@ data:
     SENTINEL_PORT="{{ .Values.sentinel.port }}"
     MASTER_NAME="{{ .Values.sentinel.masterName }}"
     HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
-    VALKEY_SERVICE="{{ include "valkey.fullname" . }}.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
 
     # Set authentication if enabled
     {{- if .Values.auth.enabled }}
@@ -40,14 +39,13 @@ data:
 
     # Function to run Valkey commands
     run_valkey_command() {
-        local args=("-h" "$VALKEY_LOOPBACK" "-p" "$VALKEY_PORT")
-        valkey-cli "${args[@]}" "$@"
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT" "$@"
     }
 
     # Function to check if current instance is master
     is_master() {
         VALKEY_ROLE=$(run_valkey_command role | head -1)
-        [[ "$VALKEY_ROLE" == "master" ]]
+        [ "$VALKEY_ROLE" = "master" ]
     }
 
     # Function to get full hostname for a pod
@@ -57,17 +55,16 @@ data:
         echo "${full_hostname}"
     }
 
-    # Function to run Sentinel commands
+    # Function to run Sentinel commands against the local Sentinel sidecar
     run_sentinel_command() {
-        valkey-cli -h "$VALKEY_SERVICE" -p "$SENTINEL_PORT" {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} sentinel "$@"
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$SENTINEL_PORT" {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} sentinel "$@"
     }
 
     # Function to check if sentinel failover has finished
     sentinel_failover_finished() {
-        VALKEY_SENTINEL_INFO=($(run_sentinel_command get-master-addr-by-name "$MASTER_NAME" 2>/dev/null || echo ""))
-        if [ ${#VALKEY_SENTINEL_INFO[@]} -ge 1 ]; then
-            VALKEY_MASTER_HOST="${VALKEY_SENTINEL_INFO[0]}"
-            [[ "$VALKEY_MASTER_HOST" != "$(get_full_hostname $HOSTNAME)" ]]
+        VALKEY_MASTER_HOST=$(run_sentinel_command get-master-addr-by-name "$MASTER_NAME" 2>/dev/null | head -1 || echo "")
+        if [ -n "$VALKEY_MASTER_HOST" ]; then
+            [ "$VALKEY_MASTER_HOST" != "$(get_full_hostname "$HOSTNAME")" ]
         else
             # If we can't get master info, assume failover is complete
             return 0
@@ -76,17 +73,17 @@ data:
 
     # Function to wait with retries
     retry_while() {
-        local condition="$1"
-        local max_attempts="$2"
-        local sleep_time="$3"
-        local attempt=0
+        condition="$1"
+        max_attempts="$2"
+        sleep_time="$3"
+        attempt=0
 
-        while [ $attempt -lt $max_attempts ]; do
+        while [ "$attempt" -lt "$max_attempts" ]; do
             if $condition; then
                 return 0
             fi
             sleep "$sleep_time"
-            ((attempt++))
+            attempt=$((attempt + 1))
         done
         return 1
     }

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -315,7 +315,7 @@ spec:
             preStop:
               exec:
                 command:
-                  - /bin/bash
+                  - /bin/sh
                   - /scripts/prestop.sh
           {{- end }}
           resources:

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -350,6 +350,11 @@ spec:
           volumeMounts:
             - name: sentinel-config
               mountPath: /tmp
+            {{- if .Values.sentinel.preStop.enabled }}
+            - name: prestop-script
+              mountPath: /scripts
+              readOnly: true
+            {{- end }}
           {{- if .Values.sentinel.extraVolumeMounts }}
             {{- toYaml .Values.sentinel.extraVolumeMounts | nindent 12 }}
           {{- end }}
@@ -510,6 +515,14 @@ spec:
                   name: {{ include "valkey.secretName" . }}
                   key: {{ include "valkey.passwordKey" . }}
           {{- end }}
+          {{- if .Values.sentinel.preStop.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - /scripts/prestop-sentinel.sh
+          {{- end }}
           resources: {{- toYaml .Values.sentinel.resources | nindent 12 }}
         {{- end }}
         {{- if .Values.metrics.enabled }}
@@ -607,6 +620,7 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
   {{- if .Values.persistentVolumeClaimRetentionPolicy.enabled }}
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: {{ .Values.persistentVolumeClaimRetentionPolicy.whenDeleted }}

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -542,6 +542,14 @@
                 "port": {
                     "type": "integer"
                 },
+                "preStop": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "quorum": {
                     "type": "integer"
                 },
@@ -558,6 +566,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "valkeyShutdownWaitFailover": {
+                    "type": "boolean"
                 }
             }
         },
@@ -617,6 +628,9 @@
                     "type": "integer"
                 }
             }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": "integer"
         },
         "tls": {
             "type": "object",

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -311,6 +311,12 @@ startupProbe:
   ## @param startupProbe.successThreshold Success threshold for startupProbe
   successThreshold: 1
 
+## @param terminationGracePeriodSeconds Seconds Kubernetes waits for the pod to terminate gracefully
+## When Sentinel is enabled this must be high enough for the preStop failover to
+## finish (the hook can take ~45s: 20s failover wait + Sentinel preStop wait).
+## Recommended: 60 for Sentinel setups.
+terminationGracePeriodSeconds: 30
+
 ## @section Node Selection
 ## @param nodeSelector Node labels for pod assignment
 nodeSelector: {}
@@ -455,6 +461,17 @@ sentinel:
     # requests:
     #   cpu: 25m
     #   memory: 64Mi
+  ## @param sentinel.valkeyShutdownWaitFailover Whether the Valkey container should wait for Sentinel failover before shutting down
+  ## When true: on master termination the preStop hook triggers a failover and
+  ## waits for it to complete (graceful, near zero-downtime handoff).
+  ## When false: the Valkey container shuts down immediately without waiting.
+  valkeyShutdownWaitFailover: true
+  ## Sentinel container preStop hook for zero-downtime rolling updates.
+  ## Keeps the local Sentinel alive until failover completes so clients can still
+  ## use it to discover the new master while the pod is terminating.
+  preStop:
+    ## @param sentinel.preStop.enabled Enable the preStop hook on the Sentinel container
+    enabled: true
 
 ## @param resources Resource limits and requests for Valkey init container pod
 initContainer:


### PR DESCRIPTION
### Description of the change

This is a follow-up to #1421. That PR got the valkey Sentinel `preStop` hook
working again; this one goes a step further and brings over the zero-downtime
handling that #781 added to the redis chart, so that a planned master rollout
hands the master off cleanly instead of waiting for Sentinel to notice it's gone.

The gap today: when the master pod is terminated, the Valkey container runs its
failover hook, but the Sentinel sidecar next to it gets SIGTERM'd at the same
time and can die before the failover finishes, so clients briefly have nothing
to ask for the new master. And the pod's grace period isn't configurable, so a
slow handoff can get cut off by SIGKILL.

So this adds the following, all only when `architecture: replication` and
`sentinel.enabled` are set:

- `sentinel.preStop.enabled` (default true): a preStop hook on the Sentinel
  container that keeps it alive until failover completes. It's POSIX sh like the
  other hook, so it runs on the default Alpine image.
- `sentinel.valkeyShutdownWaitFailover` (default true): a switch to turn off the
  Valkey container's failover wait if you'd rather it just shut down.
- `terminationGracePeriodSeconds` (default 30): now configurable so the pod
  isn't killed mid-handoff. 60 is a good value with Sentinel.

Bumps the chart 0.23.1 -> 0.24.0 and updates values.yaml, the schema, the README
tables and the HA example.

Heads up: this is stacked on #1421, so until that one merges the diff here also
includes the fix commit.

### Benefits

Rolling the master pod (say, an image bump) now hands off with basically no
client-visible downtime instead of a write stall while Sentinel waits out
`down-after-milliseconds`. The Sentinel sidecar stays up through the failover,
and you can give the whole thing enough time with `terminationGracePeriodSeconds`.

### Possible drawbacks

Because the hooks are on by default, shutting down the master pod now takes a bit
longer when Sentinel is enabled. That's the whole point (it's waiting for the
handoff), and you can opt out with the two switches above. Standalone and
non-Sentinel installs are unaffected.

### Applicable issues

- relates to #1411 (suggestion 3), ports #781 to valkey

### Additional information

Tested on a local minikube cluster with replication + Sentinel and 3 replicas:
both hooks are mounted and wired, the grace period is applied, running the hook
drives `CLIENT PAUSE` -> `SENTINEL FAILOVER` -> completion against the local
sidecar, and deleting the master pod fails over cleanly with zero
`FailedPreStopHook` events. `helm lint`, `helm unittest`, and `sh -n`/`dash -n`
on both scripts all pass.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified
