### PR TITLE
[keycloak] Add configurable pod termination settings

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.14
+version: 0.21.15
 appVersion: "26.7.0"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -109,9 +109,11 @@ The following table lists the configurable parameters of the Keycloak chart and 
 
 ### Pod configuration
 
-| Parameter               | Description                                                    | Default |
-| ----------------------- | -------------------------------------------------------------- | ------- |
-| `shareProcessNamespace` | Enable process namespace sharing between containers in the pod | `false` |
+| Parameter                       | Description                                                                                         | Default |
+| ------------------------------- | --------------------------------------------------------------------------------------------------- | ------- |
+| `shareProcessNamespace`         | Enable process namespace sharing between containers in the pod                                      | `false` |
+| `terminationGracePeriodSeconds` | Seconds Kubernetes waits for the Keycloak pod to terminate. Leave empty to use the Kubernetes default | `""`    |
+| `lifecycle`                     | Lifecycle hooks for the Keycloak container                                                            | `{}`    |
 
 ### Extra volumes and volumes mount
 

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -37,6 +37,9 @@ spec:
       {{- with .Values.shareProcessNamespace }}
       shareProcessNamespace: {{ . }}
       {{- end }}
+      {{- if ne (toString .Values.terminationGracePeriodSeconds) "" }}
+      terminationGracePeriodSeconds: {{ int .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       initContainers:
         - name: copy-quarkus-lib
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
@@ -73,6 +76,10 @@ spec:
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "keycloak.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
           command:
             - {{ .Values.image.command }}
           args:

--- a/charts/keycloak/tests/statefulset-parameters_test.yaml
+++ b/charts/keycloak/tests/statefulset-parameters_test.yaml
@@ -2,6 +2,46 @@ suite: test service account
 templates:
   - templates/statefulset.yaml
 tests:
+  - it: should not render pod termination settings by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.terminationGracePeriodSeconds
+      - isNull:
+          path: spec.template.spec.containers[0].lifecycle
+
+  - it: should render a custom termination grace period
+    set:
+      terminationGracePeriodSeconds: 45
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 45
+
+  - it: should render a zero-second termination grace period
+    set:
+      terminationGracePeriodSeconds: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 0
+
+  - it: should render custom container lifecycle hooks
+    set:
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - sleep 15
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 15
+
   - it: liveness probe should use /health/live
     asserts:
       - equal:

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -402,6 +402,9 @@
                 }
             }
         },
+        "lifecycle": {
+            "type": "object"
+        },
         "livenessProbe": {
             "type": "object",
             "properties": {
@@ -735,6 +738,14 @@
                     "type": "integer"
                 }
             }
+        },
+        "terminationGracePeriodSeconds": {
+            "type": [
+                "integer",
+                "string"
+            ],
+            "minimum": 0,
+            "pattern": "^$"
         },
         "tls": {
             "type": "object",

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -43,6 +43,10 @@ podLabels: {}
 ## @section Pod configuration
 ## @param shareProcessNamespace Enable process namespace sharing between containers in the pod
 shareProcessNamespace: false
+## @param terminationGracePeriodSeconds Seconds Kubernetes waits for the Keycloak pod to terminate. Leave empty to use the Kubernetes default
+terminationGracePeriodSeconds: "" # @schema type:[integer, string]; minimum:0; pattern:^$
+## @param lifecycle Lifecycle hooks for the Keycloak container
+lifecycle: {}
 
 ## @section extra volumes and volumes mount
 ## @param extraVolumes Optionally specify extra list of additional volumes for Keycloak pod


### PR DESCRIPTION
### Description of the change

Add configurable pod termination settings to the Keycloak chart:

- Add `terminationGracePeriodSeconds` at the pod level.
- Add `lifecycle` hooks to the main Keycloak container.
- Keep both settings disabled by default using `""` and `{}`.
- Update the generated values schema and chart documentation.
- Add unit tests covering default values, custom grace periods, zero seconds, and `preStop` lifecycle hooks.
- Bump the chart patch version from `0.21.14` to `0.21.15`.

### Benefits

These settings allow users to configure graceful Keycloak shutdown behavior during Kubernetes rolling updates and Helm
upgrades.

A `preStop` lifecycle hook can give ingress controllers, service meshes, and Kubernetes endpoints time to stop routing new
requests before the container exits. A configurable termination grace period gives Keycloak enough time to complete in-flight
requests and shut down cleanly.

This can reduce authentication errors and temporary downtime during deployments.

### Possible drawbacks

Incorrect lifecycle hooks or termination grace periods may increase pod shutdown duration or cause forced termination.

The lifecycle configuration is passed directly to the Kubernetes container specification. Users are responsible for providing
valid Kubernetes lifecycle hooks.

### Applicable issues

N/A

### Additional information

Validation performed:

- `helm lint charts/keycloak`
- `helm unittest charts/keycloak`
- 58 unit tests passed
- `./test-charts.sh --create-cluster --skip-install keycloak`

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the
changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../
CONTRIBUTING.md#setting-up-your-development-environment))