### PR TITLE
Add kafka to update-dependencies.sh and sort the chart list

### DIFF
--- a/update-dependencies.sh
+++ b/update-dependencies.sh
@@ -4,8 +4,10 @@
 # The common chart is a library chart and doesn't have dependencies
 
 charts=(
+  "clusterpirate"
   "etcd"
   "ghost"
+  "kafka"
   "keycloak"
   "mariadb"
   "memcached"
@@ -13,14 +15,13 @@ charts=(
   "mongodb"
   "nginx"
   "postgres"
-  "rabbitmq-cluster-operator"
   "rabbitmq"
+  "rabbitmq-cluster-operator"
   "redis"
   "rustfs"
   "timescaledb"
   "valkey"
   "zookeeper"
-  "clusterpirate"
 )
 
 echo "Updating Helm chart dependencies..."


### PR DESCRIPTION
### Description of the change

kafka is the only chart with a `dependencies:` block in its Chart.yaml that is missing from the `charts` list, so the script never refreshes `charts/kafka/Chart.lock`. Also sorted the list alphabetically.

### Benefits

The script refreshes every chart that has dependencies, and the list is now sorted and matches that set exactly, so a missing entry is easy to spot.

### Possible drawbacks

None.

### Checklist

- [X] All commits are signed and verified