### PR TITLE
[ghost] Honor global.imageRegistry for the MariaDB init container

### DIFF
--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.20.8
+version: 0.20.9
 appVersion: "6.57.1"
 keywords:
   - ghost

--- a/charts/ghost/README.md
+++ b/charts/ghost/README.md
@@ -288,9 +288,12 @@ The following tables list the configurable parameters of the Ghost chart organiz
 
 ### Init Container Parameters
 
-| Parameter                             | Description                  | Default          |
-| ------------------------------------- | ---------------------------- | ---------------- |
-| `initContainers.waitForMariadb.image` | MariaDB init container image | `mariadb:12.0.2` |
+| Parameter                                  | Description                                                                     | Default    |
+| ------------------------------------------ | ------------------------------------------------------------------------------- | ---------- |
+| `initContainers.waitForMariadb.image`      | MariaDB init container image (leave empty to use registry/repository/tag)         | `""`       |
+| `initContainers.waitForMariadb.registry`   | MariaDB init container image registry (overrides `global.imageRegistry`)          | `""`       |
+| `initContainers.waitForMariadb.repository` | MariaDB init container image repository                                           | `mariadb`  |
+| `initContainers.waitForMariadb.tag`        | MariaDB init container image tag                                                  | `12.0.2`   |
 
 ### Autoscaling Parameters
 

--- a/charts/ghost/templates/_helpers.tpl
+++ b/charts/ghost/templates/_helpers.tpl
@@ -48,6 +48,18 @@ Return the proper Ghost image name
 {{- end }}
 
 {{/*
+Return the proper MariaDB init container image name
+*/}}
+{{- define "ghost.initContainers.waitForMariadb.image" -}}
+{{- $config := .Values.initContainers.waitForMariadb -}}
+{{- if $config.image -}}
+{{- $config.image -}}
+{{- else -}}
+{{- include "cloudpirates.image" (dict "image" $config "global" .Values.global) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "ghost.imagePullSecrets" -}}

--- a/charts/ghost/templates/deployment.yaml
+++ b/charts/ghost/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- if .Values.mariadb.enabled }}
       initContainers:
         - name: wait-for-mariadb
-          image: "{{ .Values.initContainers.waitForMariadb.image | default "mariadb:12.0.2" }}"
+          image: {{ include "ghost.initContainers.waitForMariadb.image" . | quote }}
           env:
             {{- if .Values.mariadb.auth.existingSecret }}
             - name: MARIADB_USER

--- a/charts/ghost/tests/init-container-image_test.yaml
+++ b/charts/ghost/tests/init-container-image_test.yaml
@@ -1,0 +1,61 @@
+suite: test ghost mariadb init container image
+templates:
+  - deployment.yaml
+set:
+  mariadb:
+    enabled: true
+  initContainers:
+    waitForMariadb:
+      image: ""
+      registry: ""
+      repository: mariadb
+      tag: 12.0.2
+tests:
+  - it: should build the image from repository and tag by default
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-mariadb
+            image: mariadb:12.0.2
+          any: true
+
+  - it: should use global.imageRegistry for the init container image
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-mariadb
+            image: myregistry.example.com/mariadb:12.0.2
+          any: true
+
+  - it: should use the init container registry when no global registry is set
+    set:
+      initContainers:
+        waitForMariadb:
+          registry: quay.io
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-mariadb
+            image: quay.io/mariadb:12.0.2
+          any: true
+
+  - it: should use a fully qualified image verbatim when set
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      initContainers:
+        waitForMariadb:
+          image: ghcr.io/example/mariadb:11.4.0
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: wait-for-mariadb
+            image: ghcr.io/example/mariadb:11.4.0
+          any: true

--- a/charts/ghost/values.yaml
+++ b/charts/ghost/values.yaml
@@ -233,9 +233,15 @@ extraObjects: []
 ## @section Init Container Configuration
 ## Configuration for init containers
 initContainers:
-  ## @param initContainers.waitForMariadb.image MariaDB init container image for waiting
   waitForMariadb:
-    image: "mariadb:12.0.2@sha256:03a03a6817bb9eaa21e5aed1b734d432ec3f80021f5a2de1795475f158217545"
+    ## @param initContainers.waitForMariadb.image MariaDB init container image for waiting (leave empty to use registry/repository/tag)
+    image: ""
+    ## @param initContainers.waitForMariadb.registry MariaDB init container image registry (overrides global.imageRegistry)
+    registry: ""
+    ## @param initContainers.waitForMariadb.repository MariaDB init container image repository
+    repository: mariadb
+    ## @param initContainers.waitForMariadb.tag MariaDB init container image tag
+    tag: "12.0.2@sha256:03a03a6817bb9eaa21e5aed1b734d432ec3f80021f5a2de1795475f158217545"
 
 config:
   database:


### PR DESCRIPTION
### Description of the change

`initContainers.waitForMariadb.image` is one full image string, so there is nothing for `global.imageRegistry` to prefix. Split it into registry/repository/tag, the same shape keycloak uses for `initContainers.waitForPostgres`. Setting `image` still overrides everything.

The split form also matches the regex manager in `renovate.json`, so this image gets updates again.

### Benefits

`global.imageRegistry` applies to the init container, and renovate can update the image.

### Possible drawbacks

None. The default render is identical.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))