### PR TITLE
[zookeeper] Exec the command override on its own line

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.13.4
+version: 0.13.5
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -85,8 +85,7 @@ spec:
               echo "Calculated ZOO_MY_ID=$ZOO_MY_ID (pod-index=$POD_INDEX + offset=$SERVER_ID_OFFSET)"
               
               {{- if .Values.command }}
-              {{- /* user-supplied full command */ -}}
-              {{- range $i, $c := .Values.command -}}{{ if $i }} {{ end }}{{ $c | quote }}{{- end -}}
+              exec {{ range $i, $c := .Values.command }}{{ if $i }} {{ end }}{{ $c | quote }}{{ end }}
               {{- else }}
               exec /docker-entrypoint.sh zkServer.sh start-foreground
               {{- end }}

--- a/charts/zookeeper/tests/command_test.yaml
+++ b/charts/zookeeper/tests/command_test.yaml
@@ -1,0 +1,67 @@
+suite: test zookeeper custom command
+templates:
+  - templates/statefulset.yaml
+tests:
+  - it: should exec the docker entrypoint by default
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "(?m)^exec /docker-entrypoint\\.sh zkServer\\.sh start-foreground$"
+
+  - it: should end the ZOO_MY_ID echo line by default
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "(?m)^echo \"Calculated ZOO_MY_ID=\\$ZOO_MY_ID \\(pod-index=\\$POD_INDEX \\+ offset=\\$SERVER_ID_OFFSET\\)\"$"
+
+  - it: should exec a user supplied command on its own line
+    set:
+      command:
+        - /bin/my-entrypoint.sh
+        - --foo
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "(?m)^exec \"/bin/my-entrypoint\\.sh\" \"--foo\"$"
+
+  - it: should not concatenate a user supplied command onto the preceding echo
+    set:
+      command:
+        - /bin/my-entrypoint.sh
+        - --foo
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "(?m)^echo \"Calculated ZOO_MY_ID=\\$ZOO_MY_ID \\(pod-index=\\$POD_INDEX \\+ offset=\\$SERVER_ID_OFFSET\\)\"$"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "offset=\\$SERVER_ID_OFFSET\\)\"\""
+
+  - it: should exec a single element command
+    set:
+      command:
+        - /bin/my-entrypoint.sh
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "(?m)^exec \"/bin/my-entrypoint\\.sh\"$"
+
+  - it: should not run the docker entrypoint when a command is supplied
+    set:
+      command:
+        - /bin/my-entrypoint.sh
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: "/docker-entrypoint\\.sh"
+
+  - it: should keep the shell wrapper command unchanged
+    set:
+      command:
+        - /bin/my-entrypoint.sh
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - /bin/sh
+            - -ec


### PR DESCRIPTION
### Description of the change

The template comment and the range action both left-trim, so `command` is concatenated onto the end of the preceding `echo` rather than starting a new shell line. The shell prints the command as arguments, the script runs to completion, and the container exits 0 and restarts in a loop.

### Benefits

`command` runs. `exec` matches the default branch, so the process keeps PID 1 and signal handling.

### Possible drawbacks

None. `command` defaults to `[]` and the default render is byte identical.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified