### PR TITLE
[redis] Drop password secret ref when auth is disabled

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.0
+version: 0.34.1
 appVersion: "8.8.1"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1246,7 +1246,7 @@ spec:
             failureThreshold: {{ .Values.sentinel.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.sentinel.livenessProbe.successThreshold }}
           {{- end }}
-          {{- if and (or .Values.auth.enabled .Values.auth.sentinel) (not .Values.auth.acl.enabled) }}
+          {{- if and .Values.auth.enabled (not .Values.auth.acl.enabled) }}
           env:
             - name: REDIS_PASSWORD
               valueFrom:
@@ -1302,7 +1302,7 @@ spec:
               value: /etc/redis/tls-client/{{ .Values.tls.client.certKeyFilename }}
             {{- end }}
             {{- end }}
-            {{- if and (or .Values.auth.enabled .Values.auth.metrics) (not .Values.auth.acl.enabled) }}
+            {{- if and .Values.auth.enabled (not .Values.auth.acl.enabled) }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/redis/tests/auth_argv_test.yaml
+++ b/charts/redis/tests/auth_argv_test.yaml
@@ -379,3 +379,44 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'CONFIG_FILE="/usr/local/etc/redis/redis.conf"'
+
+  - it: should avoid metrics authentication environment when auth is disabled
+    template: statefulset.yaml
+    set:
+      auth.enabled: false
+      metrics.enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-redis
+                key: redis-password
+
+  - it: should avoid sentinel authentication environment when auth is disabled
+    template: statefulset.yaml
+    set:
+      auth.enabled: false
+      architecture: replication
+      sentinel.enabled: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].env
+
+  - it: should keep sentinel authentication environment when only sentinel auth is disabled
+    template: statefulset.yaml
+    set:
+      auth.sentinel: false
+      architecture: replication
+      sentinel.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-redis
+                key: redis-password


### PR DESCRIPTION
### Description of the change

`templates/secret.yaml` only renders when `auth.enabled` is true, but the Sentinel and metrics containers gate their password environment on `or .Values.auth.enabled .Values.auth.sentinel` and `or .Values.auth.enabled .Values.auth.metrics`. Both sub-toggles default to true, so `auth.enabled=false` still emits a `secretKeyRef` to a Secret that is never created and the pods stay in CreateContainerConfigError.

```
helm template rel charts/redis --set auth.enabled=false --set metrics.enabled=true
```

Both gates now match the init and main containers, which already use `and .Values.auth.enabled (not .Values.auth.acl.enabled)`.

### Benefits

Disabling auth works with metrics or Sentinel enabled.

### Possible drawbacks

None when auth is enabled. The Sentinel container still gets the password with `auth.sentinel=false`, which `sentinel auth-pass` needs. Covered by a test.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified