### PR TITLE
[redis] Option to override cluster announce ip and hostname

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.32.4
+version: 0.33.0
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -221,6 +221,17 @@ user sentinel >sentinelpassword ~* +client +info +ping +publish +subscribe +psub
 | `config.existingConfigmap`    | Name of existing ConfigMap to use    | `""`                   |
 | `config.existingConfigmapKey` | Key in existing ConfigMap            | `""`                   |
 
+### Redis Cluster Configuration (only applicable when `architecture=cluster`)
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `cluster.announceHostnames` | Enable hostname-based announcements for Redis Cluster (recommended for Kubernetes). When enabled, Redis announces pod hostnames instead of IPs, making the cluster more resilient to pod restarts | `false` |
+| `cluster.announceHostnamesOverride` | Map of hostnames to announce for Redis Cluster topology. Overrides the default behavior of announcing pod hostnames. Useful for external access with LoadBalancers. Only works if `announceHostnames` is `true` (e.g. `0: foo-bar-0`) | `{}` |
+| `cluster.announceIpsOverride` | Map of IPs to announce for Redis Cluster topology. Overrides the default behavior of announcing pod IPs. Useful for external access with LoadBalancers. Only works if `announceHostnames` is `false` (e.g. `0: 1.2.3.4`) | `{}` |
+| `cluster.startupSleepTime` | Seconds to sleep in the init container before configuring Redis Cluster. Useful when persistence is disabled: gives the cluster time to detect a failed master and elect a new one before the restarting pod rejoins, preventing the old master from re-entering as master with an empty dataset. Set to `0` to disable | `0` |
+| `cluster.config.nodeTimeout` | Cluster node timeout in milliseconds | `15000` |
+| `cluster.config.requireFullCoverage` | Require full coverage to accept queries | `true` |
+
 ### Metrics
 
 | Parameter                                  | Description                                                                             | Default                    |

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -477,8 +477,17 @@ spec:
               echo "cluster-announce-bus-port ${EXTERNAL_BUS}" >> /tmp/redis.conf
               {{- else if .Values.cluster.announceHostnames }}
               # Hostname-based cluster announcements (recommended for Kubernetes)
+              {{- if .Values.cluster.announceHostnamesOverride }}
+              declare -A clusterAnnounceHostnameOverrides=(
+              {{- range $k, $v := .Values.cluster.announceHostnamesOverride }}
+                [{{ $k | quote }}]={{ $v | quote }}
+              {{- end }}
+              )
+              MY_HOSTNAME_FQDN="${clusterAnnounceHostnameOverrides[$POD_ORDINAL]}"
+              {{- else }}
               MY_HOSTNAME=$(hostname)
               MY_HOSTNAME_FQDN="${MY_HOSTNAME}.{{ include "redis.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+              {{- end }}
               echo "" >> /tmp/redis.conf
               echo "# Cluster hostname-based announcements for Kubernetes resilience" >> /tmp/redis.conf
               echo "cluster-preferred-endpoint-type hostname" >> /tmp/redis.conf
@@ -489,12 +498,21 @@ spec:
               # IP-based cluster announcements (default Redis behavior)
               echo "" >> /tmp/redis.conf
               echo "# Cluster IP-based announcements (default behavior)" >> /tmp/redis.conf
+              {{- if .Values.cluster.announceIpsOverride }}
+              declare -A clusterAnnounceIpOverrides=(
+              {{- range $k, $v := .Values.cluster.announceIpsOverride }}
+                [{{ $k | quote }}]={{ $v | quote }}
+              {{- end }}
+              )
+              MY_IP="${clusterAnnounceIpOverrides[$POD_ORDINAL]}"
+              {{- else }}
               {{- if eq .Values.ipFamily "ipv4" }}
               MY_IP=$(hostname -i | awk '{print $1}' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
               {{- else if eq .Values.ipFamily "ipv6" }}
               MY_IP=$(hostname -i | awk '{print $1}' | grep -E '^[0-9a-fA-F:]+$' | head -n1)
               {{- else }}
               MY_IP=$(hostname -i | awk '{print $1}')
+              {{- end }}
               {{- end }}
               echo "cluster-announce-ip ${MY_IP}" >> /tmp/redis.conf
               echo "cluster-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/redis.conf

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -54,6 +54,18 @@
                 "announceHostnames": {
                     "type": "boolean"
                 },
+                "announceHostnamesOverride": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "announceIpsOverride": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "config": {
                     "type": "object",
                     "properties": {

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -55,16 +55,10 @@
                     "type": "boolean"
                 },
                 "announceHostnamesOverride": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "announceIpsOverride": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
+                    "type": "object"
                 },
                 "config": {
                     "type": "object",

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -466,10 +466,10 @@
                     "type": "boolean"
                 },
                 "maxUnavailable": {
-                    "type": "string"
+                    "type": ["integer", "string"]
                 },
                 "minAvailable": {
-                    "type": "integer"
+                    "type": ["integer", "string"]
                 }
             }
         },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -189,6 +189,16 @@ cluster:
   ## cluster re-form via gossip after all pods are deleted and recreated (persisted nodes.conf keeps resolvable
   ## hostnames instead of stale IPs). Disable only if your clients cannot resolve the headless service hostnames.
   announceHostnames: true
+  ## @param cluster.announceHostnamesOverride Map of hostnames to announce for Redis Cluster topology.
+  ## Overrides the default behavior of announcing pod hostnames. Useful for external access with LoadBalancers for example.
+  ## Only works if announceHostnames is true.
+  ## Example: 0: foo-bar-0
+  announceHostnamesOverride: {}
+  ## @param cluster.announceIpsOverride Map of IPs to announce for Redis Cluster topology.
+  ## Overrides the default behavior of announcing pod IPs. Useful for external access with LoadBalancers for example.
+  ## Only works if announceHostnames is false.
+  ## Example: 0: 1.2.3.4
+  announceIpsOverride: {}
   ## @param cluster.startupSleepTime Seconds to sleep in the init container before configuring Redis Cluster
   ## Useful when persistence is disabled: gives the cluster time to detect a failed master and elect
   ## a new one before the restarting pod rejoins, preventing the old master from re-entering as master


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Allow for override of cluster-announce-ip or cluster-announce-hostname if external access through a load balancer or similar service is used. This follows the pattern bitnami uses for their redis-cluster helm chart.
https://github.com/bitnami/charts/blob/main/bitnami/redis-cluster/templates/redis-statefulset.yaml#L116

### Benefits

Allow for external access of redis-cluster with correct topology for connecting clients.

### Possible drawbacks

n/a

### Applicable issues

n/a

### Additional information

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
