### PR TITLE
[keycloak] Build database URL from subchart fullname

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.20
+version: 0.21.21
 appVersion: "26.7.1"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -169,13 +169,13 @@ Return the database JDBC URL
 {{- printf "jdbc:h2:mem:keycloak" -}}
 {{- else if eq .Values.database.type "postgres" -}}
 {{- if .Values.postgres.enabled -}}
-{{- printf "jdbc:postgresql://%s-postgres:%s/%s%s" .Release.Name "5432" (default "keycloak" .Values.postgres.auth.database) (ternary (printf "?%s" .Values.database.jdbcParams) "" (ne .Values.database.jdbcParams "")) -}}
+{{- printf "jdbc:postgresql://%s:%s/%s%s" (include "postgres.fullname" .Subcharts.postgres) "5432" (default "keycloak" .Values.postgres.auth.database) (ternary (printf "?%s" .Values.database.jdbcParams) "" (ne .Values.database.jdbcParams "")) -}}
 {{- else -}}
 {{- printf "jdbc:postgresql://%s:%s/%s%s" .Values.database.host (default "5432" (.Values.database.port | toString)) .Values.database.name (ternary (printf "?%s" .Values.database.jdbcParams) "" (ne .Values.database.jdbcParams "")) -}}
 {{- end -}}
 {{- else if or (eq .Values.database.type "mysql") (eq .Values.database.type "mariadb") -}}
 {{- if .Values.mariadb.enabled -}}
-{{- printf "jdbc:%s://%s-mariadb:%s/%s%s" .Values.database.type .Release.Name "3306" (default "keycloak" .Values.mariadb.auth.database) (ternary (printf "?%s" .Values.database.jdbcParams) "" (ne .Values.database.jdbcParams "")) -}}
+{{- printf "jdbc:%s://%s:%s/%s%s" .Values.database.type (include "mariadb.fullname" .Subcharts.mariadb) "3306" (default "keycloak" .Values.mariadb.auth.database) (ternary (printf "?%s" .Values.database.jdbcParams) "" (ne .Values.database.jdbcParams "")) -}}
 {{- else -}}
 {{- printf "jdbc:%s://%s:%s/%s%s" .Values.database.type .Values.database.host (default "3306" (.Values.database.port | toString)) .Values.database.name (ternary (printf "?%s" .Values.database.jdbcParams) "" (ne .Values.database.jdbcParams "")) -}}
 {{- end -}}

--- a/charts/keycloak/tests/database-url_test.yaml
+++ b/charts/keycloak/tests/database-url_test.yaml
@@ -1,0 +1,73 @@
+suite: test keycloak database url
+templates:
+  - templates/statefulset.yaml
+tests:
+  - it: should point at the embedded postgres service by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --db-url=jdbc:postgresql://RELEASE-NAME-postgres:5432/keycloak
+
+  - it: should follow the postgres subchart fullnameOverride
+    set:
+      postgres:
+        fullnameOverride: my-pg
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --db-url=jdbc:postgresql://my-pg:5432/keycloak
+      - equal:
+          path: spec.template.spec.initContainers[1].command[2]
+          value: "until pg_isready -h my-pg -p 5432 -U postgres; do echo waiting for database; sleep 2; done;"
+
+  - it: should follow the postgres subchart nameOverride
+    set:
+      postgres:
+        nameOverride: pgx
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --db-url=jdbc:postgresql://RELEASE-NAME-pgx:5432/keycloak
+
+  - it: should point at the embedded mariadb service by default
+    set:
+      database:
+        type: mariadb
+      postgres:
+        enabled: false
+      mariadb:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --db-url=jdbc:mariadb://RELEASE-NAME-mariadb:3306/keycloak
+
+  - it: should follow the mariadb subchart fullnameOverride
+    set:
+      database:
+        type: mariadb
+      postgres:
+        enabled: false
+      mariadb:
+        enabled: true
+        fullnameOverride: my-maria
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --db-url=jdbc:mariadb://my-maria:3306/keycloak
+      - equal:
+          path: spec.template.spec.initContainers[1].command[2]
+          value: "until mariadb-admin ping -h my-maria -P 3306 --silent; do echo waiting for database; sleep 2; done;"
+
+  - it: should use the external database host when the subchart is disabled
+    set:
+      postgres:
+        enabled: false
+      database:
+        host: pg.example.com
+        port: "5433"
+        name: kc
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --db-url=jdbc:postgresql://pg.example.com:5433/kc


### PR DESCRIPTION
### Description of the change

`keycloak.databaseUrl` built the host as `{{ .Release.Name }}-postgres` and `{{ .Release.Name }}-mariadb`, while the wait-for-database init container and the password `secretKeyRef` both use `postgres.fullname` and `mariadb.fullname`. They diverge when the subchart name is overridden, and also when the release name already contains the subchart name, since `fullname` then returns the release name unchanged.

```
helm template postgres-idp charts/keycloak
helm template rel charts/keycloak --set postgres.fullnameOverride=my-pg
```

Both render a `--db-url` pointing at a Service that does not exist.

### Benefits

The JDBC URL always matches the Service the subchart creates.

### Possible drawbacks

None. With default names the rendered URL is unchanged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified