### PR TITLE
[rustfs] Point the console HTTPRoute at the console Service

### DIFF
--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: (ALPHA) High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.10.5
+version: 0.10.6
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/templates/httproute.yaml
+++ b/charts/rustfs/templates/httproute.yaml
@@ -121,7 +121,7 @@ spec:
         {{- end }}
       {{- end }}
       backendRefs:
-        - name: {{ include "rustfs.fullname" $ }}-pod0
+        - name: {{ include "rustfs.fullname" $ }}-console
           port: {{ $.Values.consoleService.port }}
     {{- end }}
     {{- else }}
@@ -132,7 +132,7 @@ spec:
             type: {{ if eq .pathType "Exact" }}Exact{{ else }}PathPrefix{{ end }}
             value: {{ .path }}
       backendRefs:
-        - name: {{ include "rustfs.fullname" $ }}-pod0
+        - name: {{ include "rustfs.fullname" $ }}-console
           port: {{ $.Values.consoleService.port }}
     {{- end }}
     {{- end }}

--- a/charts/rustfs/tests/httproute_test.yaml
+++ b/charts/rustfs/tests/httproute_test.yaml
@@ -1,0 +1,56 @@
+suite: test rustfs gateway api routes
+templates:
+  - httproute.yaml
+  - service.yaml
+tests:
+  - it: should point the console route at the console Service
+    template: httproute.yaml
+    set:
+      gatewayAPI:
+        consoleHttpRoute:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-rustfs-console
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 9001
+
+  - it: should create a Service under the name the console route points at
+    template: service.yaml
+    documentIndex: 1
+    set:
+      gatewayAPI:
+        consoleHttpRoute:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-rustfs-console
+      - equal:
+          path: spec.ports[0].port
+          value: 9001
+
+  - it: should point the api route at the main Service
+    template: httproute.yaml
+    set:
+      gatewayAPI:
+        httpRoute:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-rustfs
+
+  - it: should follow fullnameOverride on the console backend
+    template: httproute.yaml
+    set:
+      fullnameOverride: storage
+      gatewayAPI:
+        consoleHttpRoute:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: storage-console


### PR DESCRIPTION
### Description of the change

Both console `backendRefs` in httproute.yaml name `<fullname>-pod0`. No template creates a Service by that name, `grep -rn pod0` matches only those two lines. The console Service is `<fullname>-console` and consoleIngress already uses it.

### Benefits

The Gateway API console route resolves to a real Service instead of returning 503.

### Possible drawbacks

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))