### PR TITLE
[mongodb] add terminationGracePeriodSeconds support across statefulsets

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.18.4
+version: 0.18.5
 appVersion: "8.3.7"
 keywords:
   - mongodb

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -251,6 +251,7 @@ customUsers:
 | `containerSecurityContext.allowPrivilegeEscalation` | Set MongoDB container's privilege escalation | `false` |
 | `podSecurityContext.fsGroup`                        | Set MongoDB pod's Security Context fsGroup   | `999`   |
 | `priorityClassName`                                 | Priority class for the mongodb instance      | `""`    |
+| `terminationGracePeriodSeconds`                     | Seconds Kubernetes waits for graceful pod termination before SIGKILL | `30` |
 
 ### Health Check Parameters
 

--- a/charts/mongodb/templates/statefulset-arbiter.yaml
+++ b/charts/mongodb/templates/statefulset-arbiter.yaml
@@ -53,6 +53,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           {{- with .Values.containerSecurityContext }}

--- a/charts/mongodb/templates/statefulset-configserver.yaml
+++ b/charts/mongodb/templates/statefulset-configserver.yaml
@@ -54,6 +54,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "mongodb.serviceAccountName" . }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- with (coalesce .Values.shardedCluster.configsvr.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mongodb/templates/statefulset-hidden.yaml
+++ b/charts/mongodb/templates/statefulset-hidden.yaml
@@ -55,6 +55,7 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           {{- with .Values.containerSecurityContext }}

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -50,6 +50,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "mongodb.serviceAccountName" . }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- with (coalesce .Values.shardedCluster.mongos.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mongodb/templates/statefulset-shard.yaml
+++ b/charts/mongodb/templates/statefulset-shard.yaml
@@ -60,6 +60,7 @@ spec:
       {{- if $.Values.serviceAccount.create }}
       serviceAccountName: {{ include "mongodb.serviceAccountName" $ }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds | default 30 }}
       {{- $nodeSelector := coalesce $.Values.shardedCluster.shardsvr.dataNode.nodeSelector $.Values.shardedCluster.shardsvr.nodeSelector $.Values.nodeSelector }}
       {{- with $nodeSelector }}
       nodeSelector:
@@ -546,6 +547,7 @@ spec:
       {{- if $.Values.serviceAccount.create }}
       serviceAccountName: {{ include "mongodb.serviceAccountName" $ }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds | default 30 }}
       {{- $nodeSelector := coalesce $.Values.shardedCluster.shardsvr.arbiter.nodeSelector $.Values.shardedCluster.shardsvr.nodeSelector $.Values.nodeSelector }}
       {{- with $nodeSelector }}
       nodeSelector:

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -56,6 +56,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }} 

--- a/charts/mongodb/values.schema.json
+++ b/charts/mongodb/values.schema.json
@@ -967,6 +967,9 @@
         "tolerations": {
             "type": "array"
         },
+        "terminationGracePeriodSeconds": {
+            "type": "integer"
+        },
         "updateStrategyType": {
             "type": "string"
         }

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -197,6 +197,9 @@ podSecurityContext:
 ## @param priorityClassName Priority class for the mongodb instance
 priorityClassName: ""
 
+## @param terminationGracePeriodSeconds Seconds Kubernetes waits for the pod to terminate gracefully before SIGKILL
+terminationGracePeriodSeconds: 30
+
 livenessProbe:
   ## @param livenessProbe.enabled Enable liveness probe
   enabled: true


### PR DESCRIPTION
### Description of the change

Add terminationGracePeriodSeconds support to the mongodb chart by updating values, schema, and all mongodb StatefulSet templates (standalone, replica set, hidden, arbiter, configserver, mongos, shard data node, shard arbiter). Also update README parameter docs and bump chart version to 0.18.5.

### Benefits

- Enables configurable graceful shutdown timing for MongoDB pods.
- Aligns mongodb behavior with existing valkey support.
- Prevents silent no-op when users set this value.

### Possible drawbacks

- None expected; default stays 30 so behavior is unchanged unless overridden.

### Applicable issues

- fixes #

### Additional information

- Validation run: helm lint ./charts/mongodb; helm unittest charts/mongodb; helm template with default and override values.

### Checklist

- [X] Chart version bumped in Chart.yaml according to semver. This is not necessary when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the README.md
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see CONTRIBUTING.md)
