### PR TITLE
[valkey] Honor global.imageRegistry for the metrics exporter image

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.25.4
+version: 0.25.5
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -136,3 +136,10 @@ Return the proper master-proxy (HAProxy) image name
 {{- define "valkey.masterProxy.image" -}}
 {{- include "cloudpirates.image" (dict "image" .Values.sentinel.masterProxy.image "global" .Values.global) -}}
 {{- end }}
+
+{{/*
+Return the proper Valkey exporter image name
+*/}}
+{{- define "valkey.metrics.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.metrics.image "global" .Values.global) -}}
+{{- end }}

--- a/charts/valkey/templates/statefulset.yaml
+++ b/charts/valkey/templates/statefulset.yaml
@@ -650,7 +650,7 @@ spec:
         {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
-          image: "{{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}"
+          image: {{ include "valkey.metrics.image" . | quote }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           env:

--- a/charts/valkey/tests/metrics-image_test.yaml
+++ b/charts/valkey/tests/metrics-image_test.yaml
@@ -1,0 +1,59 @@
+suite: test valkey exporter image
+templates:
+  - statefulset.yaml
+set:
+  metrics:
+    enabled: true
+    image:
+      registry: docker.io
+      repository: oliver006/redis_exporter
+      tag: v1.89.0-alpine
+tests:
+  - it: should use the chart registry when no global registry is set
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: docker.io/oliver006/redis_exporter:v1.89.0-alpine
+          any: true
+
+  - it: should use global.imageRegistry for the exporter image
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: myregistry.example.com/oliver006/redis_exporter:v1.89.0-alpine
+          any: true
+
+  - it: should let global.imageRegistry override the image registry
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      metrics:
+        image:
+          registry: quay.io
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: myregistry.example.com/oliver006/redis_exporter:v1.89.0-alpine
+          any: true
+
+  - it: should omit the registry prefix when both registries are empty
+    set:
+      metrics:
+        image:
+          registry: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: oliver006/redis_exporter:v1.89.0-alpine
+          any: true


### PR DESCRIPTION
### Description of the change

The exporter builds its image string from `metrics.image.registry`, so `global.imageRegistry` is ignored. It should go through `cloudpirates.image` like `valkey.image`, `valkey.sentinel.image` and `valkey.masterProxy.image` already do.

### Benefits

`global.imageRegistry` applies to the exporter.

### Possible drawbacks

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))