### PR TITLE
[keycloak] Fix truststore password secret reference

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.23
+version: 0.21.24
 appVersion: "26.7.1"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -231,6 +231,18 @@ Return TLS truststore secret name
 {{- end }}
 
 {{/*
+Return the secret holding the truststore password. Without an existing truststore
+secret the password is stored alongside the admin credentials.
+*/}}
+{{- define "keycloak.truststorePasswordSecretName" -}}
+{{- if .Values.tls.truststoreExistingSecret -}}
+    {{- .Values.tls.truststoreExistingSecret -}}
+{{- else -}}
+    {{- include "keycloak.secretName" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return metrics service name
 */}}
 {{- define "keycloak.metrics.fullname" -}}

--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -154,9 +154,6 @@ spec:
             {{- end }}
             {{- if .Values.tls.truststoreEnabled }}
             - --https-trust-store-file={{ .Values.tls.truststoreFile }}
-            {{- if .Values.tls.truststorePassword }}
-            - --https-trust-store-password={{ .Values.tls.truststorePassword }}
-            {{- end }}
             {{- end }}
           env:
             - name: KC_HTTP_RELATIVE_PATH
@@ -172,7 +169,7 @@ spec:
             - name: KC_HTTPS_TRUST_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "keycloak.truststoreSecretName" . }}
+                  name: {{ include "keycloak.truststorePasswordSecretName" . }}
                   key: {{ .Values.tls.truststoreExistingSecretPasswordKey }}
             {{- end }}
             {{- if .Values.database.type }}

--- a/charts/keycloak/tests/truststore_test.yaml
+++ b/charts/keycloak/tests/truststore_test.yaml
@@ -1,0 +1,64 @@
+suite: test keycloak truststore password handling
+templates:
+  - templates/statefulset.yaml
+  - templates/secret.yaml
+tests:
+  - it: should read the truststore password from the secret that holds it
+    template: templates/statefulset.yaml
+    set:
+      tls:
+        truststoreEnabled: true
+        truststorePassword: changeit
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_HTTPS_TRUST_STORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-keycloak
+                key: truststore-password
+
+  - it: should write the truststore password into the same secret
+    template: templates/secret.yaml
+    documentIndex: 0
+    set:
+      tls:
+        truststoreEnabled: true
+        truststorePassword: changeit
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-keycloak
+      - isNotNull:
+          path: data["truststore-password"]
+
+  - it: should read the truststore password from an existing truststore secret
+    template: templates/statefulset.yaml
+    set:
+      tls:
+        truststoreEnabled: true
+        truststoreExistingSecret: keycloak-truststore
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KC_HTTPS_TRUST_STORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-truststore
+                key: truststore-password
+
+  - it: should not pass the truststore password as a command line argument
+    template: templates/statefulset.yaml
+    set:
+      tls:
+        truststoreEnabled: true
+        truststorePassword: changeit
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --https-trust-store-file=/opt/keycloak/truststore/truststore.jks
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --https-trust-store-password=changeit

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -46,7 +46,7 @@ podLabels: {}
 ## @param shareProcessNamespace Enable process namespace sharing between containers in the pod
 shareProcessNamespace: false
 ## @param terminationGracePeriodSeconds Seconds Kubernetes waits for the Keycloak pod to terminate. Leave empty to use the Kubernetes default
-terminationGracePeriodSeconds: "" # @schema type:[integer, string]; minimum:0; pattern:^$
+terminationGracePeriodSeconds: ""  # @schema type:[integer, string]; minimum:0; pattern:^$
 ## @param lifecycle Lifecycle hooks for the Keycloak container
 lifecycle: {}
 


### PR DESCRIPTION
### Description of the change

`tls.truststorePassword` is written into the release Secret, but `KC_HTTPS_TRUST_STORE_PASSWORD` read it from `keycloak.truststoreSecretName`, which falls back to `<fullname>-truststore`, a Secret no template creates. It was also passed as `--https-trust-store-password=<value>`.

```
helm template rel charts/keycloak --set tls.truststoreEnabled=true --set tls.truststorePassword=changeit
```

### Benefits

The password is read from where the chart writes it, and no longer appears in plain text in the StatefulSet or the process list.

### Possible drawbacks

None. With `tls.truststoreExistingSecret` set the behaviour is unchanged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified