### PR TITLE
[valkey] Add sentinel.masterProxy: HAProxy sidecar for a stable master endpoint

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.24.6
+version: 0.25.0
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:
@@ -42,6 +42,11 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
+    - kind: added
+      description: "Add sentinel.masterProxy: an HAProxy sidecar bundled into each Valkey pod that gives non-Sentinel-aware clients a stable master endpoint, determined from INFO replication on the data plane instead of a Kubernetes Service selector patched via kubectl/RBAC"
+      links:
+        - name: "Changelog"
+          url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/valkey/CHANGELOG.md"
     - kind: added
       description: "Add namespaceOverride Value to all Charts that missing it"
       links:

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -45,6 +45,8 @@ annotations:
     - kind: added
       description: "Add sentinel.masterProxy: an HAProxy sidecar bundled into each Valkey pod that gives non-Sentinel-aware clients a stable master endpoint, determined from INFO replication on the data plane instead of a Kubernetes Service selector patched via kubectl/RBAC"
       links:
+        - name: "Pull Request"
+          url: "https://github.com/CloudPirates-io/helm-charts/pull/1523"
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/valkey/CHANGELOG.md"
     - kind: added

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -300,6 +300,19 @@ Sentinel provides high availability for Valkey replication. When enabled, Sentin
 | `sentinel.resources`                 | Resource limits and requests for Sentinel container                                 | `{}`                                                                                         |
 | `sentinel.valkeyShutdownWaitFailover` | Whether the Valkey container waits for Sentinel failover before shutting down       | `true`                                                                                       |
 | `sentinel.preStop.enabled`           | Enable the preStop hook on the Sentinel container                                    | `true`                                                                                       |
+| `sentinel.masterProxy.enabled`             | Enable a stable master endpoint for non-Sentinel-aware clients via an HAProxy sidecar | `false`     |
+| `sentinel.masterProxy.image.registry`      | HAProxy image registry                                                                | `docker.io` |
+| `sentinel.masterProxy.image.repository`    | HAProxy image repository                                                              | `haproxy`   |
+| `sentinel.masterProxy.image.tag`           | HAProxy image tag                                                                     | `3.0-alpine`|
+| `sentinel.masterProxy.image.pullPolicy`    | HAProxy image pull policy                                                             | `IfNotPresent` |
+| `sentinel.masterProxy.containerPort`       | Port the HAProxy sidecar listens on                                                   | `6380`      |
+| `sentinel.masterProxy.checkInterval`       | Health check interval (HAProxy `inter`)                                               | `"1s"`      |
+| `sentinel.masterProxy.checkRise`           | Consecutive successful checks before a backend is marked master-eligible             | `2`         |
+| `sentinel.masterProxy.checkFall`           | Consecutive failed checks before a backend is marked down                            | `2`         |
+| `sentinel.masterProxy.requireConnectedReplica` | Also require `connected_slaves > 0` on the candidate master                       | `false`     |
+| `sentinel.masterProxy.resources`           | Resource limits and requests for the HAProxy sidecar                                  | `{}`        |
+| `sentinel.masterProxy.service.type`        | Kubernetes service type for the master proxy service                                  | `""`        |
+| `sentinel.masterProxy.service.annotations` | Additional custom annotations for the master proxy service                            | `{}`        |
 
 ### Init Container Configuration
 

--- a/charts/valkey/README.md
+++ b/charts/valkey/README.md
@@ -280,6 +280,8 @@ Configure Valkey as a replica of an external Redis/Valkey server. This is useful
 
 Sentinel provides high availability for Valkey replication. When enabled, Sentinel monitors the master and automatically promotes a replica to master if the master fails.
 
+When `sentinel.masterProxy.enabled` is set, the `<release>-master` Service always selects every Valkey pod rather than just the current master, since any pod's HAProxy sidecar can forward a connection to whichever one is actually master - so `kubectl get endpoints <release>-master` won't tell you who that is. To check, look at the HAProxy sidecar's own logs on any pod: `kubectl logs <pod> -c haproxy`, which reports every time a backend transitions `UP`/`DOWN`.
+
 | Parameter                            | Description                                                                         | Default                                                                                      |
 | ------------------------------------ | ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `sentinel.enabled`                   | Enable Valkey Sentinel for high availability                                        | `false`                                                                                      |
@@ -309,7 +311,6 @@ Sentinel provides high availability for Valkey replication. When enabled, Sentin
 | `sentinel.masterProxy.checkInterval`       | Health check interval (HAProxy `inter`)                                               | `"1s"`      |
 | `sentinel.masterProxy.checkRise`           | Consecutive successful checks before a backend is marked master-eligible             | `2`         |
 | `sentinel.masterProxy.checkFall`           | Consecutive failed checks before a backend is marked down                            | `2`         |
-| `sentinel.masterProxy.requireConnectedReplica` | Also require `connected_slaves > 0` on the candidate master                       | `false`     |
 | `sentinel.masterProxy.resources`           | Resource limits and requests for the HAProxy sidecar                                  | `{}`        |
 | `sentinel.masterProxy.service.type`        | Kubernetes service type for the master proxy service                                  | `""`        |
 | `sentinel.masterProxy.service.annotations` | Additional custom annotations for the master proxy service                            | `{}`        |

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -129,3 +129,10 @@ Return Valkey config full path name
 {{- define "valkey.configFullName" -}}
 {{- printf "%s/valkey.conf" (include "valkey.configDir" .) -}}
 {{- end }}
+
+{{/*
+Return the proper master-proxy (HAProxy) image name
+*/}}
+{{- define "valkey.masterProxy.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.sentinel.masterProxy.image "global" .Values.global) -}}
+{{- end }}

--- a/charts/valkey/templates/sentinel-master-proxy-service.yaml
+++ b/charts/valkey/templates/sentinel-master-proxy-service.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.sentinel.enabled .Values.sentinel.masterProxy.enabled (eq .Values.architecture "replication") (not .Values.tls.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "valkey.fullname" . }}-master
+  namespace: {{ include "cloudpirates.namespace" . }}
+  labels:
+    {{- include "valkey.labels" . | nindent 4 }}
+    app.kubernetes.io/component: master-proxy
+  {{- $annotations := merge .Values.sentinel.masterProxy.service.annotations .Values.commonAnnotations }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  # Selects every StatefulSet pod: the HAProxy sidecar runs in each one and forwards
+  # to whichever pod is currently master, so any pod can answer this Service.
+  type: {{ .Values.sentinel.masterProxy.service.type | default .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: haproxy
+      protocol: TCP
+      name: valkey
+  selector:
+    {{- include "valkey.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -525,6 +525,99 @@ spec:
           {{- end }}
           resources: {{- toYaml .Values.sentinel.resources | nindent 12 }}
         {{- end }}
+        {{- if and .Values.sentinel.enabled .Values.sentinel.masterProxy.enabled (eq .Values.architecture "replication") }}
+        {{- if .Values.tls.enabled }}
+        {{- fail "sentinel.masterProxy is not yet supported together with tls.enabled" }}
+        {{- end }}
+        - name: haproxy
+          securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
+          image: {{ include "valkey.masterProxy.image" . }}
+          imagePullPolicy: {{ .Values.sentinel.masterProxy.image.pullPolicy }}
+          {{- if .Values.auth.enabled }}
+          env:
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "valkey.secretName" . }}
+                  key: {{ include "valkey.passwordKey" . }}
+          {{- end }}
+          volumeMounts:
+            - name: haproxy-config
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              cat > /tmp/haproxy.cfg << 'EOF'
+              global
+                  maxconn 2000
+
+              defaults
+                  mode tcp
+                  timeout connect 2s
+                  timeout client 30s
+                  timeout server 30s
+
+              resolvers cluster_dns
+                  parse-resolv-conf
+                  hold valid 10s
+                  hold other 30s
+                  hold refused 30s
+                  hold nx 30s
+                  hold timeout 30s
+                  hold obsolete 30s
+
+              frontend valkey_master_fe
+                  bind *:{{ .Values.sentinel.masterProxy.containerPort }}
+                  default_backend valkey_master_be
+
+              backend valkey_master_be
+                  mode tcp
+                  option tcp-check
+                  tcp-check connect
+                  {{- if .Values.auth.enabled }}
+                  tcp-check send "AUTH __VALKEY_PASSWORD__\r\n"
+                  tcp-check expect string +OK
+                  {{- end }}
+                  tcp-check send "PING\r\n"
+                  tcp-check expect string +PONG
+                  tcp-check send "INFO replication\r\n"
+                  tcp-check expect string role:master min-recv 100
+                  {{- if .Values.sentinel.masterProxy.requireConnectedReplica }}
+                  tcp-check expect ! string connected_slaves:0
+                  {{- end }}
+                  tcp-check send "QUIT\r\n"
+                  tcp-check expect string +OK
+                  {{- range $i := until (int $.Values.replicaCount) }}
+                  server {{ include "valkey.fullname" $ }}-{{ $i }} {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.fullname" $ }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.service.port }} check inter {{ $.Values.sentinel.masterProxy.checkInterval }} rise {{ $.Values.sentinel.masterProxy.checkRise }} fall {{ $.Values.sentinel.masterProxy.checkFall }} resolvers cluster_dns resolve-prefer ipv4 init-addr none
+                  {{- end }}
+              EOF
+              {{- if .Values.auth.enabled }}
+              sed -i "s/__VALKEY_PASSWORD__/${VALKEY_PASSWORD}/" /tmp/haproxy.cfg
+              {{- end }}
+              exec haproxy -f /tmp/haproxy.cfg -db
+          ports:
+            - name: haproxy
+              containerPort: {{ .Values.sentinel.masterProxy.containerPort }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: haproxy
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: haproxy
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.sentinel.masterProxy.resources | nindent 12 }}
+        {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
@@ -581,6 +674,10 @@ spec:
           configMap:
             name: {{ include "valkey.fullname" . }}-prestop-script
             defaultMode: 0755
+        {{- if .Values.sentinel.masterProxy.enabled }}
+        - name: haproxy-config
+          emptyDir: {}
+        {{- end }}
         {{- end }}
         {{- end }}
         - name: config

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -529,6 +529,9 @@ spec:
         {{- if .Values.tls.enabled }}
         {{- fail "sentinel.masterProxy is not yet supported together with tls.enabled" }}
         {{- end }}
+        {{- if eq (int .Values.sentinel.masterProxy.containerPort) (int .Values.service.port) }}
+        {{- fail "sentinel.masterProxy.containerPort must differ from service.port" }}
+        {{- end }}
         - name: haproxy
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "valkey.masterProxy.image" . }}
@@ -594,7 +597,7 @@ spec:
                   tcp-check send "QUIT\r\n"
                   tcp-check expect string +OK
                   {{- range $i := until (int $.Values.replicaCount) }}
-                  server {{ include "valkey.fullname" $ }}-{{ $i }} {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.fullname" $ }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.service.port }} check inter {{ $.Values.sentinel.masterProxy.checkInterval }} rise {{ $.Values.sentinel.masterProxy.checkRise }} fall {{ $.Values.sentinel.masterProxy.checkFall }} resolvers cluster_dns resolve-prefer ipv4 init-addr none
+                  server {{ include "valkey.fullname" $ }}-{{ $i }} {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.fullname" $ }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.service.port }} check inter {{ $.Values.sentinel.masterProxy.checkInterval }} rise {{ $.Values.sentinel.masterProxy.checkRise }} fall {{ $.Values.sentinel.masterProxy.checkFall }} resolvers cluster_dns resolve-prefer {{ if eq $.Values.ipFamily "ipv6" }}ipv6{{ else }}ipv4{{ end }} init-addr none
                   {{- end }}
 
               # Fallback used only when no server qualifies for valkey_master_strict
@@ -616,11 +619,12 @@ spec:
                   tcp-check send "QUIT\r\n"
                   tcp-check expect string +OK
                   {{- range $i := until (int $.Values.replicaCount) }}
-                  server {{ include "valkey.fullname" $ }}-{{ $i }} {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.fullname" $ }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.service.port }} check inter {{ $.Values.sentinel.masterProxy.checkInterval }} rise {{ $.Values.sentinel.masterProxy.checkRise }} fall {{ $.Values.sentinel.masterProxy.checkFall }} resolvers cluster_dns resolve-prefer ipv4 init-addr none
+                  server {{ include "valkey.fullname" $ }}-{{ $i }} {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.fullname" $ }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.service.port }} check inter {{ $.Values.sentinel.masterProxy.checkInterval }} rise {{ $.Values.sentinel.masterProxy.checkRise }} fall {{ $.Values.sentinel.masterProxy.checkFall }} resolvers cluster_dns resolve-prefer {{ if eq $.Values.ipFamily "ipv6" }}ipv6{{ else }}ipv4{{ end }} init-addr none
                   {{- end }}
               EOF
               {{- if .Values.auth.enabled }}
-              sed -i "s/__VALKEY_PASSWORD__/${VALKEY_PASSWORD}/" /tmp/haproxy.cfg
+              ESCAPED_PASSWORD=$(printf '%s' "$VALKEY_PASSWORD" | sed -e 's/\\/\\\\/g' -e 's/[/&]/\\&/g')
+              sed -i "s/__VALKEY_PASSWORD__/${ESCAPED_PASSWORD}/" /tmp/haproxy.cfg
               {{- end }}
               exec haproxy -f /tmp/haproxy.cfg -db
           ports:

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -589,7 +589,7 @@ spec:
                   tcp-check expect string +PONG
                   tcp-check send "INFO replication\r\n"
                   tcp-check expect string role:master min-recv 100
-                  tcp-check expect ! string connected_slaves:0
+                  tcp-check expect rstring connected_slaves:[1-9][0-9]*
                   tcp-check expect string master_failover_state:no-failover
                   tcp-check send "QUIT\r\n"
                   tcp-check expect string +OK

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -570,9 +570,14 @@ spec:
 
               frontend valkey_master_fe
                   bind *:{{ .Values.sentinel.masterProxy.containerPort }}
-                  default_backend valkey_master_be
+                  use_backend valkey_master_strict if { nbsrv(valkey_master_strict) gt 0 }
+                  default_backend valkey_master_any
 
-              backend valkey_master_be
+              # Preferred: role:master, an attached replica, and not mid-failover.
+              # Excludes a pod that self-declared master on restart before Sentinel
+              # finished failing over (no replica ever attached to it), and one that
+              # knows it's still in the middle of a handoff.
+              backend valkey_master_strict
                   mode tcp
                   option tcp-check
                   tcp-check connect
@@ -584,9 +589,30 @@ spec:
                   tcp-check expect string +PONG
                   tcp-check send "INFO replication\r\n"
                   tcp-check expect string role:master min-recv 100
-                  {{- if .Values.sentinel.masterProxy.requireConnectedReplica }}
                   tcp-check expect ! string connected_slaves:0
+                  tcp-check expect string master_failover_state:no-failover
+                  tcp-check send "QUIT\r\n"
+                  tcp-check expect string +OK
+                  {{- range $i := until (int $.Values.replicaCount) }}
+                  server {{ include "valkey.fullname" $ }}-{{ $i }} {{ include "valkey.fullname" $ }}-{{ $i }}.{{ include "valkey.fullname" $ }}-headless.{{ include "cloudpirates.namespace" $ }}.svc.{{ $.Values.clusterDomain }}:{{ $.Values.service.port }} check inter {{ $.Values.sentinel.masterProxy.checkInterval }} rise {{ $.Values.sentinel.masterProxy.checkRise }} fall {{ $.Values.sentinel.masterProxy.checkFall }} resolvers cluster_dns resolve-prefer ipv4 init-addr none
                   {{- end }}
+
+              # Fallback used only when no server qualifies for valkey_master_strict
+              # (e.g. right after a fresh install, or a replica mid-resync). Keeps the
+              # endpoint available instead of going dark, at the cost of trusting a
+              # role:master answer on its own.
+              backend valkey_master_any
+                  mode tcp
+                  option tcp-check
+                  tcp-check connect
+                  {{- if .Values.auth.enabled }}
+                  tcp-check send "AUTH __VALKEY_PASSWORD__\r\n"
+                  tcp-check expect string +OK
+                  {{- end }}
+                  tcp-check send "PING\r\n"
+                  tcp-check expect string +PONG
+                  tcp-check send "INFO replication\r\n"
+                  tcp-check expect string role:master min-recv 100
                   tcp-check send "QUIT\r\n"
                   tcp-check expect string +OK
                   {{- range $i := until (int $.Values.replicaCount) }}

--- a/charts/valkey/tests/sentinel-master-proxy_test.yaml
+++ b/charts/valkey/tests/sentinel-master-proxy_test.yaml
@@ -112,3 +112,58 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[2].command[2]
           pattern: "(?ms)^backend valkey_master_any$.*?master_failover_state:no-failover"
+
+  - it: should fail when containerPort collides with service.port
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+          containerPort: 6379
+    asserts:
+      - failedTemplate:
+          errorMessage: "sentinel.masterProxy.containerPort must differ from service.port"
+
+  - it: should prefer ipv6 DNS resolution when ipFamily is ipv6
+    template: statefulset.yaml
+    set:
+      ipFamily: ipv6
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "resolve-prefer ipv6"
+      - notMatchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "resolve-prefer ipv4"
+
+  - it: should default to ipv4 DNS resolution when ipFamily is auto
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "resolve-prefer ipv4"
+
+  - it: should escape sed-special characters in the password before substitution
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "ESCAPED_PASSWORD=.*sed -e '[^']*\\\\\\\\[^']*' -e '[^']*&[^']*'"
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "sed -i \"s/__VALKEY_PASSWORD__/\\$\\{ESCAPED_PASSWORD\\}/\" /tmp/haproxy\\.cfg"

--- a/charts/valkey/tests/sentinel-master-proxy_test.yaml
+++ b/charts/valkey/tests/sentinel-master-proxy_test.yaml
@@ -102,13 +102,13 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[2].command[2]
-          pattern: "(?ms)^backend valkey_master_strict$.*?connected_slaves:0.*?^backend valkey_master_any$"
+          pattern: "(?ms)^backend valkey_master_strict$.*?connected_slaves:\\[1-9\\].*?^backend valkey_master_any$"
       - matchRegex:
           path: spec.template.spec.containers[2].command[2]
           pattern: "(?ms)^backend valkey_master_strict$.*?master_failover_state:no-failover.*?^backend valkey_master_any$"
       - notMatchRegex:
           path: spec.template.spec.containers[2].command[2]
-          pattern: "(?ms)^backend valkey_master_any$.*?connected_slaves:0"
+          pattern: "(?ms)^backend valkey_master_any$.*?connected_slaves:"
       - notMatchRegex:
           path: spec.template.spec.containers[2].command[2]
           pattern: "(?ms)^backend valkey_master_any$.*?master_failover_state:no-failover"

--- a/charts/valkey/tests/sentinel-master-proxy_test.yaml
+++ b/charts/valkey/tests/sentinel-master-proxy_test.yaml
@@ -1,0 +1,103 @@
+suite: test sentinel.masterProxy
+set:
+  architecture: replication
+  sentinel:
+    enabled: true
+  auth:
+    password: testpass123
+tests:
+  - it: should not render the haproxy sidecar by default
+    template: statefulset.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - notExists:
+          path: spec.template.spec.containers[2]
+
+  - it: should not render the master-proxy service when masterProxy is disabled
+    template: sentinel-master-proxy-service.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render the haproxy sidecar when masterProxy is enabled
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[2].ports[0].containerPort
+          value: 6380
+      - equal:
+          path: spec.template.spec.containers[2].readinessProbe.tcpSocket.port
+          value: haproxy
+      - equal:
+          path: spec.template.spec.containers[2].livenessProbe.tcpSocket.port
+          value: haproxy
+
+  - it: should render a static master service selecting all StatefulSet pods when masterProxy is enabled
+    template: sentinel-master-proxy-service.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-valkey-master
+      - equal:
+          path: spec.ports[0].targetPort
+          value: haproxy
+      - notExists:
+          path: spec.selector["app.kubernetes.io/component"]
+
+  - it: should fail when masterProxy and tls are both enabled
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - failedTemplate:
+          errorMessage: "sentinel.masterProxy is not yet supported together with tls.enabled"
+
+  - it: should not require an attached replica by default
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "connected_slaves:0"
+
+  - it: should require an attached replica when requireConnectedReplica is true
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+          requireConnectedReplica: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "connected_slaves:0"

--- a/charts/valkey/tests/sentinel-master-proxy_test.yaml
+++ b/charts/valkey/tests/sentinel-master-proxy_test.yaml
@@ -77,27 +77,38 @@ tests:
       - failedTemplate:
           errorMessage: "sentinel.masterProxy is not yet supported together with tls.enabled"
 
-  - it: should not require an attached replica by default
+  - it: should fall back to valkey_master_any when no strict candidate is available
     template: statefulset.yaml
     set:
       sentinel:
         enabled: true
         masterProxy:
           enabled: true
-    asserts:
-      - notMatchRegex:
-          path: spec.template.spec.containers[2].command[2]
-          pattern: "connected_slaves:0"
-
-  - it: should require an attached replica when requireConnectedReplica is true
-    template: statefulset.yaml
-    set:
-      sentinel:
-        enabled: true
-        masterProxy:
-          enabled: true
-          requireConnectedReplica: true
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[2].command[2]
-          pattern: "connected_slaves:0"
+          pattern: "use_backend valkey_master_strict if \\{ nbsrv\\(valkey_master_strict\\) gt 0 \\}"
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "default_backend valkey_master_any"
+
+  - it: should require an attached replica and no in-progress failover only on the strict backend
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        masterProxy:
+          enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "(?ms)^backend valkey_master_strict$.*?connected_slaves:0.*?^backend valkey_master_any$"
+      - matchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "(?ms)^backend valkey_master_strict$.*?master_failover_state:no-failover.*?^backend valkey_master_any$"
+      - notMatchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "(?ms)^backend valkey_master_any$.*?connected_slaves:0"
+      - notMatchRegex:
+          path: spec.template.spec.containers[2].command[2]
+          pattern: "(?ms)^backend valkey_master_any$.*?master_failover_state:no-failover"

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -536,6 +536,60 @@
                 "masterName": {
                     "type": "string"
                 },
+                "masterProxy": {
+                    "type": "object",
+                    "properties": {
+                        "checkFall": {
+                            "type": "integer"
+                        },
+                        "checkInterval": {
+                            "type": "string"
+                        },
+                        "checkRise": {
+                            "type": "integer"
+                        },
+                        "containerPort": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requireConnectedReplica": {
+                            "type": "boolean"
+                        },
+                        "resources": {
+                            "type": "object"
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": "object"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
                 "parallelSyncs": {
                     "type": "integer"
                 },

--- a/charts/valkey/values.schema.json
+++ b/charts/valkey/values.schema.json
@@ -571,9 +571,6 @@
                                 }
                             }
                         },
-                        "requireConnectedReplica": {
-                            "type": "boolean"
-                        },
                         "resources": {
                             "type": "object"
                         },

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -472,6 +472,58 @@ sentinel:
   preStop:
     ## @param sentinel.preStop.enabled Enable the preStop hook on the Sentinel container
     enabled: true
+  masterProxy:
+    ## @param sentinel.masterProxy.enabled Enable a stable master endpoint for non-Sentinel-aware clients
+    ## Adds an HAProxy sidecar to every Valkey pod (alongside the existing Sentinel sidecar) that
+    ## determines the master by checking INFO replication on each backend directly, instead of
+    ## trusting a Kubernetes Service selector patched from Sentinel's opinion. It also closes
+    ## client connections to a demoted master, forcing an immediate reconnect instead of leaving
+    ## clients writing against a stale socket. Because it's bundled into the StatefulSet, proxy
+    ## redundancy scales automatically with replicaCount and needs no separate RBAC, ServiceAccount,
+    ## affinity, or PodDisruptionBudget.
+    enabled: false
+    image:
+      ## @param sentinel.masterProxy.image.registry HAProxy image registry
+      registry: docker.io
+      ## @param sentinel.masterProxy.image.repository HAProxy image repository
+      repository: haproxy
+      ## @param sentinel.masterProxy.image.tag HAProxy image tag
+      tag: "3.0-alpine"
+      ## @param sentinel.masterProxy.image.pullPolicy HAProxy image pull policy
+      pullPolicy: IfNotPresent
+    ## @param sentinel.masterProxy.containerPort Port the HAProxy sidecar listens on (must differ from service.port, which the Valkey container in the same pod already uses)
+    containerPort: 6380
+    ## @param sentinel.masterProxy.checkInterval Health check interval (HAProxy `inter`, e.g. "1s")
+    checkInterval: "1s"
+    ## @param sentinel.masterProxy.checkRise Consecutive successful checks before a backend is marked master-eligible
+    checkRise: 2
+    ## @param sentinel.masterProxy.checkFall Consecutive failed checks before a backend is marked down
+    checkFall: 2
+    ## @param sentinel.masterProxy.requireConnectedReplica Also require connected_slaves > 0 on the candidate master
+    ## Plain `role:master` is not sufficient on its own: a pod that restarts with empty/ephemeral
+    ## storage can come back up self-declared as master (see the sentinel container's bootstrap
+    ## logic) before Sentinel has finished failing over, producing two backends that both report
+    ## role:master at once - confirmed in testing. Requiring at least one attached replica excludes
+    ## the orphaned one.
+    ## Trade-off: right after a fresh install, or right after a replica restarts and starts
+    ## resyncing, the real master can transiently show connected_slaves:0 too - with this enabled,
+    ## the master endpoint is unavailable for that window rather than risking a split-brain read.
+    ## Defaults to false (matching plain role:master, like the reference design) until there's a
+    ## safer way to bound that window; enable it if you'd rather fail closed than risk split-brain.
+    requireConnectedReplica: false
+    ## @param sentinel.masterProxy.resources Resource limits and requests for the HAProxy sidecar
+    resources: {}
+      # limits:
+      #   cpu: 100m
+      #   memory: 64Mi
+      # requests:
+      #   cpu: 10m
+      #   memory: 32Mi
+    service:
+      ## @param sentinel.masterProxy.service.type Kubernetes service type for the master proxy service
+      type: ""
+      ## @param sentinel.masterProxy.service.annotations Additional custom annotations for the master proxy service
+      annotations: {}
 
 ## @param resources Resource limits and requests for Valkey init container pod
 initContainer:

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -491,7 +491,9 @@ sentinel:
       tag: "3.0-alpine"
       ## @param sentinel.masterProxy.image.pullPolicy HAProxy image pull policy
       pullPolicy: IfNotPresent
-    ## @param sentinel.masterProxy.containerPort Port the HAProxy sidecar listens on (must differ from service.port, which the Valkey container in the same pod already uses)
+    ## @param sentinel.masterProxy.containerPort Port the HAProxy sidecar listens on
+    ## Must differ from service.port, which the Valkey container in the same pod already uses -
+    ## enforced at render time with a `fail` if they collide.
     containerPort: 6380
     ## @param sentinel.masterProxy.checkInterval Health check interval (HAProxy `inter`, e.g. "1s")
     checkInterval: "1s"

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -499,18 +499,17 @@ sentinel:
     checkRise: 2
     ## @param sentinel.masterProxy.checkFall Consecutive failed checks before a backend is marked down
     checkFall: 2
-    ## @param sentinel.masterProxy.requireConnectedReplica Also require connected_slaves > 0 on the candidate master
     ## Plain `role:master` is not sufficient on its own: a pod that restarts with empty/ephemeral
     ## storage can come back up self-declared as master (see the sentinel container's bootstrap
     ## logic) before Sentinel has finished failing over, producing two backends that both report
-    ## role:master at once - confirmed in testing. Requiring at least one attached replica excludes
-    ## the orphaned one.
-    ## Trade-off: right after a fresh install, or right after a replica restarts and starts
-    ## resyncing, the real master can transiently show connected_slaves:0 too - with this enabled,
-    ## the master endpoint is unavailable for that window rather than risking a split-brain read.
-    ## Defaults to false (matching plain role:master, like the reference design) until there's a
-    ## safer way to bound that window; enable it if you'd rather fail closed than risk split-brain.
-    requireConnectedReplica: false
+    ## role:master at once - confirmed in testing. To guard against this, the proxy prefers a
+    ## candidate with an attached replica and no failover in progress (connected_slaves > 0 and
+    ## master_failover_state:no-failover), falling back to plain role:master only when no
+    ## candidate satisfies that stricter check - e.g. right after a fresh install, or right after
+    ## a replica restarts and is still resyncing, so the endpoint never goes fully unavailable.
+    ## This narrows split-brain exposure but doesn't eliminate it: if two candidates satisfy the
+    ## stricter check at the same instant (a replica split 1:1 across the old and new master), the
+    ## proxy can still round-robin between both until one drops out.
     ## @param sentinel.masterProxy.resources Resource limits and requests for the HAProxy sidecar
     resources: {}
       # limits:


### PR DESCRIPTION
### Description of the change

Valkey with Sentinel doesn't give clients a way in if they can't speak the Sentinel protocol - that's #1470. This adds `sentinel.masterProxy`, which bundles an HAProxy sidecar into every Valkey pod (next to the existing Sentinel sidecar) and gives you a `<release>-master` Service that always points at whoever the current master is.

HAProxy doesn't ask Sentinel or the Kubernetes API who the master is. It checks each Valkey pod directly with `INFO replication` every second and only forwards traffic to whichever one answers `role:master`. Sentinel keeps doing what it already does - detecting the failure, promoting a replica - HAProxy just reacts to that on the data plane, independently.

This follows up on the discussion in #1470 around not directly porting the Redis chart's `sentinel.masterService` (kubectl exec into a Sentinel pod + patch the Service selector) into Valkey. That design has some real weaknesses worth avoiding here: a 60s poll interval by default, `pods/exec` RBAC, `--force-conflicts --field-manager=helm` to fight Helm for ownership of the selector on every upgrade, and - the one that matters most - it never closes the client's existing connection to the demoted master, so a pooled connection can sit there getting `-READONLY` on writes until the app happens to notice.

What's in this PR:

- `sentinel.masterProxy.*` values, disabled by default
- an `haproxy` container added to the StatefulSet, with its own readiness/liveness probes
- a static `<release>-master` Service - the selector never changes, all 3 pods run the sidecar, whichever one you land on forwards you to the real master
- helm-unittest coverage in `tests/sentinel-master-proxy_test.yaml`
- README and values.schema.json updated

A couple of things worth calling out that aren't obvious from just reading the diff:

- HAProxy resolves each pod's hostname through a `resolvers` block with periodic re-resolution, not once at startup. Without that, a StatefulSet pod that restarts with a new IP gets stuck marked down forever, since HAProxy's default behavior is to resolve server hostnames once at boot.
- Trusting a plain `role:master` answer isn't enough on its own: a pod that restarts with empty/ephemeral storage can come back up self-declared master before Sentinel has finished failing over, so for a window you get two pods both answering `role:master` - I hit this in testing. To guard against it, the proxy runs two HAProxy backends: `valkey_master_strict` also requires an attached replica (`connected_slaves > 0`) and no failover in progress (`master_failover_state:no-failover`), and the frontend routes there via `nbsrv()` whenever a candidate qualifies, falling back to `valkey_master_any` (plain `role:master`) otherwise so the endpoint never goes fully unavailable (a fresh install or a resyncing replica can transiently leave nobody qualifying for the strict backend). This narrows the split-brain window rather than closing it outright - if two candidates satisfy the strict backend at the same instant (a replica split across the old and new master), traffic can still get round-robined between both until one drops out. Happy to discuss whether that residual risk is acceptable or whether a different mechanism is preferred.
- TLS isn't supported yet - enabling both `tls.enabled` and `sentinel.masterProxy.enabled` fails at render time with an explicit error instead of quietly producing something broken.

Tested end-to-end against a local k3d cluster (3 replicas, Sentinel enabled): force-killed the master pod under write load and the client reconnected cleanly through the proxy with no lasting split-brain, and normal operation was confirmed to route to the correct master.

### Benefits

- No RBAC, ServiceAccount, or Kubernetes API access needed at all - it's a plain TCP proxy watching the data plane.
- Reacts to a failover in about as long as the health check takes (a couple seconds), not a poll interval.
- Closes stale connections to the demoted master instead of leaving them open.
- Proxy redundancy scales with `replicaCount` automatically since it's a sidecar, not a separate Deployment with its own replica count to manage.

### Possible drawbacks

- One more container per pod (small footprint, but it's there).
- `kubectl get endpoints <release>-master` will show all 3 pods, not just the current master, since any pod's sidecar can forward to the real one. `kubectl logs <pod> -c haproxy` is the way to check instead - it logs every backend UP/DOWN transition.
- The split-brain guard narrows but doesn't fully close the window described above where two pods could momentarily both look like a valid master.
- No TLS support yet.

### Applicable issues

Addresses #1470

### Additional information

Open to adjusting based on what direction maintainers prefer. This leans towards the proxy option discussed in the issue rather than a controller that patches Sentinel's opinion into the Service, mainly because it's the only one of the two that actually closes stale connections rather than just answering the "who's master" question faster.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to semver
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified
