### PR TITLE
[rustfs] Name the created ServiceAccount from serviceAccount.name

### DIFF
--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: (ALPHA) High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.10.4
+version: 0.10.5
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/templates/serviceaccount.yaml
+++ b/charts/rustfs/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "rustfs.fullname" . }}
+  name: {{ include "rustfs.serviceAccountName" . }}
   namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "rustfs.labels" . | nindent 4 }}

--- a/charts/rustfs/tests/serviceaccount_test.yaml
+++ b/charts/rustfs/tests/serviceaccount_test.yaml
@@ -1,0 +1,65 @@
+suite: Test service account
+templates:
+  - serviceaccount.yaml
+  - deployment.yaml
+tests:
+  - it: should name the created ServiceAccount after the fullname by default
+    template: serviceaccount.yaml
+    asserts:
+      - equal:
+          path: kind
+          value: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rustfs
+      - equal:
+          path: secrets[0].name
+          value: RELEASE-NAME-rustfs
+
+  - it: should mount the default ServiceAccount name on the pod
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-rustfs
+
+  - it: should name the created ServiceAccount after serviceAccount.name
+    set:
+      serviceAccount:
+        name: custom-sa
+    template: serviceaccount.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+      - equal:
+          path: secrets[0].name
+          value: RELEASE-NAME-rustfs
+
+  - it: should reference the custom ServiceAccount name on the pod
+    set:
+      serviceAccount:
+        name: custom-sa
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa
+
+  - it: should respect fullnameOverride when serviceAccount.name is empty
+    set:
+      fullnameOverride: completely-custom-rustfs
+    template: serviceaccount.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: completely-custom-rustfs
+
+  - it: should not create a ServiceAccount when disabled
+    set:
+      serviceAccount:
+        create: false
+    template: serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
### Description of the change

The ServiceAccount object is named from `rustfs.fullname`, so `serviceAccount.name` reaches the pod's `serviceAccountName` but not the object the chart creates, leaving the pod referencing a ServiceAccount that does not exist.

### Benefits

`serviceAccount.name` names both. Twelve other charts in this repo already use the helper here.

### Possible drawbacks

None. The helper falls back to `rustfs.fullname` when `serviceAccount.name` is empty, so the default render is unchanged. The `secrets:` entry is left alone since it references the credentials Secret.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified