### PR TITLE
[redis] Mount the config volume only when defined

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.4
+version: 0.34.5
 appVersion: "8.10.0"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -618,8 +618,10 @@ spec:
           {{- end }}
           resources: {{- toYaml .Values.initContainer.resources | nindent 12 }}
           volumeMounts:
+            {{- if or .Values.config.content .Values.config.existingConfigmap }}
             - name: config
               mountPath: {{ .Values.config.mountPath }}
+            {{- end }}
             - name: redis-config
               mountPath: /tmp
             {{- if and .Values.auth.acl.enabled .Values.auth.acl.existingSecret }}

--- a/charts/redis/tests/config_test.yaml
+++ b/charts/redis/tests/config_test.yaml
@@ -1,0 +1,59 @@
+suite: test redis configuration volume
+templates:
+  - statefulset.yaml
+tests:
+  - it: should mount the config volume in the init container by default
+    set:
+      architecture: replication
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /usr/local/etc/redis
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-redis-config
+
+  - it: should not mount the config volume in the init container when no config is provided
+    set:
+      architecture: replication
+      config.content: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /usr/local/etc/redis
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /usr/local/etc/redis
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-redis-config
+
+  - it: should mount the config volume in the init container when an existing configmap is used
+    set:
+      architecture: replication
+      config.content: ""
+      config.existingConfigmap: redis-custom-config
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /usr/local/etc/redis
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: redis-custom-config


### PR DESCRIPTION
### Description of the change

The `config` volume only renders when `config.content` or `config.existingConfigmap` is set, and the main container already guards its mount the same way. The init container mounted it unconditionally, so an empty `config.content` produced a volumeMount with no matching volume and the API server rejected the StatefulSet.

```
helm template rel charts/redis --set architecture=replication --set config.content=""
```

### Benefits

The chart installs with an empty `config.content`.

### Possible drawbacks

None. The mount is unchanged whenever a config source is set, which is the default.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified