### PR TITLE
[redis] exec redis-metrics so SIGTERM reaches the process

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.14
+version: 0.34.15
 appVersion: "8.10.0"
 keywords:
   - redis

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1317,14 +1317,14 @@ spec:
             - -c
             - |
               {{- include "redis.auth.acl.setupScript" (dict "type" "metrics" "context" .) | nindent 14 }}
-              /redis_exporter {{- range .Values.metrics.extraArgs }} {{ . }}{{- end }}
+              exec /redis_exporter {{- range .Values.metrics.extraArgs }} {{ . }}{{- end }}
           {{- else }}
           command:
             - /bin/sh
             - -c
             - |
               {{- include "redis.auth.acl.setupScript" (dict "type" "metrics" "context" .) | nindent 14 }}
-              /redis_exporter
+              exec /redis_exporter
           {{- end }}
           ports:
             - name: metrics


### PR DESCRIPTION
NOTE: I am deliberatly copying this from https://github.com/CloudPirates-io/helm-charts/pull/1425 as this is pretty much the same issue just for redis-metrics.
Thank you @https://github.com/wittfabian for your template

### Description of the change

The `redis-metrics` containers start their main process as a child of
`/bin/sh` — the command is a multi-statement `sh -c` script, so the shell is
**not** replaced by the final process and stays PID 1. A non-interactive shell
blocked in `wait` does not forward `SIGTERM` to its child and does not exit
until the child does, so `redis_exporter` never receive the
shutdown signal. The pod then rides out the full `terminationGracePeriodSeconds`
and is `SIGKILL`ed at the deadline.

### Benefits

- Rolling updates no longer wait the full `terminationGracePeriodSeconds` per
  pod — `redis_exporter` receive `SIGTERM` and shut down
  promptly and gracefully instead of being `SIGKILL`ed.

### Possible drawbacks

None expected. `exec` is the last statement in both scripts, so no subsequent
shell logic is skipped. Behavior is otherwise identical.

### Applicable issues

n/a

### Additional information

n/a

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/) 
- [x] No new variables (no `values.yaml` / `README.md` changes needed).
- [x] Title of the pull request follows this pattern `[<name_of_the_chart>] Descriptive title`.
