### PR TITLE
[redis] Honor redisShutdownWaitFailover=false

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.5
+version: 0.34.6
 appVersion: "8.10.0"
 keywords:
   - redis

--- a/charts/redis/templates/prestop-configmap.yaml
+++ b/charts/redis/templates/prestop-configmap.yaml
@@ -150,7 +150,7 @@ data:
     echo "Redis preStop hook starting for pod: $HOSTNAME"
 
     # Check if we should wait for failover (controlled by sentinel.redisShutdownWaitFailover)
-    WAIT_FOR_FAILOVER={{ .Values.sentinel.redisShutdownWaitFailover | default true }}
+    WAIT_FOR_FAILOVER={{ if .Values.sentinel.redisShutdownWaitFailover }}true{{ else }}false{{ end }}
 
     # Only proceed with failover if this instance is the master
     if is_master && [ "$WAIT_FOR_FAILOVER" = "true" ]; then

--- a/charts/redis/tests/prestop_test.yaml
+++ b/charts/redis/tests/prestop_test.yaml
@@ -1,0 +1,24 @@
+suite: test redis prestop failover wait
+templates:
+  - prestop-configmap.yaml
+set:
+  architecture: replication
+  replicaCount: 3
+  sentinel.enabled: true
+tests:
+  - it: should wait for failover by default
+    asserts:
+      - matchRegex:
+          path: data["prestop.sh"]
+          pattern: 'WAIT_FOR_FAILOVER=true'
+
+  - it: should not wait for failover when redisShutdownWaitFailover is disabled
+    set:
+      sentinel.redisShutdownWaitFailover: false
+    asserts:
+      - matchRegex:
+          path: data["prestop.sh"]
+          pattern: 'WAIT_FOR_FAILOVER=false'
+      - notMatchRegex:
+          path: data["prestop.sh"]
+          pattern: 'WAIT_FOR_FAILOVER=true'


### PR DESCRIPTION
### Description of the change

`WAIT_FOR_FAILOVER={{ .Values.sentinel.redisShutdownWaitFailover | default true }}` always rendered `true`, because sprig's `default` treats boolean false as empty. The opt-out branch in `prestop.sh` was unreachable.

```
helm template rel charts/redis --set architecture=replication --set sentinel.enabled=true --set sentinel.redisShutdownWaitFailover=false
```

### Benefits

Masters skip the failover wait when the value is disabled, as documented in `values.yaml`.

### Possible drawbacks

None. The default stays `true` and renders identically.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified