### PR TITLE
[redis] Honor global.imageRegistry for the volume permissions image

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.15
+version: 0.34.16
 appVersion: "8.10.0"
 keywords:
   - redis

--- a/charts/redis/templates/_helpers.tpl
+++ b/charts/redis/templates/_helpers.tpl
@@ -95,6 +95,13 @@ Return the proper Redis metrics image name
 {{- end }}
 
 {{/*
+Return the proper Redis volume permissions image name
+*/}}
+{{- define "redis.volumePermissions.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.volumePermissions.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
 Sentinel selector labels
 */}}
 {{- define "redis.sentinel.selectorLabels" -}}

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -76,7 +76,7 @@ spec:
       initContainers:
         {{- if .Values.volumePermissions.enabled }}
         - name: volume-permissions
-          image: "{{ .Values.volumePermissions.image.registry | default .Values.global.imageRegistry }}/{{ .Values.volumePermissions.image.repository }}:{{ .Values.volumePermissions.image.tag }}"
+          image: {{ include "redis.volumePermissions.image" . | quote }}
           imagePullPolicy: {{ include "cloudpirates.imagePullPolicy" (dict "image" .Values.volumePermissions.image) }}
           command:
             - /bin/sh

--- a/charts/redis/tests/volume-permissions-image_test.yaml
+++ b/charts/redis/tests/volume-permissions-image_test.yaml
@@ -1,0 +1,59 @@
+suite: test redis volume permissions image
+templates:
+  - statefulset.yaml
+set:
+  volumePermissions:
+    enabled: true
+    image:
+      registry: docker.io
+      repository: busybox
+      tag: 1.38.0
+tests:
+  - it: should use the chart registry when no global registry is set
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: volume-permissions
+            image: docker.io/busybox:1.38.0
+          any: true
+
+  - it: should use global.imageRegistry for the volume permissions image
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: volume-permissions
+            image: myregistry.example.com/busybox:1.38.0
+          any: true
+
+  - it: should let global.imageRegistry override the image registry
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      volumePermissions:
+        image:
+          registry: quay.io
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: volume-permissions
+            image: myregistry.example.com/busybox:1.38.0
+          any: true
+
+  - it: should omit the registry prefix when both registries are empty
+    set:
+      volumePermissions:
+        image:
+          registry: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: volume-permissions
+            image: busybox:1.38.0
+          any: true


### PR DESCRIPTION
### Description of the change

`volumePermissions.image.registry` defaults to `docker.io` and the template does `registry | default global.imageRegistry`, so the global value never wins. Switched to the `cloudpirates.image` helper like the other containers.

### Benefits

`global.imageRegistry` applies to the volume-permissions init container.

### Possible drawbacks

None. Nothing changes unless `global.imageRegistry` is set.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))