### PR TITLE
[rabbitmq-cluster-operator] Use the cluster operator PodMonitor namespace

### DIFF
--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: "2.22.3"
 keywords:
   - rabbitmq-cluster-operator

--- a/charts/rabbitmq-cluster-operator/templates/cluster-operator/podmonitor.yaml
+++ b/charts/rabbitmq-cluster-operator/templates/cluster-operator/podmonitor.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "cloudpirates.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.podMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
   name: {{ printf "%s-metrics" (include "rmqco.clusterOperator.fullname" .) }}
-  namespace: {{ default (include "cloudpirates.namespace" .) .Values.msgTopologyOperator.metrics.podMonitor.namespace | quote }}
+  namespace: {{ default (include "cloudpirates.namespace" .) .Values.clusterOperator.metrics.podMonitor.namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "cloudpirates.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}

--- a/charts/rabbitmq-cluster-operator/tests/podmonitor-namespace_test.yaml
+++ b/charts/rabbitmq-cluster-operator/tests/podmonitor-namespace_test.yaml
@@ -1,0 +1,61 @@
+suite: test rabbitmq-cluster-operator podmonitor namespaces
+templates:
+  - cluster-operator/podmonitor.yaml
+  - messaging-topology-operator/podmonitor.yaml
+tests:
+  - it: should default both PodMonitors to the release namespace
+    set:
+      clusterOperator:
+        metrics:
+          podMonitor:
+            enabled: true
+      msgTopologyOperator:
+        metrics:
+          podMonitor:
+            enabled: true
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should put the cluster operator PodMonitor in its own namespace value
+    template: cluster-operator/podmonitor.yaml
+    set:
+      clusterOperator:
+        metrics:
+          podMonitor:
+            enabled: true
+            namespace: cluster-operator-monitoring
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: cluster-operator-monitoring
+
+  - it: should not move the cluster operator PodMonitor with the topology operator value
+    template: cluster-operator/podmonitor.yaml
+    set:
+      clusterOperator:
+        metrics:
+          podMonitor:
+            enabled: true
+      msgTopologyOperator:
+        metrics:
+          podMonitor:
+            namespace: topology-monitoring
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should put the topology operator PodMonitor in its own namespace value
+    template: messaging-topology-operator/podmonitor.yaml
+    set:
+      msgTopologyOperator:
+        metrics:
+          podMonitor:
+            enabled: true
+            namespace: topology-monitoring
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: topology-monitoring


### PR DESCRIPTION
### Description of the change

The cluster operator PodMonitor reads `.Values.msgTopologyOperator.metrics.podMonitor.namespace`. So `clusterOperator.metrics.podMonitor.namespace` is ignored, and setting the topology operator value moves the cluster operator PodMonitor with it. The topology operator template already reads its own value.

### Benefits

Each PodMonitor follows its own namespace value.

### Possible drawbacks

Anyone who set `msgTopologyOperator.metrics.podMonitor.namespace` and relied on it moving both PodMonitors will need to set the cluster operator value too.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))