### PR TITLE
[etcd] Render only one of minAvailable and maxUnavailable

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.8.5
+version: 0.8.6
 appVersion: "3.7.1"
 keywords:
   - etcd

--- a/charts/etcd/templates/poddisruptionbudget.yaml
+++ b/charts/etcd/templates/poddisruptionbudget.yaml
@@ -12,9 +12,8 @@ metadata:
   {{- end }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | quote }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:

--- a/charts/etcd/tests/etcd-functionality_test.yaml
+++ b/charts/etcd/tests/etcd-functionality_test.yaml
@@ -228,7 +228,60 @@ tests:
     asserts:
       - equal:
           path: spec.minAvailable
-          value: "2"
+          value: 2
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should set integer minAvailable in PDB
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should set percentage minAvailable in PDB
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: "50%"
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: "50%"
+      - isNull:
+          path: spec.maxUnavailable
+
+  - it: should set maxUnavailable in PDB by default
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should set maxUnavailable in PDB
+    template: poddisruptionbudget.yaml
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 2
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+      - isNull:
+          path: spec.minAvailable
 
   # NetworkPolicy
   - it: should create NetworkPolicy when enabled

--- a/charts/etcd/values.schema.json
+++ b/charts/etcd/values.schema.json
@@ -291,7 +291,10 @@
                     "type": "integer"
                 },
                 "minAvailable": {
-                    "type": "string"
+                    "type": [
+                        "integer",
+                        "string"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
### Description of the change

`maxUnavailable` defaults to `1` and each field was guarded independently, so setting `podDisruptionBudget.minAvailable` rendered both, which the Kubernetes API rejects. `minAvailable` was also piped through `quote`, turning an integer into `"2"`, which PDB validation rejects since a string is only accepted as a percentage.

### Benefits

Both forms of `minAvailable` produce a valid manifest. The schema is relaxed to `["integer", "string"]` to match the redis chart, so `--set podDisruptionBudget.minAvailable=2` is no longer rejected before rendering.

### Possible drawbacks

One existing assertion in `etcd-functionality_test.yaml` changes from `value: "2"` to `value: 2`, since `minAvailable` is no longer quoted. That assertion was pinning the behaviour this fixes. The default render is unchanged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified