### PR TITLE
[redis] Fix the metrics service port name in the ServiceMonitor

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.33.5
+version: 0.33.6
 appVersion: "8.8.1"
 keywords:
   - redis

--- a/charts/redis/templates/servicemonitor.yaml
+++ b/charts/redis/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
       {{- include "redis.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: metrics
   endpoints:
-    - port: metrics
+    - port: {{ .Values.metrics.service.name }}
       {{- with .Values.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
@@ -44,7 +44,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if and .Values.sentinel.enabled (eq .Values.architecture "replication") }}
-    - port: metrics
+    - port: {{ .Values.metrics.service.name }}
       {{- with .Values.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/charts/redis/tests/servicemonitor_test.yaml
+++ b/charts/redis/tests/servicemonitor_test.yaml
@@ -1,0 +1,69 @@
+suite: test redis service monitor
+templates:
+  - servicemonitor.yaml
+  - metrics-service.yaml
+tests:
+  - it: should scrape the port name exposed by the metrics service
+    template: servicemonitor.yaml
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].port
+          value: http-metrics
+
+  - it: should expose that same port name on the metrics service
+    template: metrics-service.yaml
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].name
+          value: http-metrics
+
+  - it: should follow a custom metrics service name
+    template: servicemonitor.yaml
+    set:
+      metrics:
+        enabled: true
+        service:
+          name: metrics
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+
+  - it: should scrape the metrics service port on the sentinel endpoint
+    template: servicemonitor.yaml
+    set:
+      architecture: replication
+      sentinel:
+        enabled: true
+      metrics:
+        enabled: true
+        service:
+          name: custom-metrics
+        serviceMonitor:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].port
+          value: custom-metrics
+      - equal:
+          path: spec.endpoints[1].port
+          value: custom-metrics
+      - equal:
+          path: spec.endpoints[1].path
+          value: /scrape


### PR DESCRIPTION
### Description of the change

The ServiceMonitor hardcodes `port: metrics`, but the metrics Service names its port from `.Values.metrics.service.name`, which defaults to `http-metrics` since #1498. The endpoint matches no port on the Service, so Prometheus scrapes nothing.

### Benefits

Metrics are scraped again with the default `metrics.service.name`.

### Possible drawbacks

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))