### PR TITLE
[postgres] Default the database name to auth.username

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.19.14
+version: 0.19.15
 appVersion: "18.4.0"
 keywords:
   - postgres
@@ -43,9 +43,7 @@ annotations:
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
     - kind: fixed
-      description: "Use shared security context helper for metrics sidecar on OpenShift"
+      description: "Default auth.database to auth.username so the published connection details match the database the image creates"
       links:
-        - name: "Issue"
-          url: "https://github.com/CloudPirates-io/helm-charts/issues/1399"
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/postgres/CHANGELOG.md"

--- a/charts/postgres/templates/_helpers.tpl
+++ b/charts/postgres/templates/_helpers.tpl
@@ -117,7 +117,7 @@ Get PostgreSQL database name
 {{- if .Values.auth.database -}}
 {{- .Values.auth.database -}}
 {{- else -}}
-postgres
+{{- include "postgres.username" . -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/postgres/tests/database-defaults_test.yaml
+++ b/charts/postgres/tests/database-defaults_test.yaml
@@ -1,0 +1,105 @@
+suite: test postgres database default in secret
+templates:
+  - secret.yaml
+
+tests:
+  - it: should default the database to auth.username when auth.database is empty
+    set:
+      auth:
+        username: myuser
+        password: pw
+    asserts:
+      - equal:
+          path: data.username
+          value: "bXl1c2Vy"
+      - equal:
+          path: data.database
+          value: "bXl1c2Vy"
+      - equal:
+          path: data.uri
+          value: "cG9zdGdyZXNxbDovL215dXNlcjpwd0BSRUxFQVNFLU5BTUUtcG9zdGdyZXMuTkFNRVNQQUNFLnN2Yzo1NDMyL215dXNlcg=="
+
+  - it: should prefer auth.database over auth.username
+    set:
+      auth:
+        username: myuser
+        database: mydb
+        password: pw
+    asserts:
+      - equal:
+          path: data.database
+          value: "bXlkYg=="
+      - equal:
+          path: data.uri
+          value: "cG9zdGdyZXNxbDovL215dXNlcjpwd0BSRUxFQVNFLU5BTUUtcG9zdGdyZXMuTkFNRVNQQUNFLnN2Yzo1NDMyL215ZGI="
+
+  - it: should keep postgres as the database when neither username nor database is set
+    set:
+      auth:
+        password: pw
+    asserts:
+      - equal:
+          path: data.username
+          value: "cG9zdGdyZXM="
+      - equal:
+          path: data.database
+          value: "cG9zdGdyZXM="
+      - equal:
+          path: data.uri
+          value: "cG9zdGdyZXNxbDovL3Bvc3RncmVzOnB3QFJFTEVBU0UtTkFNRS1wb3N0Z3Jlcy5OQU1FU1BBQ0Uuc3ZjOjU0MzIvcG9zdGdyZXM="
+---
+suite: test postgres database default in statefulset
+templates:
+  - statefulset.yaml
+
+tests:
+  - it: should use auth.username in the metrics DSN when auth.database is empty
+    set:
+      auth:
+        username: myuser
+      metrics:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[1].name
+          value: DATA_SOURCE_NAME
+      - equal:
+          path: spec.template.spec.containers[1].env[1].value
+          value: "postgresql://myuser:$(POSTGRES_PASSWORD)@localhost:5432/myuser?sslmode=disable"
+
+  - it: should prefer auth.database in the metrics DSN
+    set:
+      auth:
+        username: myuser
+        database: mydb
+      metrics:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[1].value
+          value: "postgresql://myuser:$(POSTGRES_PASSWORD)@localhost:5432/mydb?sslmode=disable"
+
+  - it: should keep the postgres database in the metrics DSN by default
+    set:
+      metrics:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].env[1].value
+          value: "postgresql://postgres:$(POSTGRES_PASSWORD)@localhost:5432/postgres?sslmode=disable"
+
+  - it: should not set POSTGRES_DB when only auth.username is given
+    set:
+      auth:
+        username: myuser
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            value: myuser
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: POSTGRES_DB


### PR DESCRIPTION
### Description of the change

`postgres.database` returned the literal `postgres` whenever `auth.database` is empty. But with `auth.username` set the chart leaves `POSTGRES_DB` unset, so the image creates a database named after the user, as values.yaml and the README already promise.

### Benefits

The Secret's `database` and `uri` keys and the exporter `DATA_SOURCE_NAME` name the database that is actually created.

### Possible drawbacks

Those keys change when `auth.username` is set and `auth.database` is empty. The default render is unchanged.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified