### PR TITLE
[rabbitmq] Gate ServiceAccount creation on serviceAccount.create

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.21.14
+version: 0.21.15
 appVersion: "4.3.4"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/templates/_helpers.tpl
+++ b/charts/rabbitmq/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{- define "rabbitmq.serviceAccountName" -}}
-    {{- if or .Values.peerDiscoveryK8sPlugin.enabled -}}
+    {{- if .Values.serviceAccount.create -}}
         {{- default (include "rabbitmq.fullname" .) .Values.serviceAccount.name }}
     {{- else -}}
         {{- default "default" .Values.serviceAccount.name -}}

--- a/charts/rabbitmq/templates/serviceaccount.yaml
+++ b/charts/rabbitmq/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.peerDiscoveryK8sPlugin.enabled .Values.serviceAccount.create }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/rabbitmq/tests/service-account_test.yaml
+++ b/charts/rabbitmq/tests/service-account_test.yaml
@@ -1,0 +1,127 @@
+suite: test service account creation
+templates:
+  - templates/serviceaccount.yaml
+  - templates/statefulset.yaml
+tests:
+  - it: should create the service account with default values
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/serviceaccount.yaml
+      - isKind:
+          of: ServiceAccount
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rabbitmq
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-rabbitmq
+        template: templates/statefulset.yaml
+
+  - it: should create the service account with a custom name and annotations
+    set:
+      serviceAccount:
+        create: true
+        name: my-service-account
+        annotations:
+          key1: value1
+          key2: value2
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-service-account
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: metadata.annotations.key1
+          value: value1
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: metadata.annotations.key2
+          value: value2
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-service-account
+        template: templates/statefulset.yaml
+
+  - it: should not create the service account and fall back to default when create is false
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+        template: templates/statefulset.yaml
+
+  - it: should use an existing service account when create is false and name is set
+    set:
+      serviceAccount:
+        create: false
+        name: existing-service-account
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-service-account
+        template: templates/statefulset.yaml
+
+  - it: should create the service account when peer discovery is disabled
+    set:
+      peerDiscoveryK8sPlugin:
+        enabled: false
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rabbitmq
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-rabbitmq
+        template: templates/statefulset.yaml
+
+  - it: should create the service account when peer discovery is enabled
+    set:
+      peerDiscoveryK8sPlugin:
+        enabled: true
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rabbitmq
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-rabbitmq
+        template: templates/statefulset.yaml
+
+  - it: should not create the service account when peer discovery is enabled and create is false
+    set:
+      peerDiscoveryK8sPlugin:
+        enabled: true
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+        template: templates/statefulset.yaml

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -109,7 +109,7 @@ config:
     ##   value: "8GB"            # absolute: 8 gigabytes
     ##   value: "8590000000"     # absolute: 8590000000 bytes (use string for large numbers)
     ##
-    value: 0.4 # @schema type:[number, string]
+    value: 0.4  # @schema type:[number, string]
   ## Logging configuration
   ## ref: https://www.rabbitmq.com/docs/logging
   ##
@@ -164,7 +164,7 @@ queueBalancing:
   ## Helps RabbitMQ make better decisions during cluster formation and queue placement
   ## Leave empty/null to use RabbitMQ's default
   clusterFormation:
-    targetClusterSizeHint: null # @schema type:[integer,null]
+    targetClusterSizeHint: null  # @schema type:[integer,null]
 
   ## Quorum queue reconciliation settings (for RabbitMQ 3.10+)
   ## Helps ensure quorum queues have the correct number of replicas across cluster nodes
@@ -175,13 +175,13 @@ queueBalancing:
       enabled: false
       ## @param queueBalancing.quorumQueues.continuousMembershipReconciliation.targetGroupSize Target number of members per quorum queue (integer)
       ## Set to cluster size for full replication, or leave empty/null to use cluster_formation.target_cluster_size_hint
-      targetGroupSize: null # @schema type:[integer,null]
+      targetGroupSize: null  # @schema type:[integer,null]
       ## @param queueBalancing.quorumQueues.continuousMembershipReconciliation.interval Reconciliation check interval in milliseconds
       ## Default: 3600000 (1 hour) to match RabbitMQ's default
       interval: 3600000
       ## @param queueBalancing.quorumQueues.continuousMembershipReconciliation.triggerInterval How often to trigger reconciliation in milliseconds (integer)
       ## Leave empty/null to use RabbitMQ's default
-      triggerInterval: null # @schema type:[integer,null]
+      triggerInterval: null  # @schema type:[integer,null]
 
   ## Automatic queue rebalancing
   ## @param queueBalancing.autoRebalance.enabled Enable automatic queue rebalancing on pod startup


### PR DESCRIPTION
### Description of the change

The ServiceAccount template also required `peerDiscoveryK8sPlugin.enabled`, but `rabbitmq.serviceAccountName` did not. With the default `serviceAccount.create: true` and a `serviceAccount.name` set, the StatefulSet referenced a ServiceAccount the chart never creates, and `serviceAccount.annotations` was dropped entirely.

### Benefits

A named ServiceAccount is created with its annotations regardless of peer discovery, and `create: false` falls back to `default`. This matches postgres, valkey, mongodb and minio.

### Possible drawbacks

This changes the default render. A default install currently gets `serviceAccountName: default` and no ServiceAccount; it now gets a dedicated one, which is a pod template change and so rolls pods on upgrade. No value is renamed or redefaulted, and the new ServiceAccount is equally unprivileged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified