### PR TITLE
[all] fix lint error in extraobjects template

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: "3.7.0"
 keywords:
   - etcd

--- a/charts/etcd/templates/extraobjects.yaml
+++ b/charts/etcd/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.20.2
+version: 0.20.3
 appVersion: "6.53.0"
 keywords:
   - ghost

--- a/charts/ghost/templates/extraobjects.yaml
+++ b/charts/ghost/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka is a distributed event streaming platform used for high-performance data pipelines, streaming analytics, and data integration. This chart deploys Kafka in KRaft mode (no ZooKeeper required).
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "4.3.1"
 keywords:
   - kafka

--- a/charts/kafka/templates/extraobjects.yaml
+++ b/charts/kafka/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.17
+version: 0.21.18
 appVersion: "26.7.0"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/extraobjects.yaml
+++ b/charts/keycloak/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.16.6
+version: 0.16.7
 appVersion: "12.3.2"
 keywords:
   - mariadb

--- a/charts/mariadb/templates/extraobjects.yaml
+++ b/charts/mariadb/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "1.6.45"
 keywords:
   - memcached

--- a/charts/memcached/templates/extraobjects.yaml
+++ b/charts/memcached/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/templates/extraobjects.yaml
+++ b/charts/minio/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.18.2
+version: 0.18.3
 appVersion: "8.3.4"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/extraobjects.yaml
+++ b/charts/mongodb/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.16.0
+version: 0.16.1
 appVersion: "1.31.3"
 keywords:
   - nginx

--- a/charts/nginx/templates/extraobjects.yaml
+++ b/charts/nginx/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.19.11
+version: 0.19.12
 appVersion: "18.4.0"
 keywords:
   - postgres

--- a/charts/postgres/templates/extraobjects.yaml
+++ b/charts/postgres/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.33.0
+version: 0.33.1
 appVersion: "8.8.0"
 keywords:
   - redis

--- a/charts/redis/templates/extraobjects.yaml
+++ b/charts/redis/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: (ALPHA) High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/templates/extraobjects.yaml
+++ b/charts/rustfs/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "2.28.3"
 keywords:
   - timescaledb

--- a/charts/timescaledb/templates/extraobjects.yaml
+++ b/charts/timescaledb/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.24.4
+version: 0.24.5
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/extraobjects.yaml
+++ b/charts/valkey/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/templates/extraobjects.yaml
+++ b/charts/zookeeper/templates/extraobjects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.extraObjects }}
 ---
-{{- include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
+{{ include "cloudpirates.tplvalues.render" (dict "value" . "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Fixes lint error caused by left-trim of rendered extra objects:

```
[ERROR] templates/extraobjects.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1
```

### Applicable issues

- fixes #1499 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
