### PR TITLE
[rabbitmq-cluster-operator] Honor metrics.serviceMonitor.labels

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.5.5
+version: 0.5.6
 appVersion: "2.22.3"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ template "rmqco.clusterOperator.fullname" . }}
   labels:
     {{- include "rmqco.labels" . | nindent 4 }}
-    {{- if .Values.clusterOperator.metrics.serviceMonitor.additionalLabels }}
-    {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- $smLabels := merge (deepCopy (.Values.clusterOperator.metrics.serviceMonitor.labels | default dict)) (.Values.clusterOperator.metrics.serviceMonitor.additionalLabels | default dict) }}
+    {{- if $smLabels }}
+    {{- include "cloudpirates.tplvalues.render" (dict "value" $smLabels "context" $) | nindent 4 }}
     {{- end }}
   namespace: {{ default (include "cloudpirates.namespace" .) .Values.clusterOperator.metrics.serviceMonitor.namespace | quote }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -5,8 +5,9 @@ metadata:
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
   labels:
     {{- include "rmqmto.labels" . | nindent 4 }}
-    {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels }}
-    {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- $smLabels := merge (deepCopy (.Values.msgTopologyOperator.metrics.serviceMonitor.labels | default dict)) (.Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels | default dict) }}
+    {{- if $smLabels }}
+    {{- include "cloudpirates.tplvalues.render" (dict "value" $smLabels "context" $) | nindent 4 }}
     {{- end }}
   namespace: {{ default (include "cloudpirates.namespace" .) .Values.msgTopologyOperator.metrics.serviceMonitor.namespace | quote }}
   {{- if .Values.commonAnnotations }}

--- a/charts/rabbitmq-cluster-operator/tests/servicemonitor_labels_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/servicemonitor_labels_test.yaml
@@ -1,0 +1,142 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: rabbitmq-cluster-operator-servicemonitor-labels-tests
+templates:
+  - templates/cluster-operator/servicemonitor.yaml
+  - templates/messaging-topology-operator/servicemonitor.yaml
+set:
+  clusterOperator.metrics.service.enabled: true
+  clusterOperator.metrics.serviceMonitor.enabled: true
+  msgTopologyOperator.metrics.service.enabled: true
+  msgTopologyOperator.metrics.serviceMonitor.enabled: true
+
+tests:
+  - it: should not add extra labels when neither labels nor additionalLabels are set
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+        template: templates/cluster-operator/servicemonitor.yaml
+      - notExists:
+          path: metadata.labels.release
+        template: templates/cluster-operator/servicemonitor.yaml
+      - notExists:
+          path: metadata.labels.legacy
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: rabbitmq-operator
+        template: templates/cluster-operator/servicemonitor.yaml
+      - isKind:
+          of: ServiceMonitor
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+      - notExists:
+          path: metadata.labels.release
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+      - notExists:
+          path: metadata.labels.legacy
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: messaging-topology-operator
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+
+  - it: should render serviceMonitor labels on both servicemonitors
+    set:
+      clusterOperator.metrics.serviceMonitor.labels:
+        release: kube-prometheus
+      msgTopologyOperator.metrics.serviceMonitor.labels:
+        release: kube-prometheus
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+
+  - it: should render templated serviceMonitor labels on both servicemonitors
+    set:
+      clusterOperator.metrics.serviceMonitor.labels:
+        release: "{{ .Release.Name }}-prometheus"
+      msgTopologyOperator.metrics.serviceMonitor.labels:
+        release: "{{ .Release.Name }}-prometheus"
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: RELEASE-NAME-prometheus
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.release
+          value: RELEASE-NAME-prometheus
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+
+  - it: should keep rendering the deprecated additionalLabels on both servicemonitors
+    set:
+      clusterOperator.metrics.serviceMonitor.additionalLabels:
+        legacy: old
+      msgTopologyOperator.metrics.serviceMonitor.additionalLabels:
+        legacy: old
+    asserts:
+      - equal:
+          path: metadata.labels.legacy
+          value: old
+        template: templates/cluster-operator/servicemonitor.yaml
+      - notExists:
+          path: metadata.labels.release
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.legacy
+          value: old
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+      - notExists:
+          path: metadata.labels.release
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+
+  - it: should merge labels and the deprecated additionalLabels on both servicemonitors
+    set:
+      clusterOperator.metrics.serviceMonitor.labels:
+        release: kube-prometheus
+      clusterOperator.metrics.serviceMonitor.additionalLabels:
+        legacy: old
+      msgTopologyOperator.metrics.serviceMonitor.labels:
+        release: kube-prometheus
+      msgTopologyOperator.metrics.serviceMonitor.additionalLabels:
+        legacy: old
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.legacy
+          value: old
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.legacy
+          value: old
+        template: templates/messaging-topology-operator/servicemonitor.yaml
+
+  - it: should let labels win over the deprecated additionalLabels on key collision
+    set:
+      clusterOperator.metrics.serviceMonitor.labels:
+        release: kube-prometheus
+      clusterOperator.metrics.serviceMonitor.additionalLabels:
+        release: stale
+      msgTopologyOperator.metrics.serviceMonitor.labels:
+        release: kube-prometheus
+      msgTopologyOperator.metrics.serviceMonitor.additionalLabels:
+        release: stale
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+        template: templates/cluster-operator/servicemonitor.yaml
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+        template: templates/messaging-topology-operator/servicemonitor.yaml


### PR DESCRIPTION
### Description of the change

Both ServiceMonitor templates read only `metrics.serviceMonitor.additionalLabels`, which values.yaml has commented out and marked deprecated. `metrics.serviceMonitor.labels`, the key values.yaml and the README actually document, was never read by any template.

### Benefits

Setting the documented key works, on both the cluster operator and the messaging topology operator ServiceMonitor.

### Possible drawbacks

None. The two maps are merged, so anyone relying on the undocumented `additionalLabels` keeps working and the default render is unchanged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified