### PR TITLE
[redis] Refactor/metrics service name

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.32.4
+version: 0.33.0
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -236,6 +236,7 @@ user sentinel >sentinelpassword ~* +client +info +ping +publish +subscribe +psub
 | `metrics.port`                             | Port that the metrics server and endpoint is running on                                 | `9121`                     |
 | `metrics.service.enabled`                  | Enable the dedicated metrics service                                                    | `true`                     |
 | `metrics.service.type`                     | Metrics service type                                                                    | `ClusterIP`                |
+| `metrics.service.name`                     | Metrics service name                                                                    | `http-metrics`             |
 | `metrics.service.port`                     | Metrics service port                                                                    | `9121`                     |
 | `metrics.service.annotations`              | Additional custom annotations for Metrics service                                       | `{}`                       |
 | `metrics.service.loadBalancerIP`           | LoadBalancer IP if metrics service type is `LoadBalancer`                               | `""`                       |

--- a/charts/redis/templates/metrics-service.yaml
+++ b/charts/redis/templates/metrics-service.yaml
@@ -34,7 +34,7 @@ spec:
   clusterIP: {{ .Values.metrics.service.clusterIP }}
   {{- end }}
   ports:
-    - name: metrics
+    - name: {{ .Values.metrics.service.name | default "metrics" }}
       port: {{ .Values.metrics.service.port }}
       protocol: TCP
       targetPort: metrics

--- a/charts/redis/templates/metrics-service.yaml
+++ b/charts/redis/templates/metrics-service.yaml
@@ -34,7 +34,7 @@ spec:
   clusterIP: {{ .Values.metrics.service.clusterIP }}
   {{- end }}
   ports:
-    - name: {{ .Values.metrics.service.name | default "metrics" }}
+    - name: {{ .Values.metrics.service.name }}
       port: {{ .Values.metrics.service.port }}
       protocol: TCP
       targetPort: metrics

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -373,6 +373,9 @@
                         "loadBalancerSourceRanges": {
                             "type": "array"
                         },
+                        "name": {
+                            "type": "string"
+                        },
                         "nodePort": {
                             "type": "string"
                         },

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -624,7 +624,7 @@ metrics:
     ## @param metrics.service.type Metrics service type
     type: ClusterIP
     ## @param metrics.service.name Metrics service name
-    name: metrics
+    name: http-metrics
     ## @param metrics.service.port Metrics service port
     port: 9121
     ## @param metrics.service.annotations Additional custom annotations for Metrics service

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -623,6 +623,8 @@ metrics:
     enabled: true
     ## @param metrics.service.type Metrics service type
     type: ClusterIP
+    ## @param metrics.service.name Metrics service name
+    name: metrics
     ## @param metrics.service.port Metrics service port
     port: 9121
     ## @param metrics.service.annotations Additional custom annotations for Metrics service


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

- Introduced the `metrics.service.name` variable in `values.yaml` with a default value of `http-metrics`.
- Updated the `metrics-service` Helm template to dynamically render the port name using {`{ .Values.metrics.service.name }}` instead of a hardcoded value.
- This change allows standard `<protocol>-<suffix>` naming conventions required by modern service meshes and metrics scrapers to correctly detect HTTP traffic.
- Updated Readme.md

### Benefits

Enables configurable port naming in `values.yaml` and improves L7 service mesh and Prometheus compatibility.

### Possible drawbacks

Existing Prometheus or Ingress configurations referencing old port names must be updated.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
