### PR TITLE
[timescaledb] Apply podLabels to the pod template

### DIFF
--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.13.3
+version: 0.13.4
 appVersion: "2.29.1"
 keywords:
   - timescaledb

--- a/charts/timescaledb/templates/statefulset.yaml
+++ b/charts/timescaledb/templates/statefulset.yaml
@@ -21,6 +21,9 @@ spec:
     metadata:
       labels:
         {{- include "timescaledb.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.commonAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/timescaledb/tests/pod-labels_test.yaml
+++ b/charts/timescaledb/tests/pod-labels_test.yaml
@@ -1,0 +1,72 @@
+suite: test timescaledb podLabels
+templates:
+  - statefulset.yaml
+tests:
+  - it: should add podLabels to the pod template
+    set:
+      podLabels:
+        team: platform
+        tier: database
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.tier
+          value: database
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: timescaledb
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should not add podLabels to the immutable selector
+    set:
+      podLabels:
+        team: platform
+        tier: database
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: timescaledb
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - isNull:
+          path: spec.selector.matchLabels.team
+      - isNull:
+          path: spec.selector.matchLabels.tier
+
+  - it: should not add podLabels to the statefulset metadata labels
+    set:
+      podLabels:
+        team: platform
+    asserts:
+      - isNull:
+          path: metadata.labels.team
+
+  - it: should keep podLabels on the volume claim template
+    set:
+      podLabels:
+        team: platform
+    asserts:
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.labels.team
+          value: platform
+
+  - it: should not add any pod labels when podLabels is empty
+    asserts:
+      - isNull:
+          path: spec.template.metadata.labels.team
+      - isNull:
+          path: spec.template.metadata.labels.tier
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: timescaledb
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm


### PR DESCRIPTION
### Description of the change

`podLabels` is documented in values.yaml, values.schema.json and the README, but the only template reading it is the `volumeClaimTemplates` label merge, so the labels land on the PVCs and never on the pods.

### Benefits

`podLabels` reaches the pods, using the same idiom as the etcd and valkey charts.

### Possible drawbacks

None. The `with` guard keeps the default render unchanged and `spec.selector` is untouched, so upgrades only trigger a normal rolling update. The `volumeClaimTemplates` merge is left alone since that field is immutable on an existing StatefulSet.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified