### PR TITLE
[mariadb] Honor global.imageRegistry for the metrics exporter image

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.16.8
+version: 0.16.9
 appVersion: "12.3.2"
 keywords:
   - mariadb

--- a/charts/mariadb/templates/_helpers.tpl
+++ b/charts/mariadb/templates/_helpers.tpl
@@ -43,6 +43,13 @@ Return the proper MariaDB image name
 {{- end }}
 
 {{/*
+Return the proper MariaDB exporter image name
+*/}}
+{{- define "mariadb.metrics.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.metrics.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "mariadb.imagePullSecrets" -}}

--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -283,7 +283,7 @@ spec:
             {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
-          image: {{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
+          image: {{ include "mariadb.metrics.image" . | quote }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
           args: 
             - "--mysqld.username=exporter"

--- a/charts/mariadb/tests/metrics-image_test.yaml
+++ b/charts/mariadb/tests/metrics-image_test.yaml
@@ -1,0 +1,59 @@
+suite: test mariadb exporter image
+templates:
+  - statefulset.yaml
+set:
+  metrics:
+    enabled: true
+    image:
+      registry: docker.io
+      repository: prom/mysqld-exporter
+      tag: v0.18.0
+tests:
+  - it: should use the chart registry when no global registry is set
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: docker.io/prom/mysqld-exporter:v0.18.0
+          any: true
+
+  - it: should use global.imageRegistry for the exporter image
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: myregistry.example.com/prom/mysqld-exporter:v0.18.0
+          any: true
+
+  - it: should let global.imageRegistry override the image registry
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      metrics:
+        image:
+          registry: quay.io
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: myregistry.example.com/prom/mysqld-exporter:v0.18.0
+          any: true
+
+  - it: should omit the registry prefix when both registries are empty
+    set:
+      metrics:
+        image:
+          registry: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: metrics
+            image: prom/mysqld-exporter:v0.18.0
+          any: true


### PR DESCRIPTION
### Description of the change

The exporter image is built inline from `metrics.image.registry` and `global.imageRegistry` is ignored. Switched to the `cloudpirates.image` helper. Also quoted the image string, the other containers quote theirs.

### Benefits

`global.imageRegistry` applies to the exporter.

### Possible drawbacks

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))