### PR TITLE
[nginx] Mount the stream server config outside the conf.d volume

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.16.1
+version: 0.16.2
 appVersion: "1.31.3"
 keywords:
   - nginx

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -171,7 +171,8 @@ spec:
           {{- end }}
           {{- if or .Values.streamServerConfig .Values.existingStreamServerConfigConfigmap }}
             - name: stream-server-config
-              mountPath: /etc/nginx/conf.d
+              mountPath: /etc/nginx/conf.d/stream-server-config.conf
+              subPath: stream-server-config.conf
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -270,7 +271,7 @@ spec:
         - name: static-site
           {{- include "nginx.staticSiteVolume" . | nindent 10 }}
         {{- end }}
-      {{- if or .Values.serverConfig .Values.streamServerConfig .Values.existingServerConfigConfigmap }}
+      {{- if or .Values.serverConfig .Values.existingServerConfigConfigmap }}
         - name: nginx-server-config
           configMap:
             name: {{ include "nginx.serverConfigConfigmapName" . }}
@@ -278,11 +279,6 @@ spec:
             items:
               - key: server-config.conf
                 path: server-config.conf
-            {{- end }}
-            {{- if .Values.streamServerConfig }}
-            items:
-              - key: stream-server-config.conf
-                path: stream-server-config.conf
             {{- end }}
       {{- end }}
       {{- if or .Values.config .Values.existingConfigConfigmap }}

--- a/charts/nginx/tests/server-config-volumes_test.yaml
+++ b/charts/nginx/tests/server-config-volumes_test.yaml
@@ -1,0 +1,166 @@
+suite: test nginx server config volumes
+templates:
+  - deployment.yaml
+  - configmap.yaml
+set:
+  image:
+    tag: 1.6.31@sha256:testdigest123
+tests:
+  - it: should not render any server config volume or mount by default
+    template: deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nginx-server-config
+          any: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: stream-server-config
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nginx-server-config
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: stream-server-config
+          any: true
+
+  - it: should render only the nginx-server-config volume when serverConfig is set
+    template: deployment.yaml
+    set:
+      serverConfig: |
+        server { listen 8080; }
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nginx-server-config
+            configMap:
+              name: RELEASE-NAME-nginx
+              items:
+                - key: server-config.conf
+                  path: server-config.conf
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: stream-server-config
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nginx-server-config
+            mountPath: /etc/nginx/conf.d
+
+  - it: should not render an unmounted nginx-server-config volume when only streamServerConfig is set
+    template: deployment.yaml
+    set:
+      streamServerConfig: |
+        server { listen 9000; }
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nginx-server-config
+          any: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: stream-server-config
+            configMap:
+              name: RELEASE-NAME-nginx
+              items:
+                - key: stream-server-config.conf
+                  path: stream-server-config.conf
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nginx-server-config
+          any: true
+
+  - it: should render a single items list on the nginx-server-config volume when both configs are set
+    template: deployment.yaml
+    set:
+      serverConfig: |
+        server { listen 8080; }
+      streamServerConfig: |
+        server { listen 9000; }
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: nginx-server-config
+            configMap:
+              name: RELEASE-NAME-nginx
+              items:
+                - key: server-config.conf
+                  path: server-config.conf
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: stream-server-config
+            configMap:
+              name: RELEASE-NAME-nginx
+              items:
+                - key: stream-server-config.conf
+                  path: stream-server-config.conf
+      - equal:
+          path: spec.template.spec.volumes[1].configMap.items
+          value:
+            - key: server-config.conf
+              path: server-config.conf
+
+  - it: should mount both configs at distinct paths when both configs are set
+    template: deployment.yaml
+    set:
+      serverConfig: |
+        server { listen 8080; }
+      streamServerConfig: |
+        server { listen 9000; }
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: nginx-server-config
+            mountPath: /etc/nginx/conf.d
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: stream-server-config
+            mountPath: /etc/nginx/conf.d/stream-server-config.conf
+            subPath: stream-server-config.conf
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: stream-server-config
+            mountPath: /etc/nginx/conf.d
+
+  - it: should keep the stream config file path when existingStreamServerConfigConfigmap is used
+    template: deployment.yaml
+    set:
+      existingStreamServerConfigConfigmap: my-stream-cm
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: stream-server-config
+            configMap:
+              name: my-stream-cm
+              items:
+                - key: stream-server-config.conf
+                  path: stream-server-config.conf
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: stream-server-config
+            mountPath: /etc/nginx/conf.d/stream-server-config.conf
+            subPath: stream-server-config.conf
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: nginx-server-config
+          any: true


### PR DESCRIPTION
### Description of the change

With both `serverConfig` and `streamServerConfig` set, the `nginx-server-config` volume emitted `items:` twice in one configMap mapping and both volumes mounted at `/etc/nginx/conf.d`. A stream-only install also produced an unmounted volume.

### Benefits

The rendered volume is valid with both values set, and the stream config no longer collides with the server config mount. In-container paths are unchanged.

### Possible drawbacks

The stream config becomes a `subPath` mount, so it does not update in place; for inline values the `checksum/server-configuration` annotation already rolls the pods. The two volumes stay separate because the existing-configmap values can name different ConfigMaps.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified