### PR TITLE
[nginx] Fix custom port README example

### DIFF
--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -57,6 +57,10 @@ To run Nginx on port 8080 with matching health checks:
 
 ```yaml
 # my-values.yaml
+containerPorts:
+  - name: http
+    containerPort: 8080
+    protocol: TCP
 serverConfig: |
   server {
     listen 0.0.0.0:8080;


### PR DESCRIPTION
# [nginx] Fix custom port README example

## Summary

The custom-port README example configured Nginx to listen on port 8080 but did not configure the container port consumed by the deployment and HTTP probes. This adds the named `containerPorts` entry so the example consistently configures port 8080.

Fixes #1480

## Changes

- Add an HTTP `containerPorts` entry for port 8080 to the Nginx custom-port example.

## Testing

- `git -C repo diff --check` — passed.
- Attempted `cd repo && sandbox-run "helm dependency build charts/nginx && helm lint charts/nginx && helm template nginx-8080 charts/nginx --set containerPorts[0].name=http --set containerPorts[0].containerPort=8080 --set containerPorts[0].protocol=TCP --set livenessProbe.type=httpGet --set readinessProbe.type=httpGet >/dev/null"` — could not run because the sandbox image does not provide Helm (`helm: command not found`).

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
