### PR TITLE
[keycloak] Pass managementPort to the server

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.19
+version: 0.21.20
 appVersion: "26.7.0"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -123,6 +123,9 @@ spec:
             {{- if .Values.keycloak.httpsPort }}
             - --https-port={{ .Values.keycloak.httpsPort }}
             {{- end }}
+            {{- if .Values.keycloak.managementPort }}
+            - --http-management-port={{ .Values.keycloak.managementPort }}
+            {{- end }}
             {{- if and .Values.database.type (not (has .Values.database.type (list "h2-file" "h2-mem" "dev-mem"))) }}
             - --db={{ .Values.database.type }}
             - --db-url={{ include "keycloak.databaseUrl" . }}

--- a/charts/keycloak/tests/statefulset-parameters_test.yaml
+++ b/charts/keycloak/tests/statefulset-parameters_test.yaml
@@ -68,6 +68,28 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /auth/health/ready
+  - it: should pass the default management port to keycloak
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --http-management-port=9000
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9000
+  - it: should pass a custom management port to keycloak
+    set:
+      keycloak:
+        managementPort: 9001
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --http-management-port=9001
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9001
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: management
   - it: hostname explicitly set should be unchanged
     set:
       keycloak:


### PR DESCRIPTION
### Description of the change

`keycloak.managementPort` sets the `management` container port and all three probes, but was never passed to Keycloak. The management interface stayed on its built-in default of 9000, so any other value left the probes pointing at a port nothing listens on and the pod never became ready.

```
helm template rel charts/keycloak --set keycloak.managementPort=9001
```

### Benefits

`keycloak.managementPort` moves the management interface, which matters when 9000 is taken by a sidecar or reserved by policy.

### Possible drawbacks

None. The default renders `--http-management-port=9000`, which is Keycloak's own default.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified