### PR TITLE
[valkey] exec valkey-server/valkey-sentinel so SIGTERM reaches the process

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.24.0
+version: 0.24.1
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -250,7 +250,7 @@ spec:
               CONFIG_FILE="{{ include "valkey.configFullName" . }}"
               {{- end }}
 
-              valkey-server "$CONFIG_FILE" {{- if .Values.auth.enabled }} --requirepass "${VALKEY_PASSWORD}" {{- end }}
+              exec valkey-server "$CONFIG_FILE" {{- if .Values.auth.enabled }} --requirepass "${VALKEY_PASSWORD}" {{- end }}
           ports:
             - name: valkey
               containerPort: {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.targetPort }}{{ end }}
@@ -487,7 +487,7 @@ spec:
               echo "Starting Sentinel with config:"
               cat /tmp/sentinel.conf
 
-              valkey-sentinel /tmp/sentinel.conf
+              exec valkey-sentinel /tmp/sentinel.conf
           ports:
             - name: sentinel
               containerPort: {{ .Values.sentinel.port }}


### PR DESCRIPTION
### Description of the change

The `valkey` and `sentinel` containers start their main process as a child of
`/bin/sh` — the command is a multi-statement `sh -c` script, so the shell is
**not** replaced by the final process and stays PID 1. A non-interactive shell
blocked in `wait` does not forward `SIGTERM` to its child and does not exit
until the child does, so `valkey-server` / `valkey-sentinel` never receive the
shutdown signal. The pod then rides out the full `terminationGracePeriodSeconds`
and is `SIGKILL`ed at the deadline.

Verified with `ps` inside a running pod (Alpine image):

```
# valkey container            # sentinel container         # metrics (control)
PID  PPID  COMMAND            PID  PPID  COMMAND           PID  PPID  COMMAND
  1    0   sh                   1    0   sh                  1    0   redis_exporter
  8    1   valkey-server       28    1   valkey-sentinel
```

`metrics` execs its process via the image ENTRYPOINT and shuts down instantly;
`valkey` and `sentinel` always wait the whole grace period.

The fix prefixes both final commands with `exec` so the process replaces the
shell and becomes PID 1. Both are the last statement in their respective
scripts, so `exec` is safe (nothing runs afterwards).

```diff
- valkey-server "$CONFIG_FILE" {{- if .Values.auth.enabled }} --requirepass "${VALKEY_PASSWORD}" {{- end }}
+ exec valkey-server "$CONFIG_FILE" {{- if .Values.auth.enabled }} --requirepass "${VALKEY_PASSWORD}" {{- end }}

- valkey-sentinel /tmp/sentinel.conf
+ exec valkey-sentinel /tmp/sentinel.conf
```

### Benefits

- Rolling updates no longer wait the full `terminationGracePeriodSeconds` per
  pod — `valkey-server` / `valkey-sentinel` receive `SIGTERM` and shut down
  promptly and gracefully instead of being `SIGKILL`ed.
- Complements the preStop work in #1421 / #1422: the graceful failover hook runs
  before `SIGTERM`, and now the process itself also exits cleanly afterwards.

### Possible drawbacks

None expected. `exec` is the last statement in both scripts, so no subsequent
shell logic is skipped. Behavior is otherwise identical.

### Applicable issues

- fixes #1424

### Additional information

Tested on a 3-node `architecture: replication` + `sentinel.enabled: true`
cluster: `helm lint` passes, `helm template` renders `exec valkey-server` /
`exec valkey-sentinel` for both standalone and replication, and after the change
a `kubectl delete pod` / `rollout restart` terminates pods in a few seconds
instead of the full grace period, with no `FailedPreStopHook` events.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/) (0.24.0 -> 0.24.1).
- [x] No new variables (no `values.yaml` / `README.md` changes needed).
- [x] Title of the pull request follows this pattern `[<name_of_the_chart>] Descriptive title`.
