### PR TITLE
[valkey] Use tls.port for replication and Sentinel targets

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.25.1
+version: 0.25.2
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/prestop-configmap.yaml
+++ b/charts/valkey/templates/prestop-configmap.yaml
@@ -20,7 +20,7 @@ data:
     set -e
 
     # Configuration
-    VALKEY_PORT="{{ .Values.service.port }}"
+    VALKEY_PORT="{{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}"
     SENTINEL_PORT="{{ .Values.sentinel.port }}"
     MASTER_NAME="{{ .Values.sentinel.masterName }}"
     HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
@@ -39,7 +39,7 @@ data:
 
     # Function to run Valkey commands
     run_valkey_command() {
-        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT" "$@"
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT"{{- if .Values.tls.enabled }} --tls --cert /etc/valkey/tls/{{ .Values.tls.certFilename }} --key /etc/valkey/tls/{{ .Values.tls.certKeyFilename }} --cacert /etc/valkey/tls/{{ .Values.tls.certCAFilename }}{{- end }} "$@"
     }
 
     # Function to check if current instance is master
@@ -144,7 +144,7 @@ data:
     set -e
 
     # Configuration
-    VALKEY_PORT="{{ .Values.service.port }}"
+    VALKEY_PORT="{{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}"
     SENTINEL_PORT="{{ .Values.sentinel.port }}"
     MASTER_NAME="{{ .Values.sentinel.masterName }}"
     HEADLESS_SERVICE="{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
@@ -163,7 +163,7 @@ data:
 
     # Function to run Valkey commands against the local instance
     run_valkey_command() {
-        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT" "$@"
+        valkey-cli -h "$VALKEY_LOOPBACK" -p "$VALKEY_PORT"{{- if .Values.tls.enabled }} --tls --cert /etc/valkey/tls/{{ .Values.tls.certFilename }} --key /etc/valkey/tls/{{ .Values.tls.certKeyFilename }} --cacert /etc/valkey/tls/{{ .Values.tls.certCAFilename }}{{- end }} "$@"
     }
 
     # Function to run Sentinel commands against the local Sentinel sidecar

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -110,7 +110,7 @@ spec:
                   echo "I am the current master according to Sentinel"
                 else
                   echo "Configuring as replica of current master: $CURRENT_MASTER"
-                  echo "replicaof $CURRENT_MASTER {{ .Values.service.port }}" >> /tmp/valkey/valkey.conf
+                  echo "replicaof $CURRENT_MASTER {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/valkey/valkey.conf
                   {{- if .Values.auth.enabled }}
                   echo "masterauth ${VALKEY_PASSWORD}" >> /tmp/valkey/valkey.conf
                   {{- end }}
@@ -121,7 +121,7 @@ spec:
                   echo "Bootstrap mode: configuring as replica of pod-0"
                   # Use hostname-based replication for better resilience
                   MASTER_HOSTNAME="{{ include "valkey.fullname" . }}-0.{{ include "valkey.fullname" . }}-headless"
-                  echo "replicaof $MASTER_HOSTNAME {{ .Values.service.port }}" >> /tmp/valkey/valkey.conf
+                  echo "replicaof $MASTER_HOSTNAME {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/valkey/valkey.conf
                   echo "Bootstrap replica using pod-0 hostname: $MASTER_HOSTNAME"
                   {{- if .Values.auth.enabled }}
                   echo "masterauth ${VALKEY_PASSWORD}" >> /tmp/valkey/valkey.conf
@@ -160,9 +160,9 @@ spec:
               {{- else }}
               echo "Using hostname: ${HOSTNAME}.{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
               echo "replica-announce-ip ${HOSTNAME}.{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}" >> /tmp/valkey/valkey.conf
-              echo "replica-announce-port {{ .Values.service.port }}" >> /tmp/valkey/valkey.conf
+              echo "replica-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/valkey/valkey.conf
               echo "slave-announce-ip ${HOSTNAME}.{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}" >> /tmp/valkey/valkey.conf
-              echo "slave-announce-port {{ .Values.service.port }}" >> /tmp/valkey/valkey.conf
+              echo "slave-announce-port {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/valkey/valkey.conf
               {{- end }}
 
               # Make slaves more eligible for promotion during force deletions
@@ -173,7 +173,7 @@ spec:
               if [ "$POD_ORDINAL" != "0" ]; then
                 echo "Configuring as replica of pod-0 (master)"
                 MASTER_HOSTNAME="{{ include "valkey.fullname" . }}-0.{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
-                echo "replicaof $MASTER_HOSTNAME {{ .Values.service.port }}" >> /tmp/valkey/valkey.conf
+                echo "replicaof $MASTER_HOSTNAME {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}" >> /tmp/valkey/valkey.conf
                 {{- if .Values.auth.enabled }}
                 echo "masterauth ${VALKEY_PASSWORD}" >> /tmp/valkey/valkey.conf
                 {{- end }}
@@ -371,7 +371,7 @@ spec:
               {{- else }}
               VALKEY_HOST="127.0.0.1"
               {{- end }}
-              while ! valkey-cli {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} -h "${VALKEY_HOST}" -p {{ .Values.service.port }} ping >/dev/null 2>&1; do
+              while ! valkey-cli {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} -h "${VALKEY_HOST}" -p {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}{{- if .Values.tls.enabled }} --tls --cert /etc/valkey/tls/{{ .Values.tls.certFilename }} --key /etc/valkey/tls/{{ .Values.tls.certKeyFilename }} --cacert /etc/valkey/tls/{{ .Values.tls.certCAFilename }}{{- end }} ping >/dev/null 2>&1; do
                 sleep 1
               done
               echo "Valkey is ready"
@@ -401,7 +401,7 @@ spec:
                 echo "No Sentinels available, checking Valkey instances directly..."
                 for i in $(seq 0 {{ sub .Values.replicaCount 1 }}); do
                   VALKEY_HOST="{{ include "valkey.fullname" . }}-${i}.{{ include "valkey.fullname" . }}-headless.{{ include "cloudpirates.namespace" . }}.svc.{{ .Values.clusterDomain }}"
-                  ROLE_INFO=$(valkey-cli -h "${VALKEY_HOST}" -p {{ .Values.service.port }} {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} info replication 2>/dev/null | grep "role:master" || echo "")
+                  ROLE_INFO=$(valkey-cli -h "${VALKEY_HOST}" -p {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }}{{- if .Values.tls.enabled }} --tls --cert /etc/valkey/tls/{{ .Values.tls.certFilename }} --key /etc/valkey/tls/{{ .Values.tls.certKeyFilename }} --cacert /etc/valkey/tls/{{ .Values.tls.certCAFilename }}{{- end }} {{- if .Values.auth.enabled }} -a "${VALKEY_PASSWORD}"{{- end }} info replication 2>/dev/null | grep "role:master" || echo "")
                   if [ -n "$ROLE_INFO" ]; then
                     MASTER_HOST="$VALKEY_HOST"
                     echo "Found current master by role check: $MASTER_HOST"
@@ -447,7 +447,7 @@ spec:
               # Enable hostname resolution for Valkey Sentinel
               sentinel resolve-hostnames yes
               sentinel announce-hostnames yes
-              sentinel monitor {{ .Values.sentinel.masterName }} ${MASTER_HOST} {{ .Values.service.port }} {{ .Values.sentinel.quorum }}
+              sentinel monitor {{ .Values.sentinel.masterName }} ${MASTER_HOST} {{ if .Values.tls.enabled }}{{ .Values.tls.port }}{{ else }}{{ .Values.service.port }}{{ end }} {{ .Values.sentinel.quorum }}
               sentinel down-after-milliseconds {{ .Values.sentinel.masterName }} {{ .Values.sentinel.downAfterMilliseconds }}
               sentinel failover-timeout {{ .Values.sentinel.masterName }} {{ .Values.sentinel.failoverTimeout }}
               sentinel parallel-syncs {{ .Values.sentinel.masterName }} {{ .Values.sentinel.parallelSyncs }}

--- a/charts/valkey/tests/tls-data-port_test.yaml
+++ b/charts/valkey/tests/tls-data-port_test.yaml
@@ -1,0 +1,214 @@
+suite: test data port wiring when tls is enabled
+set:
+  architecture: replication
+  auth:
+    password: testpass123
+tests:
+  - it: should point replicaof at the TLS port when TLS is enabled
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$CURRENT_MASTER 6380"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$MASTER_HOSTNAME 6380"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$[A-Z_]+ 6379"
+
+  - it: should point replicaof at the service port by default
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$CURRENT_MASTER 6379"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$MASTER_HOSTNAME 6379"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$[A-Z_]+ 6380"
+
+  - it: should point replicaof at the TLS port without sentinel when TLS is enabled
+    template: statefulset.yaml
+    set:
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$MASTER_HOSTNAME 6380"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$MASTER_HOSTNAME 6379"
+
+  - it: should point replicaof at the service port without sentinel by default
+    template: statefulset.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$MASTER_HOSTNAME 6379"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replicaof \\$MASTER_HOSTNAME 6380"
+
+  - it: should announce the TLS port when announceHostnames and TLS are enabled
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        config:
+          announceHostnames: true
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replica-announce-port 6380"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "slave-announce-port 6380"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "announce-port 6379"
+
+  - it: should announce the service port when announceHostnames is enabled by default
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+        config:
+          announceHostnames: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "replica-announce-port 6379"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "slave-announce-port 6379"
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "announce-port 6380"
+
+  - it: should monitor the TLS port from sentinel when TLS is enabled
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "sentinel monitor mymaster \\$\\{MASTER_HOST\\} 6380 2"
+      - notMatchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "sentinel monitor mymaster \\$\\{MASTER_HOST\\} 6379 2"
+
+  - it: should monitor the service port from sentinel by default
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "sentinel monitor mymaster \\$\\{MASTER_HOST\\} 6379 2"
+      - notMatchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "sentinel monitor mymaster \\$\\{MASTER_HOST\\} 6380 2"
+
+  - it: should reach the data port over TLS from the sentinel sidecar when TLS is enabled
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "while ! valkey-cli -a \"\\$\\{VALKEY_PASSWORD\\}\" -h \"\\$\\{VALKEY_HOST\\}\" -p 6380 --tls --cert /etc/valkey/tls/tls\\.crt --key /etc/valkey/tls/tls\\.key --cacert /etc/valkey/tls/ca\\.crt ping"
+      - matchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "ROLE_INFO=\\$\\(valkey-cli -h \"\\$\\{VALKEY_HOST\\}\" -p 6380 --tls --cert /etc/valkey/tls/tls\\.crt --key /etc/valkey/tls/tls\\.key --cacert /etc/valkey/tls/ca\\.crt -a"
+      - notMatchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "-p 6379"
+
+  - it: should reach the data port in plaintext from the sentinel sidecar by default
+    template: statefulset.yaml
+    set:
+      sentinel:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "while ! valkey-cli -a \"\\$\\{VALKEY_PASSWORD\\}\" -h \"\\$\\{VALKEY_HOST\\}\" -p 6379 ping"
+      - matchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "ROLE_INFO=\\$\\(valkey-cli -h \"\\$\\{VALKEY_HOST\\}\" -p 6379 -a"
+      - notMatchRegex:
+          path: spec.template.spec.containers[1].command[2]
+          pattern: "--tls"
+
+  - it: should use the TLS port and TLS client args in the preStop scripts when TLS is enabled
+    template: prestop-configmap.yaml
+    set:
+      sentinel:
+        enabled: true
+      tls:
+        enabled: true
+        existingSecret: valkey-tls
+    asserts:
+      - matchRegex:
+          path: data["prestop.sh"]
+          pattern: "VALKEY_PORT=\"6380\""
+      - matchRegex:
+          path: data["prestop.sh"]
+          pattern: "valkey-cli -h \"\\$VALKEY_LOOPBACK\" -p \"\\$VALKEY_PORT\" --tls --cert /etc/valkey/tls/tls\\.crt --key /etc/valkey/tls/tls\\.key --cacert /etc/valkey/tls/ca\\.crt \"\\$@\""
+      - matchRegex:
+          path: data["prestop-sentinel.sh"]
+          pattern: "VALKEY_PORT=\"6380\""
+      - matchRegex:
+          path: data["prestop-sentinel.sh"]
+          pattern: "valkey-cli -h \"\\$VALKEY_LOOPBACK\" -p \"\\$VALKEY_PORT\" --tls --cert /etc/valkey/tls/tls\\.crt --key /etc/valkey/tls/tls\\.key --cacert /etc/valkey/tls/ca\\.crt \"\\$@\""
+
+  - it: should use the service port without TLS client args in the preStop scripts by default
+    template: prestop-configmap.yaml
+    set:
+      sentinel:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["prestop.sh"]
+          pattern: "VALKEY_PORT=\"6379\""
+      - matchRegex:
+          path: data["prestop.sh"]
+          pattern: "valkey-cli -h \"\\$VALKEY_LOOPBACK\" -p \"\\$VALKEY_PORT\" \"\\$@\""
+      - notMatchRegex:
+          path: data["prestop.sh"]
+          pattern: "--tls"
+      - matchRegex:
+          path: data["prestop-sentinel.sh"]
+          pattern: "VALKEY_PORT=\"6379\""
+      - matchRegex:
+          path: data["prestop-sentinel.sh"]
+          pattern: "valkey-cli -h \"\\$VALKEY_LOOPBACK\" -p \"\\$VALKEY_PORT\" \"\\$@\""
+      - notMatchRegex:
+          path: data["prestop-sentinel.sh"]
+          pattern: "--tls"


### PR DESCRIPTION
### Description of the change

With `tls.enabled=true` the generated config sets `port 0` and `tls-port 6380`, so the server listens only on `tls.port`. The `replicaof` target, the announce ports, the Sentinel readiness wait and `sentinel monitor` all still used `service.port`, where nothing is listening, so replication never established.

### Benefits

Replication works under TLS. The container probes already handled this correctly and the redis chart conditionalises every one of these call sites; they were just missed here.

### Possible drawbacks

Sentinel with TLS needs more than this change: the generated `sentinel.conf` emits no TLS directives, so Sentinel still speaks plaintext to a TLS-only master. With `tls.enabled=false` every affected line renders unchanged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified