### PR TITLE
[minio] Name the created ServiceAccount from serviceAccount.name

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/templates/serviceaccount.yaml
+++ b/charts/minio/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "minio.fullname" . }}
+  name: {{ include "minio.serviceAccountName" . }}
   namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "minio.labels" . | nindent 4 }}

--- a/charts/minio/tests/serviceaccount_test.yaml
+++ b/charts/minio/tests/serviceaccount_test.yaml
@@ -1,0 +1,70 @@
+suite: test minio serviceaccount
+templates:
+  - serviceaccount.yaml
+  - deployment.yaml
+tests:
+  - it: should name the created ServiceAccount after the release by default
+    template: serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-minio
+
+  - it: should use the default ServiceAccount name in the pod spec
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-minio
+
+  - it: should name the created ServiceAccount after serviceAccount.name
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should reference the created ServiceAccount from the pod spec
+    template: deployment.yaml
+    set:
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa
+
+  - it: should keep the credentials secret reference on the fullname
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        name: custom-sa
+    asserts:
+      - equal:
+          path: secrets[0].name
+          value: RELEASE-NAME-minio
+
+  - it: should respect fullnameOverride when serviceAccount.name is empty
+    template: serviceaccount.yaml
+    set:
+      fullnameOverride: completely-custom-name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: completely-custom-name
+
+  - it: should not create a ServiceAccount when serviceAccount.create is false
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
### Description of the change

The ServiceAccount object is named from `minio.fullname`, so `serviceAccount.name` reaches the pod's `serviceAccountName` but not the object the chart creates, leaving the pod referencing a ServiceAccount that does not exist.

### Benefits

`serviceAccount.name` names both. Twelve other charts in this repo already use the helper here.

### Possible drawbacks

None. The helper falls back to `minio.fullname` when `serviceAccount.name` is empty, so the default render is unchanged. The `secrets:` entry is left alone since it references the credentials Secret.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified