### PR TITLE
[keycloak] Add support for custom revisionHistoryLimit

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.15
+version: 0.21.16
 appVersion: "26.7.0"
 keywords:
   - keycloak

--- a/charts/keycloak/README.md
+++ b/charts/keycloak/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the Keycloak chart and 
 | Parameter      | Description                           | Default |
 | -------------- | ------------------------------------- | ------- |
 | `replicaCount` | Number of Keycloak replicas to deploy | `1`     |
+| `revisionHistoryLimit` | Number of old StatefulSet revisions to retain for rollback | `10`    |
 
 ### Pod annotations and labels
 

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -13,6 +13,7 @@ spec:
   serviceName: {{ include "keycloak.fullname" . }}-headless
   podManagementPolicy: OrderedReady
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "keycloak.selectorLabels" . | nindent 6 }}

--- a/charts/keycloak/values.schema.json
+++ b/charts/keycloak/values.schema.json
@@ -664,6 +664,9 @@
         "resources": {
             "type": "object"
         },
+        "revisionHistoryLimit": {
+            "type": "integer"
+        },
         "service": {
             "type": "object",
             "properties": {

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -33,6 +33,8 @@ image:
 ## @section Deployment configuration
 ## @param replicaCount Number of Keycloak replicas to deploy
 replicaCount: 1
+## @param revisionHistoryLimit Number of old StatefulSet revisions to retain for rollback
+revisionHistoryLimit: 10
 
 ## @section Pod annotations and labels
 ## @param podAnnotations Map of annotations to add to the pods


### PR DESCRIPTION
### Description of the change
Adds `revisionHistoryLimit` as a configurable parameter for the keycloak StatefulSet, following the same pattern already applied to redis/valkey/rabbitmq/zookeeper in #723 and #725.

### Benefits
Allows tuning how many old ControllerRevision history entries are kept, consistent with other charts in this repo.

### Possible drawbacks
None — non-breaking change, default value (10) matches the previous hardcoded Kubernetes default.

Fixes #1482

### Checklist
- [X] Chart version bumped in `Chart.yaml` according to semver
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified