### PR TITLE
[nginx]: add topologySpreadConstraints to deployment

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.15.3
+version: 0.16.0
 appVersion: "1.31.3"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -457,6 +457,7 @@ All containers in `sidecars` will be added to the pod and run alongside the main
 | `priorityClassName` | Priority class for pod eviction   | `""`    |
 | `tolerations`       | Tolerations for pod assignment    | `[]`    |
 | `affinity`          | Affinity rules for pod assignment | `{}`    |
+| `topologySpreadConstraints` | Topology spread constraints for pod assignment | `[]`    |
 | `dnsPolicy`         | DNS policy for the pod            | `""`    |
 | `dnsConfig`         | DNS configuration for the pod     | `{}`    |
 

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -312,6 +312,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -578,6 +578,9 @@
         },
         "tolerations": {
             "type": "array"
+        },
+        "topologySpreadConstraints": {
+            "type": "array"
         }
     }
 }

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -230,6 +230,9 @@ tolerations: []
 ## @param affinity Affinity rules for pod assignment
 affinity: {}
 
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment
+topologySpreadConstraints: []
+
 ## @param dnsPolicy DNS policy for the pod
 dnsPolicy: ""
 


### PR DESCRIPTION
### Description of the change

Allows pod topology spread constraints to be configured for the nginx Deployment/DaemonSet, matching the pattern used in the redis chart.

### Benefits

set topology spread constraints for autoscaling

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
