### PR TITLE
[ghost] Build MariaDB host from subchart fullname

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.20.7
+version: 0.20.8
 appVersion: "6.57.1"
 keywords:
   - ghost

--- a/charts/ghost/templates/configmap.yaml
+++ b/charts/ghost/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
         {{- if .Values.mariadb.enabled }}
         "client": "mysql",
         "connection": {
-          "host": "{{ include "ghost.fullname" . }}-mariadb",
+          "host": {{ include "mariadb.fullname" .Subcharts.mariadb | quote }},
           "port": {{ .Values.mariadb.service.port }},
           "user": "",
           "password": "",

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - >
               retries=0;
               max_retries=15;
-              until [ $retries -ge $max_retries ] || mariadb-admin ping -h {{ include "ghost.fullname" . }}-mariadb
+              until [ $retries -ge $max_retries ] || mariadb-admin ping -h {{ include "mariadb.fullname" .Subcharts.mariadb }}
               -P {{ .Values.mariadb.service.port }}
               -u${MARIADB_USER}
               -p${MARIADB_PASSWORD}

--- a/charts/ghost/tests/mariadb-host_test.yaml
+++ b/charts/ghost/tests/mariadb-host_test.yaml
@@ -1,0 +1,91 @@
+suite: test ghost mariadb host
+templates:
+  - templates/configmap.yaml
+  - templates/deployment.yaml
+tests:
+  - it: should point at the embedded mariadb service by default
+    asserts:
+      - matchRegex:
+          path: data["config.production.json"]
+          pattern: '"host": "RELEASE-NAME-mariadb"'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'mariadb-admin ping -h RELEASE-NAME-mariadb -P 3306'
+        template: templates/deployment.yaml
+
+  - it: should follow the mariadb subchart fullnameOverride
+    set:
+      mariadb:
+        fullnameOverride: my-maria
+    asserts:
+      - matchRegex:
+          path: data["config.production.json"]
+          pattern: '"host": "my-maria"'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'mariadb-admin ping -h my-maria -P 3306'
+        template: templates/deployment.yaml
+
+  - it: should follow the mariadb subchart nameOverride
+    set:
+      mariadb:
+        nameOverride: mdbx
+    asserts:
+      - matchRegex:
+          path: data["config.production.json"]
+          pattern: '"host": "RELEASE-NAME-mdbx"'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'mariadb-admin ping -h RELEASE-NAME-mdbx -P 3306'
+        template: templates/deployment.yaml
+
+  - it: should not derive the host from the ghost fullname
+    asserts:
+      - notMatchRegex:
+          path: data["config.production.json"]
+          pattern: 'RELEASE-NAME-ghost-mariadb'
+        template: templates/configmap.yaml
+      - notMatchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'RELEASE-NAME-ghost-mariadb'
+        template: templates/deployment.yaml
+
+  - it: should keep the ghost fullnameOverride out of the database host
+    set:
+      fullnameOverride: my-blog
+    asserts:
+      - matchRegex:
+          path: data["config.production.json"]
+          pattern: '"host": "RELEASE-NAME-mariadb"'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'mariadb-admin ping -h RELEASE-NAME-mariadb -P 3306'
+        template: templates/deployment.yaml
+
+  - it: should use the external database host when the subchart is disabled
+    set:
+      mariadb:
+        enabled: false
+      config:
+        database:
+          client: mysql2
+          externalConnection:
+            host: db.example.com
+            port: 3307
+            database: ghostdb
+    asserts:
+      - matchRegex:
+          path: data["config.production.json"]
+          pattern: '"host": "db.example.com"'
+        template: templates/configmap.yaml
+      - matchRegex:
+          path: data["config.production.json"]
+          pattern: '"client": "mysql2"'
+        template: templates/configmap.yaml
+      - isNull:
+          path: spec.template.spec.initContainers
+        template: templates/deployment.yaml


### PR DESCRIPTION
### Description of the change

The MariaDB host is hardcoded as `<ghost-fullname>-mariadb`, but the subchart names its Service from its own fullname helper. `helm template t charts/ghost` renders `t-ghost-mariadb` while the Service is `t-mariadb`, so Ghost never connects.

### Benefits

Ghost reaches its database under any release name, and `mariadb.fullnameOverride` and `mariadb.nameOverride` take effect.

### Possible drawbacks

The host changes for releases whose name does not contain `ghost`. Releases named `ghost` render identically.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified