### PR TITLE
[mongodb] use custom probes

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.18.4
+version: 0.18.6
 appVersion: "8.3.7"
 keywords:
   - mongodb

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -262,18 +262,21 @@ customUsers:
 | `livenessProbe.timeoutSeconds`       | Timeout for each probe attempt                  | `5`     |
 | `livenessProbe.failureThreshold`     | Number of failures before pod is restarted      | `6`     |
 | `livenessProbe.successThreshold`     | Number of successes to mark probe as successful | `1`     |
+| `customLivenessProbe`                | Custom liveness probe configuration             | `{}`    |
 | `readinessProbe.enabled`             | Enable readiness probe                          | `true`  |
 | `readinessProbe.initialDelaySeconds` | Initial delay before starting probes            | `5`     |
 | `readinessProbe.periodSeconds`       | How often to perform the probe                  | `10`    |
 | `readinessProbe.timeoutSeconds`      | Timeout for each probe attempt                  | `5`     |
 | `readinessProbe.failureThreshold`    | Number of failures before pod is marked unready | `6`     |
 | `readinessProbe.successThreshold`    | Number of successes to mark probe as successful | `1`     |
+| `customReadinessProbe`               | Custom readiness probe configuration            | `{}`    |
 | `startupProbe.enabled`               | Enable startup probe                            | `true`  |
 | `startupProbe.initialDelaySeconds`   | Initial delay before starting probes            | `10`    |
 | `startupProbe.timeoutSeconds`        | Timeout for each probe attempt                  | `5`     |
 | `startupProbe.failureThreshold`      | Number of failures before pod is marked unready | `30`    |
 | `startupProbe.successThreshold`      | Number of successes to mark probe as successful | `1`     |
 | `startupProbe.periodSeconds`         | How often to perform the probe                  | `10`    |
+| `customStartupProbe`                 | Custom startup probe configuration              | `{}`    |
 
 ### Additional Parameters
 

--- a/charts/mongodb/templates/statefulset-arbiter.yaml
+++ b/charts/mongodb/templates/statefulset-arbiter.yaml
@@ -117,6 +117,10 @@ spec:
             - name: mongodb
               containerPort: 27017
               protocol: TCP
+          {{- if .Values.customStartupProbe }}
+          startupProbe:
+            {{- toYaml .Values.customStartupProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             exec:
@@ -132,6 +136,11 @@ spec:
             periodSeconds: {{ .periodSeconds }}
           {{- end }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -147,6 +156,11 @@ spec:
             successThreshold: {{ .successThreshold }}
           {{- end }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
@@ -160,6 +174,7 @@ spec:
             periodSeconds: {{ .periodSeconds }}
             failureThreshold: {{ .failureThreshold }}
             successThreshold: {{ .successThreshold }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- with .Values.replicaSet.arbiter.resources }}

--- a/charts/mongodb/templates/statefulset-configserver.yaml
+++ b/charts/mongodb/templates/statefulset-configserver.yaml
@@ -208,6 +208,10 @@ spec:
             - name: mongodb
               containerPort: 27017
               protocol: TCP
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -221,6 +225,11 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
@@ -234,6 +243,11 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customStartupProbe }}
+          startupProbe:
+            {{- toYaml .Values.customStartupProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             exec:
@@ -246,6 +260,7 @@ spec:
             successThreshold: {{ .Values.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: mongodb-configserver-volume

--- a/charts/mongodb/templates/statefulset-mongos.yaml
+++ b/charts/mongodb/templates/statefulset-mongos.yaml
@@ -193,6 +193,10 @@ spec:
             - name: mongodb
               containerPort: 27017
               protocol: TCP
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -206,6 +210,11 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
@@ -219,6 +228,11 @@ spec:
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customStartupProbe }}
+          startupProbe:
+            {{- toYaml .Values.customStartupProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             exec:
@@ -231,6 +245,7 @@ spec:
             successThreshold: {{ .Values.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.startupProbe.failureThreshold }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.config.content }}

--- a/charts/mongodb/templates/statefulset-shard.yaml
+++ b/charts/mongodb/templates/statefulset-shard.yaml
@@ -315,6 +315,10 @@ spec:
             - name: mongodb
               containerPort: 27017
               protocol: TCP
+          {{- if $.Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml $.Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
           {{- if $.Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -328,6 +332,11 @@ spec:
             failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
             periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if $.Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml $.Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
           {{- if $.Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
@@ -341,6 +350,11 @@ spec:
             failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if $.Values.customStartupProbe }}
+          startupProbe:
+            {{- toYaml $.Values.customStartupProbe | nindent 12 }}
+          {{- else }}
           {{- if $.Values.startupProbe.enabled }}
           startupProbe:
             exec:
@@ -353,6 +367,7 @@ spec:
             successThreshold: {{ $.Values.startupProbe.successThreshold }}
             failureThreshold: {{ $.Values.startupProbe.failureThreshold }}
             periodSeconds: {{ $.Values.startupProbe.periodSeconds }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: mongodb-shard-{{ $shardIndex }}-volume
@@ -673,6 +688,10 @@ spec:
             - name: mongodb
               containerPort: 27017
               protocol: TCP
+          {{- if $.Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml $.Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
           {{- if $.Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -691,6 +710,11 @@ spec:
             failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
             periodSeconds: {{ $.Values.livenessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if $.Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml $.Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
           {{- if $.Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
@@ -709,6 +733,11 @@ spec:
             failureThreshold: {{ $.Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ $.Values.readinessProbe.periodSeconds }}
           {{- end }}
+          {{- end }}
+          {{- if $.Values.customStartupProbe }}
+          startupProbe:
+            {{- toYaml $.Values.customStartupProbe | nindent 12 }}
+          {{- else }}
           {{- if $.Values.startupProbe.enabled }}
           startupProbe:
             exec:
@@ -726,6 +755,7 @@ spec:
             successThreshold: {{ $.Values.startupProbe.successThreshold }}
             failureThreshold: {{ $.Values.startupProbe.failureThreshold }}
             periodSeconds: {{ $.Values.startupProbe.periodSeconds }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: mongodb-arbiter-data

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -178,6 +178,10 @@ spec:
             {{- with .Values.extraEnvVars }}
 {{ toYaml . | indent 12 }}
             {{- end }}
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.customLivenessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -198,6 +202,11 @@ spec:
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.customReadinessProbe | nindent 12 }}
+          {{- else }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             exec:
@@ -217,6 +226,7 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
           {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
### Description of the change

Use the value customReadinessProbe, customLivenessProbe and customStartUpProbe to use custom probes in all statefulsets. 

### Benefits

Ability to use custom Probes for the mongodb StatefulSets. 

### Possible drawbacks

None, is not being used by default.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
