### PR TITLE
[memcached] Apply namespaceOverride to the metrics Service

### DIFF
--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.14.5
+version: 0.14.6
 appVersion: "1.6.45"
 keywords:
   - memcached

--- a/charts/memcached/templates/service.yaml
+++ b/charts/memcached/templates/service.yaml
@@ -30,6 +30,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "memcached.fullname" . }}-metrics
+  namespace: {{ include "cloudpirates.namespace" . }}
   labels:
     {{- include "memcached.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics

--- a/charts/memcached/tests/namespace_test.yaml
+++ b/charts/memcached/tests/namespace_test.yaml
@@ -1,0 +1,51 @@
+suite: test Memcached service namespace
+templates:
+  - service.yaml
+release:
+  name: release-name
+  namespace: release-ns
+set:
+  metrics.enabled: true
+
+tests:
+  - it: should use the release namespace when namespaceOverride is not set
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: release-ns
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: release-ns
+        documentIndex: 1
+
+  - it: should respect namespaceOverride on both services
+    set:
+      namespaceOverride: custom-ns
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+        documentIndex: 1
+
+  - it: should respect namespaceOverride on the metrics service
+    set:
+      namespaceOverride: custom-ns
+    documentSelector:
+      path: metadata.name
+      value: release-name-memcached-metrics
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-ns
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: metrics


### PR DESCRIPTION
### Description of the change

The metrics Service is the only object in the chart without a `namespace` field, so with `namespaceOverride` set it lands in the release namespace while every other object lands in the overridden one.

### Benefits

The metrics Service follows `namespaceOverride` like the rest of the chart.

### Possible drawbacks

None. `cloudpirates.namespace` falls back to `.Release.Namespace`, so without `namespaceOverride` the object renders into the namespace Helm already installs it into.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified