### PR TITLE
[keycloak] Create the database credentials Secret for mssql

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.29
+version: 0.21.30
 appVersion: "26.7.2"
 keywords:
   - keycloak

--- a/charts/keycloak/templates/secret.yaml
+++ b/charts/keycloak/templates/secret.yaml
@@ -18,7 +18,7 @@ data:
   {{- end }}
 {{- end }}
 ---
-{{- if and (not .Values.database.existingSecret) (or (eq .Values.database.type "postgres") (eq .Values.database.type "mysql") (eq .Values.database.type "mariadb")) }}
+{{- if and (not .Values.database.existingSecret) (or (eq .Values.database.type "postgres") (eq .Values.database.type "mysql") (eq .Values.database.type "mariadb") (eq .Values.database.type "mssql")) }}
 {{- if and (eq .Values.database.type "postgres") .Values.postgres.enabled }}
 {{- /* Use the existing postgres password when postgres is enabled */}}
 {{- $existingPostgresSecret := (lookup "v1" "Secret" (include "cloudpirates.namespace" .) (printf "%s-postgres" (include "cloudpirates.namespace" .))) }}

--- a/charts/keycloak/tests/mssql-db-secret_test.yaml
+++ b/charts/keycloak/tests/mssql-db-secret_test.yaml
@@ -1,0 +1,54 @@
+suite: test keycloak external database credentials secret
+templates:
+  - secret.yaml
+set:
+  postgres:
+    enabled: false
+  database:
+    host: db.example.com
+    name: keycloak
+    username: kcuser
+    password: kcpass
+tests:
+  - it: should create the db credentials Secret for mssql
+    documentIndex: 1
+    set:
+      database:
+        type: mssql
+        port: "1433"
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-keycloak-db
+      - equal:
+          path: data.db-username
+          value: a2N1c2Vy
+      - equal:
+          path: data.db-password
+          value: a2NwYXNz
+
+  - it: should create the db credentials Secret for an external postgres
+    documentIndex: 1
+    set:
+      database:
+        type: postgres
+        port: "5432"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-keycloak-db
+      - equal:
+          path: data.db-username
+          value: a2N1c2Vy
+
+  - it: should not create the db credentials Secret when existingSecret is set
+    set:
+      database:
+        type: mssql
+        port: "1433"
+        existingSecret: my-db-secret
+    asserts:
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
### Description of the change

`database.type: mssql` is documented and statefulset.yaml renders `KC_DB_USERNAME` and `KC_DB_PASSWORD` as secretKeyRefs to `<fullname>-db` for it, but secret.yaml only creates that Secret for postgres, mysql and mariadb. The pod then references a Secret that does not exist and stays in CreateContainerConfigError. Added mssql to the condition so it falls through to the external database branch, which already handles it.

### Benefits

Keycloak starts against an external SQL Server without having to pre-create the Secret by hand.

### Possible drawbacks

None. `database.existingSecret` still takes precedence.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))