### PR TITLE
[clusterpirate] Build Valkey host and secret name from subchart fullname

### DIFF
--- a/charts/clusterpirate/Chart.yaml
+++ b/charts/clusterpirate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clusterpirate
 description: Client agent for the CloudPirates Managed Observability Platform to connect your Kubernetes cluster to our infrastructure
 type: application
-version: 1.5.9
+version: 1.5.10
 appVersion: "1.0.1"
 keywords:
   - kubernetes

--- a/charts/clusterpirate/templates/configmap.yaml
+++ b/charts/clusterpirate/templates/configmap.yaml
@@ -16,7 +16,11 @@ data:
   healthPort: {{ .Values.clusterPirate.healthPort | quote }}
   metricsEnabled: {{ .Values.clusterPirate.metrics.enabled | quote }}
   metricsUpdateIntervalSeconds: {{ .Values.clusterPirate.metrics.updateIntervalSeconds | quote }}
-  valkeyHost: {{ .Values.clusterPirate.metrics.cache.host | default (printf "%s-valkey" (include "clusterpirate.fullname" .)) | quote }}
+  {{- if .Values.clusterPirate.metrics.cache.host }}
+  valkeyHost: {{ .Values.clusterPirate.metrics.cache.host | quote }}
+  {{- else }}
+  valkeyHost: {{ include "valkey.fullname" .Subcharts.valkey | quote }}
+  {{- end }}
   valkeyPort: {{ .Values.clusterPirate.metrics.cache.port | quote }}
   valkeyTtl: {{ .Values.clusterPirate.metrics.cache.ttl | quote }}
   monitoringResourceEventsEnabled: {{ .Values.clusterPirate.monitoring.resourceEventsEnabled | quote }}

--- a/charts/clusterpirate/templates/deployment.yaml
+++ b/charts/clusterpirate/templates/deployment.yaml
@@ -104,8 +104,8 @@ spec:
               secretKeyRef:
                 {{- if and .Values.valkey.enabled (not .Values.valkey.auth.existingSecret) }}
                 # Use auto-generated password from Valkey subchart
-                name: {{ include "clusterpirate.fullname" . }}-valkey
-                key: password
+                name: {{ include "valkey.secretName" .Subcharts.valkey }}
+                key: {{ include "valkey.passwordKey" .Subcharts.valkey }}
                 {{- else if .Values.valkey.auth.existingSecret }}
                 # Use existing secret specified for Valkey
                 name: {{ include "cloudpirates.tplvalues.render" (dict "value" .Values.valkey.auth.existingSecret "context" .) }}

--- a/charts/clusterpirate/tests/valkey-connection_test.yaml
+++ b/charts/clusterpirate/tests/valkey-connection_test.yaml
@@ -1,0 +1,110 @@
+suite: test clusterpirate valkey connection
+templates:
+  - configmap.yaml
+  - deployment.yaml
+tests:
+  - it: should point valkeyHost at the valkey subchart service by default
+    template: configmap.yaml
+    asserts:
+      - equal:
+          path: data.valkeyHost
+          value: RELEASE-NAME-valkey
+
+  - it: should read the valkey password from the subchart secret by default
+    template: deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VALKEY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-valkey
+                key: password
+
+  - it: should follow the valkey subchart fullnameOverride in the ConfigMap
+    template: configmap.yaml
+    set:
+      valkey:
+        fullnameOverride: vk-custom
+    asserts:
+      - equal:
+          path: data.valkeyHost
+          value: vk-custom
+
+  - it: should follow the valkey subchart fullnameOverride in the secretKeyRef
+    template: deployment.yaml
+    set:
+      valkey:
+        fullnameOverride: vk-custom
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VALKEY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: vk-custom
+                key: password
+
+  - it: should follow the valkey subchart nameOverride
+    template: configmap.yaml
+    set:
+      valkey:
+        nameOverride: vk
+    asserts:
+      - equal:
+          path: data.valkeyHost
+          value: RELEASE-NAME-vk
+
+  - it: should keep the legacy name when the release is named clusterpirate
+    template: configmap.yaml
+    release:
+      name: clusterpirate
+    asserts:
+      - equal:
+          path: data.valkeyHost
+          value: clusterpirate-valkey
+
+  - it: should prefer an explicit cache host over the subchart name
+    template: configmap.yaml
+    set:
+      clusterPirate:
+        metrics:
+          cache:
+            host: valkey.example.com
+    asserts:
+      - equal:
+          path: data.valkeyHost
+          value: valkey.example.com
+
+  - it: should render the explicit cache host when valkey is disabled
+    template: configmap.yaml
+    set:
+      valkey:
+        enabled: false
+      clusterPirate:
+        metrics:
+          cache:
+            host: valkey.example.com
+    asserts:
+      - equal:
+          path: data.valkeyHost
+          value: valkey.example.com
+
+  - it: should use the valkey existingSecret when one is configured
+    template: deployment.yaml
+    set:
+      valkey:
+        auth:
+          existingSecret: my-valkey-secret
+          existingSecretPasswordKey: valkey-password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VALKEY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-valkey-secret
+                key: valkey-password


### PR DESCRIPTION
### Description of the change

The Valkey host and the `VALKEY_PASSWORD` secret reference are built from `clusterpirate.fullname`, but the valkey subchart names its Service and Secret from its own fullname helper. They coincide only when the release is named `clusterpirate`.

### Benefits

Both resolve under any release name and `valkey.fullnameOverride` takes effect, matching the `<release-name>-valkey` format documented in values.yaml.

### Possible drawbacks

The host uses an explicit if/else rather than `| default`, because `default` evaluates both arms and `valkey.fullname` errors when `valkey.enabled=false`. Rendered names are unchanged for `helm install clusterpirate`.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified