### PR TITLE
[nginx] Honor global.imageRegistry and pull secrets for the git image

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.16.2
+version: 0.16.3
 appVersion: "1.31.3"
 keywords:
   - nginx

--- a/charts/nginx/README.md
+++ b/charts/nginx/README.md
@@ -140,6 +140,18 @@ The following table lists the configurable parameters of the Nginx chart and the
 | `image.tag`        | Nginx image tag         | `"1.29.4-alpine@sha256:1e462d5b3fe0bc6647a9fbba5f47924b771254763e8a51b638842890967e477e"` |
 | `image.pullPolicy` | Nginx image pull policy | `Always`                                                                                  |
 
+### Git Image Parameters
+
+Used by the `git-clone-repository` init container and the `git-repo-syncer` sidecar when `cloneStaticSiteFromGit.enabled` is set.
+
+| Parameter                                    | Description            | Default       |
+| -------------------------------------------- | ---------------------- | ------------- |
+| `cloneStaticSiteFromGit.image.registry`      | Git image registry     | `docker.io`   |
+| `cloneStaticSiteFromGit.image.repository`    | Git image repository   | `alpine/git`  |
+| `cloneStaticSiteFromGit.image.tag`           | Git image tag          | `v2.52.0`     |
+| `cloneStaticSiteFromGit.image.pullPolicy`    | Git image pull policy  | `IfNotPresent`|
+| `cloneStaticSiteFromGit.image.pullSecrets`   | Git image pull secrets | `[]`          |
+
 
 ### Nginx Configuration Parameters
 

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -51,7 +51,7 @@ Return the proper Nginx image name
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "nginx.imagePullSecrets" -}}
-{{ include "cloudpirates.images.renderPullSecrets" (dict "images" (list .Values.image) "context" .) }}
+{{ include "cloudpirates.images.renderPullSecrets" (dict "images" (list .Values.image .Values.cloneStaticSiteFromGit.image) "context" .) }}
 {{- end -}}
 
 {{/*
@@ -104,6 +104,13 @@ Return the proper Nginx metrics image name
 */}}
 {{- define "nginx.metrics.image" -}}
 {{- include "cloudpirates.image" (dict "image" .Values.metrics.image "global" .Values.global) -}}
+{{- end }}
+
+{{/*
+Return the proper git image name for the static site containers
+*/}}
+{{- define "nginx.cloneStaticSiteFromGit.image" -}}
+{{- include "cloudpirates.image" (dict "image" .Values.cloneStaticSiteFromGit.image "global" .Values.global) -}}
 {{- end }}
 
 {{/*

--- a/charts/nginx/templates/deployment.yaml
+++ b/charts/nginx/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           {{- if .Values.initContainerSecurityContext }}
           securityContext: {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.cloneStaticSiteFromGit.image.registry }}/{{ .Values.cloneStaticSiteFromGit.image.repository }}:{{ .Values.cloneStaticSiteFromGit.image.tag }}"
+          image: {{ include "nginx.cloneStaticSiteFromGit.image" . | quote }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy }}
           {{- if .Values.cloneStaticSiteFromGit.gitClone.command }}
           command: {{- toYaml .Values.cloneStaticSiteFromGit.gitClone.command | nindent 12 }}
@@ -182,7 +182,7 @@ spec:
           {{- if .Values.initContainerSecurityContext }}
           securityContext: {{- toYaml .Values.initContainerSecurityContext | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.cloneStaticSiteFromGit.image.registry }}/{{ .Values.cloneStaticSiteFromGit.image.repository }}:{{ .Values.cloneStaticSiteFromGit.image.tag }}"
+          image: {{ include "nginx.cloneStaticSiteFromGit.image" . | quote }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy }}
           {{- if .Values.cloneStaticSiteFromGit.gitSync.command }}
           command: {{- toYaml .Values.cloneStaticSiteFromGit.gitSync.command | nindent 12 }}

--- a/charts/nginx/tests/git-image_test.yaml
+++ b/charts/nginx/tests/git-image_test.yaml
@@ -1,0 +1,97 @@
+suite: test nginx git container image
+templates:
+  - deployment.yaml
+set:
+  cloneStaticSiteFromGit:
+    enabled: true
+    repository: https://github.com/example/static-site
+    image:
+      registry: docker.io
+      repository: alpine/git
+      tag: v2.52.0
+tests:
+  - it: should use the chart registry when no global registry is set
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: git-clone-repository
+            image: docker.io/alpine/git:v2.52.0
+          any: true
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: git-repo-syncer
+            image: docker.io/alpine/git:v2.52.0
+          any: true
+
+  - it: should use global.imageRegistry for both git containers
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: git-clone-repository
+            image: myregistry.example.com/alpine/git:v2.52.0
+          any: true
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: git-repo-syncer
+            image: myregistry.example.com/alpine/git:v2.52.0
+          any: true
+
+  - it: should let global.imageRegistry override the image registry
+    set:
+      global:
+        imageRegistry: myregistry.example.com
+      cloneStaticSiteFromGit:
+        image:
+          registry: quay.io
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: git-clone-repository
+            image: myregistry.example.com/alpine/git:v2.52.0
+          any: true
+
+  - it: should omit the registry prefix when both registries are empty
+    set:
+      cloneStaticSiteFromGit:
+        image:
+          registry: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: git-clone-repository
+            image: alpine/git:v2.52.0
+          any: true
+
+  - it: should carry a digest through the tag
+    set:
+      cloneStaticSiteFromGit:
+        image:
+          tag: v2.52.0@sha256:9c9c6debba3eac25c9230db4bbd1e17d0c27efffdb93e502a47f6f447ab90ac4
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: git-clone-repository
+            image: docker.io/alpine/git:v2.52.0@sha256:9c9c6debba3eac25c9230db4bbd1e17d0c27efffdb93e502a47f6f447ab90ac4
+          any: true
+
+  - it: should add the git image pull secrets to the pod
+    set:
+      cloneStaticSiteFromGit:
+        image:
+          pullSecrets:
+            - git-registry-credentials
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: git-registry-credentials

--- a/charts/nginx/values.schema.json
+++ b/charts/nginx/values.schema.json
@@ -77,9 +77,6 @@
                 "image": {
                     "type": "object",
                     "properties": {
-                        "digest": {
-                            "type": "string"
-                        },
                         "pullPolicy": {
                             "type": "string"
                         },

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -154,11 +154,15 @@ cloneStaticSiteFromGit:
   ## Git image settings
   ##
   image:
+    ## @param cloneStaticSiteFromGit.image.registry Git image registry
     registry: docker.io
+    ## @param cloneStaticSiteFromGit.image.repository Git image repository
     repository: alpine/git
-    tag: v2.52.0
-    digest: "sha256:9c9c6debba3eac25c9230db4bbd1e17d0c27efffdb93e502a47f6f447ab90ac4"
+    ## @param cloneStaticSiteFromGit.image.tag Git image tag
+    tag: "v2.52.0"
+    ## @param cloneStaticSiteFromGit.image.pullPolicy Git image pull policy
     pullPolicy: IfNotPresent
+    ## @param cloneStaticSiteFromGit.image.pullSecrets Git image pull secrets
     pullSecrets: []
 
   ## @param cloneStaticSiteFromGit.repository Git Repository to clone static content from


### PR DESCRIPTION
### Description of the change

`cloneStaticSiteFromGit.image` is the only image in this chart not hooked up to the shared image handling. Three things follow from that:

- both git containers build the image string inline, so `global.imageRegistry` is ignored
- `pullSecrets` is never passed to `cloudpirates.images.renderPullSecrets`, so it never reaches the pod
- the block has no `@param` comments, so the regex manager in `renovate.json` skips it

All three are fixed here. I also dropped the separate `digest` field: no template reads it, #1576 removed it from the other charts, and it was stale anyway. It was added next to `tag: v2.49.1` and #771 bumped the tag to v2.52.0 without updating it. The tag is left plain so renovate can pin it again.

### Benefits

`global.imageRegistry` and `pullSecrets` work for the git containers, and the image is back under renovate.

### Possible drawbacks

None. The digest was not used, so rendering does not change.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))