### PR TITLE
[kafka] Drop the default minAvailable when maxUnavailable is set

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka is a distributed event streaming platform used for high-performance data pipelines, streaming analytics, and data integration. This chart deploys Kafka in KRaft mode (no ZooKeeper required).
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "4.3.1"
 keywords:
   - kafka

--- a/charts/kafka/templates/poddisruptionbudget.yaml
+++ b/charts/kafka/templates/poddisruptionbudget.yaml
@@ -11,7 +11,7 @@ metadata:
 {{- . | indent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
+  {{- if and .Values.podDisruptionBudget.minAvailable (not .Values.podDisruptionBudget.maxUnavailable) }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   {{- if .Values.podDisruptionBudget.maxUnavailable }}

--- a/charts/kafka/tests/poddisruptionbudget_test.yaml
+++ b/charts/kafka/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,50 @@
+suite: test kafka pod disruption budget
+
+tests:
+  - it: should render only minAvailable by default
+    template: poddisruptionbudget.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.minAvailable
+          value: "51%"
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should render only maxUnavailable when it is set
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        maxUnavailable: "30%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "30%"
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should render only maxUnavailable when both are set
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        minAvailable: "80%"
+        maxUnavailable: "25%"
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: "25%"
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should render an explicitly set minAvailable
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        minAvailable: "75%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "75%"
+      - isNull:
+          path: spec.maxUnavailable


### PR DESCRIPTION
### Description of the change

`minAvailable` defaults to `51%` and the two blocks are guarded independently, so `--set podDisruptionBudget.maxUnavailable=30%` renders both fields. The Kubernetes API rejects a PodDisruptionBudget that sets both.

### Benefits

`maxUnavailable` can be selected without also passing `podDisruptionBudget.minAvailable=""` to clear the chart default.

### Possible drawbacks

None. The default render still emits `minAvailable: 51%`, and no working configuration has both fields set today because the apiserver refuses that manifest.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified