### PR TITLE
[postgres] Honor global.imageRegistry for the metrics exporter image

### DIFF
--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.19.15
+version: 0.19.16
 appVersion: "18.4.0"
 keywords:
   - postgres

--- a/charts/postgres/templates/_helpers.tpl
+++ b/charts/postgres/templates/_helpers.tpl
@@ -52,6 +52,13 @@ Return the proper PostgreSQL image name
 {{- end }}
 
 {{/*
+Return the proper PostgreSQL exporter image name
+*/}}
+{{- define "postgres.metrics.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.metrics.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
 Return PostgreSQL credentials secret name
 */}}
 {{- define "postgres.secretName" -}}

--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -232,7 +232,7 @@ spec:
             {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
-          image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          image: {{ include "postgres.metrics.image" . | quote }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           env:

--- a/charts/postgres/tests/metrics-image_test.yaml
+++ b/charts/postgres/tests/metrics-image_test.yaml
@@ -1,0 +1,59 @@
+suite: test postgres exporter image
+templates:
+  - statefulset.yaml
+set:
+  metrics:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: prometheuscommunity/postgres-exporter
+      tag: v0.20.1
+tests:
+  - it: should use the chart registry when no global registry is set
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: quay.io/prometheuscommunity/postgres-exporter:v0.20.1
+          any: true
+
+  - it: should use global.imageRegistry for the exporter image
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: myregistry.example.com/prometheuscommunity/postgres-exporter:v0.20.1
+          any: true
+
+  - it: should let global.imageRegistry override the image registry
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      metrics:
+        image:
+          registry: docker.io
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: myregistry.example.com/prometheuscommunity/postgres-exporter:v0.20.1
+          any: true
+
+  - it: should omit the registry prefix when both registries are empty
+    set:
+      metrics:
+        image:
+          registry: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: prometheuscommunity/postgres-exporter:v0.20.1
+          any: true


### PR DESCRIPTION
### Description of the change

The exporter image is built straight from `metrics.image.registry`, so `global.imageRegistry` does nothing for it. Moved it to the `cloudpirates.image` helper.

This also fixes `metrics.image.registry: ""` rendering as `/prometheuscommunity/postgres-exporter:v0.20.1`, which is not a valid reference.

### Benefits

`global.imageRegistry` applies to the exporter.

### Possible drawbacks

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))