### PR TITLE
[rabbitmq-cluster-operator] Added support for unsecure metrics scrape for topology operator

### DIFF
--- a/charts/rabbitmq-cluster-operator/.helmignore
+++ b/charts/rabbitmq-cluster-operator/.helmignore
@@ -1,0 +1,7 @@
+# comment
+
+# Match any file or path named .helmignore
+.helmignore
+
+# Match tests directory and all its contents
+tests/

--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.4.2
+version: 0.5.0
 appVersion: "2.22.1"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.msgTopologyOperator.enabled }}
+{{- $metricsContainerPort := .Values.msgTopologyOperator.containerPorts.metricsHttp }}
+{{- if .Values.msgTopologyOperator.metrics.service.secure }}
+{{- $metricsContainerPort = .Values.msgTopologyOperator.containerPorts.metrics }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -87,7 +91,8 @@ spec:
           {{- else }}
           args:
             - --leader-elect
-            - --metrics-bind-address=:{{ .Values.msgTopologyOperator.containerPorts.metrics }}
+            - --metrics-bind-address=:{{ $metricsContainerPort }}
+            - --metrics-secure={{ .Values.msgTopologyOperator.metrics.service.secure }}
             - --health-probe-bind-address=:{{ .Values.msgTopologyOperator.containerPorts.health }}
             {{- if .Values.msgTopologyOperator.logLevel }}
             - --zap-log-level={{ .Values.msgTopologyOperator.logLevel }}
@@ -125,8 +130,8 @@ spec:
             - name: https-webhook
               containerPort: 9443
               protocol: TCP
-            - name: https-metrics
-              containerPort: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
+            - name: metrics
+              containerPort: {{ $metricsContainerPort }}
               protocol: TCP
             - name: health
               containerPort: {{ .Values.msgTopologyOperator.containerPorts.health }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.msgTopologyOperator.enabled }}
 {{- $metricsContainerPort := .Values.msgTopologyOperator.containerPorts.metricsHttp }}
-{{- if .Values.msgTopologyOperator.metrics.service.secure }}
+{{- if .Values.msgTopologyOperator.metrics.secure }}
 {{- $metricsContainerPort = .Values.msgTopologyOperator.containerPorts.metrics }}
 {{- end }}
 apiVersion: apps/v1
@@ -92,7 +92,7 @@ spec:
           args:
             - --leader-elect
             - --metrics-bind-address=:{{ $metricsContainerPort }}
-            - --metrics-secure={{ .Values.msgTopologyOperator.metrics.service.secure }}
+            - --metrics-secure={{ .Values.msgTopologyOperator.metrics.secure }}
             - --health-probe-bind-address=:{{ .Values.msgTopologyOperator.containerPorts.health }}
             {{- if .Values.msgTopologyOperator.logLevel }}
             - --zap-log-level={{ .Values.msgTopologyOperator.logLevel }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -32,16 +32,20 @@ spec:
   sessionAffinityConfig: {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: https-metrics
-      port: {{ .Values.msgTopologyOperator.metrics.service.ports.http }}
-      targetPort: https-metrics
-      protocol: TCP
-      appProtocol: https
-      {{- if (and (or (eq .Values.msgTopologyOperator.metrics.service.type "NodePort") (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer")) (not (empty .Values.msgTopologyOperator.metrics.service.nodePorts.http))) }}
-      nodePort: {{ .Values.msgTopologyOperator.metrics.service.nodePorts.http }}
-      {{- else if eq .Values.msgTopologyOperator.metrics.service.type "ClusterIP" }}
-      nodePort: null
+    - name: metrics
+      {{- if .Values.msgTopologyOperator.metrics.service.secure }}
+      port: {{ .Values.msgTopologyOperator.metrics.service.ports.https }}
+      {{- if (or (eq .Values.msgTopologyOperator.metrics.service.type "NodePort") (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.msgTopologyOperator.metrics.service.nodePorts.https }}
       {{- end }}
+      {{- else }}
+      port: {{ .Values.msgTopologyOperator.metrics.service.ports.http }}
+      {{- if (or (eq .Values.msgTopologyOperator.metrics.service.type "NodePort") (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.msgTopologyOperator.metrics.service.nodePorts.http }}
+      {{- end }}      
+      {{- end }}      
+      targetPort: metrics
+      protocol: TCP
     {{- if .Values.msgTopologyOperator.metrics.service.extraPorts }}
     {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -33,7 +33,7 @@ spec:
   {{- end }}
   ports:
     - name: metrics
-      {{- if .Values.msgTopologyOperator.metrics.service.secure }}
+      {{- if .Values.msgTopologyOperator.metrics.secure }}
       port: {{ .Values.msgTopologyOperator.metrics.service.ports.https }}
       {{- if (or (eq .Values.msgTopologyOperator.metrics.service.type "NodePort") (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.msgTopologyOperator.metrics.service.nodePorts.https }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
@@ -63,7 +63,11 @@ spec:
         - port: 9443
         - port: {{ .Values.msgTopologyOperator.containerPorts.health }}
         {{- if .Values.msgTopologyOperator.metrics.service.enabled }}
+        {{- if .Values.msgTopologyOperator.metrics.service.secure }}
         - port: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
+        {{- else }}
+        - port: {{ .Values.msgTopologyOperator.containerPorts.metricsHttp }}
+        {{- end }}
         {{- end }}
       {{- if not .Values.msgTopologyOperator.networkPolicy.allowExternal }}
       from:
@@ -90,6 +94,6 @@ spec:
         {{- end }}
       {{- end }}
     {{- if .Values.msgTopologyOperator.networkPolicy.extraIngress }}
-    {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.msgTopologyOperator.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
+    {{ include "cloudpirates.tplvalues.render" ( dict "value" .Values.msgTopologyOperator.networkPolicy.extraIngress "context" $ ) | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/networkpolicy.yaml
@@ -63,7 +63,7 @@ spec:
         - port: 9443
         - port: {{ .Values.msgTopologyOperator.containerPorts.health }}
         {{- if .Values.msgTopologyOperator.metrics.service.enabled }}
-        {{- if .Values.msgTopologyOperator.metrics.service.secure }}
+        {{- if .Values.msgTopologyOperator.metrics.secure }}
         - port: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
         {{- else }}
         - port: {{ .Values.msgTopologyOperator.containerPorts.metricsHttp }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
@@ -28,6 +28,8 @@ spec:
     - port: metrics
       {{- if .Values.msgTopologyOperator.metrics.secure }}
       scheme: https
+      tlsConfig:
+        insecureSkipVerify: true      
       {{- else }}
       scheme: http
       {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
@@ -26,7 +26,7 @@ spec:
       - {{ include "cloudpirates.namespace" . }}
   podMetricsEndpoints:
     - port: metrics
-      {{- if .Values.msgTopologyOperator.metrics.service.secure }}
+      {{- if .Values.msgTopologyOperator.metrics.secure }}
       scheme: https
       {{- else }}
       scheme: http

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/podmonitor.yaml
@@ -25,10 +25,12 @@ spec:
     matchNames:
       - {{ include "cloudpirates.namespace" . }}
   podMetricsEndpoints:
-    - port: https-metrics
+    - port: metrics
+      {{- if .Values.msgTopologyOperator.metrics.service.secure }}
       scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
+      {{- else }}
+      scheme: http
+      {{- end }}
       {{- if .Values.msgTopologyOperator.metrics.podMonitor.interval }}
       interval: {{ .Values.msgTopologyOperator.metrics.podMonitor.interval }}
       {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -27,10 +27,12 @@ spec:
     matchNames:
       - {{ include "cloudpirates.namespace" . }}
   endpoints:
-    - port: https-metrics
+    - port: metrics
+      {{- if .Values.msgTopologyOperator.metrics.service.secure }}
       scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
+      {{- else }}
+      scheme: http
+      {{- end }}
       {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.interval }}
       interval: {{ .Values.msgTopologyOperator.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -30,6 +30,8 @@ spec:
     - port: metrics
       {{- if .Values.msgTopologyOperator.metrics.secure }}
       scheme: https
+      tlsConfig:
+        insecureSkipVerify: true      
       {{- else }}
       scheme: http
       {{- end }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -28,7 +28,7 @@ spec:
       - {{ include "cloudpirates.namespace" . }}
   endpoints:
     - port: metrics
-      {{- if .Values.msgTopologyOperator.metrics.service.secure }}
+      {{- if .Values.msgTopologyOperator.metrics.secure }}
       scheme: https
       {{- else }}
       scheme: http

--- a/charts/rabbitmq-cluster-operator/tests/cluster_operator_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/cluster_operator_test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 suite: rabbitmq-cluster-operator-tests
 templates:
   - templates/cluster-operator/deployment.yaml
@@ -286,7 +287,7 @@ tests:
           path: spec.template.spec.securityContext.fsGroupChangePolicy
           value: Always
         template: templates/cluster-operator/deployment.yaml
-      - isNull:
+      - notExists:
           path: spec.template.spec.securityContext.enabled
         template: templates/cluster-operator/deployment.yaml
 
@@ -401,6 +402,6 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
         template: templates/cluster-operator/deployment.yaml
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].securityContext.enabled
         template: templates/cluster-operator/deployment.yaml

--- a/charts/rabbitmq-cluster-operator/tests/messaging_topology_operator_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/messaging_topology_operator_test.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
 suite: rabbitmq-messaging-topology-operator-tests
 templates:
   - templates/messaging-topology-operator/deployment.yaml
@@ -221,6 +222,98 @@ tests:
           value: RELEASE-NAME-rabbitmq-messaging-topology-operator-metrics
         template: templates/messaging-topology-operator/metrics-service.yaml
 
+  - it: should bind deployment metrics to https port when secure metrics are enabled
+    set:
+      msgTopologyOperator.metrics.service.secure: true
+      msgTopologyOperator.containerPorts.metrics: 8443
+      msgTopologyOperator.containerPorts.metricsHttp: 8080
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-bind-address=:8443
+        template: templates/messaging-topology-operator/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=true
+        template: templates/messaging-topology-operator/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 8443
+        template: templates/messaging-topology-operator/deployment.yaml
+
+  - it: should bind deployment metrics to http port when secure metrics are disabled
+    set:
+      msgTopologyOperator.metrics.service.secure: false
+      msgTopologyOperator.containerPorts.metrics: 8443
+      msgTopologyOperator.containerPorts.metricsHttp: 8080
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-bind-address=:8080
+        template: templates/messaging-topology-operator/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --metrics-secure=false
+        template: templates/messaging-topology-operator/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 8080
+        template: templates/messaging-topology-operator/deployment.yaml
+
+  - it: should expose https metrics NodePort and annotations when secure metrics are enabled
+    set:
+      msgTopologyOperator.metrics.service.enabled: true
+      msgTopologyOperator.metrics.service.type: NodePort
+      msgTopologyOperator.metrics.service.secure: true
+      msgTopologyOperator.metrics.service.ports.http: 8080
+      msgTopologyOperator.metrics.service.ports.https: 8443
+      msgTopologyOperator.metrics.service.nodePorts.http: 31500
+      msgTopologyOperator.metrics.service.nodePorts.https: 31501
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8443
+        template: templates/messaging-topology-operator/metrics-service.yaml
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 31501
+        template: templates/messaging-topology-operator/metrics-service.yaml
+      - equal:
+          path: metadata.annotations["prometheus.io/scheme"]
+          value: https
+        template: templates/messaging-topology-operator/metrics-service.yaml
+      - equal:
+          path: metadata.annotations["prometheus.io/port"]
+          value: "8443"
+        template: templates/messaging-topology-operator/metrics-service.yaml
+
+  - it: should expose http metrics NodePort and annotations when secure metrics are disabled
+    set:
+      msgTopologyOperator.metrics.service.enabled: true
+      msgTopologyOperator.metrics.service.type: NodePort
+      msgTopologyOperator.metrics.service.secure: false
+      msgTopologyOperator.metrics.service.ports.http: 8080
+      msgTopologyOperator.metrics.service.ports.https: 8443
+      msgTopologyOperator.metrics.service.nodePorts.http: 31500
+      msgTopologyOperator.metrics.service.nodePorts.https: 31501
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+        template: templates/messaging-topology-operator/metrics-service.yaml
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 31500
+        template: templates/messaging-topology-operator/metrics-service.yaml
+      - equal:
+          path: metadata.annotations["prometheus.io/scheme"]
+          value: http
+        template: templates/messaging-topology-operator/metrics-service.yaml
+      - equal:
+          path: metadata.annotations["prometheus.io/port"]
+          value: "8080"
+        template: templates/messaging-topology-operator/metrics-service.yaml
+
   - it: should not create podmonitor by default
     asserts:
       - hasDocuments:
@@ -327,7 +420,7 @@ tests:
           path: spec.template.spec.securityContext.fsGroupChangePolicy
           value: Always
         template: templates/messaging-topology-operator/deployment.yaml
-      - isNull:
+      - notExists:
           path: spec.template.spec.securityContext.enabled
         template: templates/messaging-topology-operator/deployment.yaml
 
@@ -363,6 +456,6 @@ tests:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
         template: templates/messaging-topology-operator/deployment.yaml
-      - isNull:
+      - notExists:
           path: spec.template.spec.containers[0].securityContext.enabled
         template: templates/messaging-topology-operator/deployment.yaml

--- a/charts/rabbitmq-cluster-operator/tests/messaging_topology_operator_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/messaging_topology_operator_test.yaml
@@ -224,7 +224,7 @@ tests:
 
   - it: should bind deployment metrics to https port when secure metrics are enabled
     set:
-      msgTopologyOperator.metrics.service.secure: true
+      msgTopologyOperator.metrics.secure: true
       msgTopologyOperator.containerPorts.metrics: 8443
       msgTopologyOperator.containerPorts.metricsHttp: 8080
     asserts:
@@ -243,7 +243,7 @@ tests:
 
   - it: should bind deployment metrics to http port when secure metrics are disabled
     set:
-      msgTopologyOperator.metrics.service.secure: false
+      msgTopologyOperator.metrics.secure: false
       msgTopologyOperator.containerPorts.metrics: 8443
       msgTopologyOperator.containerPorts.metricsHttp: 8080
     asserts:
@@ -264,7 +264,7 @@ tests:
     set:
       msgTopologyOperator.metrics.service.enabled: true
       msgTopologyOperator.metrics.service.type: NodePort
-      msgTopologyOperator.metrics.service.secure: true
+      msgTopologyOperator.metrics.secure: true
       msgTopologyOperator.metrics.service.ports.https: 8443
       msgTopologyOperator.metrics.service.nodePorts.https: 31501
     asserts:
@@ -281,7 +281,7 @@ tests:
     set:
       msgTopologyOperator.metrics.service.enabled: true
       msgTopologyOperator.metrics.service.type: NodePort
-      msgTopologyOperator.metrics.service.secure: false
+      msgTopologyOperator.metrics.secure: false
       msgTopologyOperator.metrics.service.ports.http: 8080
       msgTopologyOperator.metrics.service.nodePorts.http: 31500
     asserts:

--- a/charts/rabbitmq-cluster-operator/tests/messaging_topology_operator_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/messaging_topology_operator_test.yaml
@@ -260,14 +260,12 @@ tests:
           value: 8080
         template: templates/messaging-topology-operator/deployment.yaml
 
-  - it: should expose https metrics NodePort and annotations when secure metrics are enabled
+  - it: should expose https metrics NodePort when secure metrics are enabled
     set:
       msgTopologyOperator.metrics.service.enabled: true
       msgTopologyOperator.metrics.service.type: NodePort
       msgTopologyOperator.metrics.service.secure: true
-      msgTopologyOperator.metrics.service.ports.http: 8080
       msgTopologyOperator.metrics.service.ports.https: 8443
-      msgTopologyOperator.metrics.service.nodePorts.http: 31500
       msgTopologyOperator.metrics.service.nodePorts.https: 31501
     asserts:
       - equal:
@@ -278,24 +276,14 @@ tests:
           path: spec.ports[0].nodePort
           value: 31501
         template: templates/messaging-topology-operator/metrics-service.yaml
-      - equal:
-          path: metadata.annotations["prometheus.io/scheme"]
-          value: https
-        template: templates/messaging-topology-operator/metrics-service.yaml
-      - equal:
-          path: metadata.annotations["prometheus.io/port"]
-          value: "8443"
-        template: templates/messaging-topology-operator/metrics-service.yaml
 
-  - it: should expose http metrics NodePort and annotations when secure metrics are disabled
+  - it: should expose http metrics NodePort when secure metrics are disabled
     set:
       msgTopologyOperator.metrics.service.enabled: true
       msgTopologyOperator.metrics.service.type: NodePort
       msgTopologyOperator.metrics.service.secure: false
       msgTopologyOperator.metrics.service.ports.http: 8080
-      msgTopologyOperator.metrics.service.ports.https: 8443
       msgTopologyOperator.metrics.service.nodePorts.http: 31500
-      msgTopologyOperator.metrics.service.nodePorts.https: 31501
     asserts:
       - equal:
           path: spec.ports[0].port
@@ -304,14 +292,6 @@ tests:
       - equal:
           path: spec.ports[0].nodePort
           value: 31500
-        template: templates/messaging-topology-operator/metrics-service.yaml
-      - equal:
-          path: metadata.annotations["prometheus.io/scheme"]
-          value: http
-        template: templates/messaging-topology-operator/metrics-service.yaml
-      - equal:
-          path: metadata.annotations["prometheus.io/port"]
-          value: "8080"
         template: templates/messaging-topology-operator/metrics-service.yaml
 
   - it: should not create podmonitor by default

--- a/charts/rabbitmq-cluster-operator/values.schema.json
+++ b/charts/rabbitmq-cluster-operator/values.schema.json
@@ -238,7 +238,7 @@
                                     "type": "object",
                                     "properties": {
                                         "http": {
-                                            "type": "string"
+                                            "type": "integer"
                                         }
                                     }
                                 },
@@ -806,6 +806,9 @@
                                 "enabled": {
                                     "type": "boolean"
                                 },
+                                "secure": {
+                                    "type": "boolean"
+                                },
                                 "externalTrafficPolicy": {
                                     "type": "string"
                                 },
@@ -822,7 +825,10 @@
                                     "type": "object",
                                     "properties": {
                                         "http": {
-                                            "type": "string"
+                                            "type": "integer"
+                                        },
+                                        "https": {
+                                            "type": "integer"
                                         }
                                     }
                                 },
@@ -830,6 +836,9 @@
                                     "type": "object",
                                     "properties": {
                                         "http": {
+                                            "type": "integer"
+                                        },
+                                        "https": {
                                             "type": "integer"
                                         }
                                     }
@@ -1039,7 +1048,7 @@
                             "type": "object",
                             "properties": {
                                 "http": {
-                                    "type": "string"
+                                    "type": "integer"
                                 }
                             }
                         },

--- a/charts/rabbitmq-cluster-operator/values.schema.json
+++ b/charts/rabbitmq-cluster-operator/values.schema.json
@@ -161,6 +161,9 @@
                 "metrics": {
                     "type": "object",
                     "properties": {
+                        "secure": {
+                            "type": "boolean"
+                        },
                         "podMonitor": {
                             "type": "object",
                             "properties": {
@@ -804,9 +807,6 @@
                                     "type": "string"
                                 },
                                 "enabled": {
-                                    "type": "boolean"
-                                },
-                                "secure": {
                                     "type": "boolean"
                                 },
                                 "externalTrafficPolicy": {

--- a/charts/rabbitmq-cluster-operator/values.yaml
+++ b/charts/rabbitmq-cluster-operator/values.yaml
@@ -917,12 +917,7 @@ msgTopologyOperator:
       ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
       externalTrafficPolicy: Cluster
       ## @param msgTopologyOperator.metrics.service.annotations [object] Additional custom annotations for RabbitMQ Messaging Topology Operator metrics service
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/scheme: >-
-          {{ .Values.msgTopologyOperator.metrics.service.secure | ternary "https" "http" }}
-        prometheus.io/port: >-
-          {{ .Values.msgTopologyOperator.metrics.service.secure | ternary .Values.msgTopologyOperator.metrics.service.ports.https .Values.msgTopologyOperator.metrics.service.ports.http }}
+      annotations: {}
       ## @param msgTopologyOperator.metrics.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
       ## If "ClientIP", consecutive client requests will be directed to the same Pod
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies

--- a/charts/rabbitmq-cluster-operator/values.yaml
+++ b/charts/rabbitmq-cluster-operator/values.yaml
@@ -420,7 +420,7 @@ clusterOperator:
       ## @param clusterOperator.metrics.service.nodePorts.http Node port for HTTP
       ## NOTE: choose port between <30000-32767>
       nodePorts:
-        http: ""
+        http: 30001
       ## @param clusterOperator.metrics.service.clusterIP RabbitMQ Cluster Operator metrics service Cluster IP
       ## e.g.:
       ## clusterIP: None
@@ -713,9 +713,11 @@ msgTopologyOperator:
   priorityClassName: ""
   ## @param msgTopologyOperator.lifecycleHooks for the RabbitMQ Messaging Topology Operator container(s) to automate configuration before or after startup
   lifecycleHooks: {}
+  ## @param msgTopologyOperator.containerPorts.metricsHttp RabbitMQ Messaging Topology Operator container port (used for metrics, HTTP)
   ## @param msgTopologyOperator.containerPorts.metrics RabbitMQ Messaging Topology Operator container port (used for metrics, HTTPS)
   ## @param msgTopologyOperator.containerPorts.health RabbitMQ Messaging Topology Operator container port (used for /healthz and /readyz probes)
   containerPorts:
+    metricsHttp: 8080
     metrics: 8443
     health: 8081
   ## @param msgTopologyOperator.extraEnvVars Array with extra environment variables to add to RabbitMQ Messaging Topology Operator nodes
@@ -762,7 +764,7 @@ msgTopologyOperator:
     ## @param msgTopologyOperator.service.nodePorts.http Node port for HTTP
     ## NOTE: choose port between <30000-32767>
     nodePorts:
-      http: ""
+      http: 30002
     ## @param msgTopologyOperator.service.clusterIP RabbitMQ Messaging Topology Operator webhook service Cluster IP
     ## e.g.:
     ## clusterIP: None
@@ -882,16 +884,20 @@ msgTopologyOperator:
     service:
       ## @param msgTopologyOperator.metrics.service.enabled Create a service for accessing the metrics endpoint
       enabled: false
+      ## Metrics endpoint authentication and transport settings.
+      ## @param msgTopologyOperator.metrics.service.secure Enable authentication/authorization on metrics endpoint
+      secure: true
       ## @param msgTopologyOperator.metrics.service.type RabbitMQ Messaging Topology Operator metrics service type
       type: ClusterIP
-      ## @param msgTopologyOperator.metrics.service.ports.http RabbitMQ Messaging Topology Operator metrics service port (target is HTTPS; metrics endpoint requires TLS as of v1.19.0)
+      ## RabbitMQ Messaging Topology Operator metrics service ports (if target is HTTPS; metrics endpoint requires TLS as of v1.19.0)
       ports:
-        http: 8443
+        http: 8080
+        https: 8443
       ## Node ports to expose
-      ## @param msgTopologyOperator.metrics.service.nodePorts.http Node port for the metrics service
       ## NOTE: choose port between <30000-32767>
       nodePorts:
-        http: ""
+        http: 31500
+        https: 31501
       ## @param msgTopologyOperator.metrics.service.clusterIP RabbitMQ Cluster Operator metrics service Cluster IP
       ## e.g.:
       ## clusterIP: None
@@ -913,8 +919,10 @@ msgTopologyOperator:
       ## @param msgTopologyOperator.metrics.service.annotations [object] Additional custom annotations for RabbitMQ Messaging Topology Operator metrics service
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/scheme: "https"
-        prometheus.io/port: "{{ .Values.msgTopologyOperator.metrics.service.ports.http }}"
+        prometheus.io/scheme: >-
+          {{ .Values.msgTopologyOperator.metrics.service.secure | ternary "https" "http" }}
+        prometheus.io/port: >-
+          {{ .Values.msgTopologyOperator.metrics.service.secure | ternary .Values.msgTopologyOperator.metrics.service.ports.https .Values.msgTopologyOperator.metrics.service.ports.http }}
       ## @param msgTopologyOperator.metrics.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
       ## If "ClientIP", consecutive client requests will be directed to the same Pod
       ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
@@ -933,6 +941,7 @@ msgTopologyOperator:
       namespace: ""
       ## @param msgTopologyOperator.metrics.serviceMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
       jobLabel: app.kubernetes.io/name
+      ## @param msgTopologyOperator.metrics.serviceMonitor.selector [object] Selector for RabbitMQ Messaging Topology Operator metrics service
       ## DEPRECATED: Use msgTopologyOperator.metrics.serviceMonitor.labels instead.
       ## This value will be removed in a future release
       ## additionalLabels: {}

--- a/charts/rabbitmq-cluster-operator/values.yaml
+++ b/charts/rabbitmq-cluster-operator/values.yaml
@@ -880,13 +880,13 @@ msgTopologyOperator:
     automountServiceAccountToken: false
   ## @section RabbitMQ Messaging Topology Operator parameters
   metrics:
+    ## Metrics endpoint authentication and transport settings.
+    ## @param msgTopologyOperator.metrics.secure Enable authentication/authorization on metrics endpoint
+    secure: true
     ## Metrics service parameters
     service:
       ## @param msgTopologyOperator.metrics.service.enabled Create a service for accessing the metrics endpoint
       enabled: false
-      ## Metrics endpoint authentication and transport settings.
-      ## @param msgTopologyOperator.metrics.service.secure Enable authentication/authorization on metrics endpoint
-      secure: true
       ## @param msgTopologyOperator.metrics.service.type RabbitMQ Messaging Topology Operator metrics service type
       type: ClusterIP
       ## RabbitMQ Messaging Topology Operator metrics service ports (if target is HTTPS; metrics endpoint requires TLS as of v1.19.0)


### PR DESCRIPTION
### Description of the change

This PR introduces the following changes:

* **Added `.helmignore` file:** Excluded the `tests` directory from the final packaged Helm chart following best practices ([helm-unittest documentation](https://github.com/helm-unittest/helm-unittest#get-started)).
* **HTTP metrics scraping support:** Added the ability to enable insecure HTTP metric scraping for the topology operator via the `msgTopologyOperator.metrics.secure` option ([RabbitMQ documentation](https://www.rabbitmq.com/kubernetes/operator/topology-operator-metrics#insecure-metrics)).
* **Cleaned up legacy annotations:** Removed `prometheus.io/*` annotations from `metrics-service` in favor of recommended Custom Resources (e.g., `PodMonitor` / `ServiceMonitor`).
* **Deprecated assertion update:** Replaced `isNull` with `notExists` assertions in test files, as `isNull` has been deprecated in `helm-unittest`.
* **IDE Integration:** Added `# yaml-language-server` directive to test files for better schema validation and autocomplete in modern IDEs.
* **Default NodePorts:** Added and explicitly defined default `NodePort` configurations.

### Benefits

* **Smaller Chart Size & Cleaner Packages:** Excluding test files via `.helmignore` keeps the published chart package lightweight.
* **Improved Monitoring Flexibility:** Allows users to scrape metrics over HTTP without requiring mandatory TLS/authentication setup when appropriate for their cluster architecture.
* **Modern Kubernetes Standards:** Aligns monitoring setup with CRD-based best practices instead of annotations.
* **Future-Proof Tests:** Removes deprecated test syntax (`isNull`) to ensure long-term compatibility with `helm-unittest`.
* **Developer Experience:** Enables schema validation and auto-completion in IDEs supporting YAML language servers.

### Possible drawbacks

* Disabling HTTPS/authentication for topology operator metrics (`msgTopologyOperator.metrics.secure=false`) transfers security responsibilities to internal network/RBAC policies.
* Helm chart users relying exclusively on legacy `prometheus.io/*` annotations for scraping will need to adopt standard Kubernetes CRDs (`PodMonitor`/`ServiceMonitor`).

### Checklist

* [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
* [x] Variables are documented in the values.yaml and added to the `README.md`
* [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
* [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](https://www.google.com/search?q=../CONTRIBUTING.md%23setting-up-your-development-environment))