### PR TITLE
[clusterpirate] Render labels on every object without breaking YAML

### DIFF
--- a/charts/clusterpirate/Chart.yaml
+++ b/charts/clusterpirate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clusterpirate
 description: Client agent for the CloudPirates Managed Observability Platform to connect your Kubernetes cluster to our infrastructure
 type: application
-version: 1.5.11
+version: 1.5.12
 appVersion: "1.0.1"
 keywords:
   - kubernetes

--- a/charts/clusterpirate/templates/clusterrole.yaml
+++ b/charts/clusterpirate/templates/clusterrole.yaml
@@ -8,10 +8,8 @@ metadata:
   annotations:
 {{- include "clusterpirate.annotations" . | indent 4 }}
   {{- end }}
-  {{- if .Values.commonLabels }}
   labels:
-{{- include "clusterpirate.labels" . | indent 4 }}
-  {{- end }}
+    {{- include "clusterpirate.labels" . | nindent 4 }}
 rules:
 # Base permissions - always required regardless of monitoring configuration
 - apiGroups: [""]

--- a/charts/clusterpirate/templates/clusterrolebinding.yaml
+++ b/charts/clusterpirate/templates/clusterrolebinding.yaml
@@ -8,10 +8,8 @@ metadata:
   annotations:
 {{- include "clusterpirate.annotations" . | indent 4 }}
   {{- end }}
-  {{- if .Values.commonLabels }}
   labels:
-{{- include "clusterpirate.labels" . | indent 4 }}
-  {{- end }}
+    {{- include "clusterpirate.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/clusterpirate/templates/configmap.yaml
+++ b/charts/clusterpirate/templates/configmap.yaml
@@ -7,10 +7,8 @@ metadata:
   annotations:
 {{- include "clusterpirate.annotations" . | indent 4 }}
   {{- end }}
-  {{- if .Values.commonLabels }}
   labels:
-{{- include "clusterpirate.labels" . | indent 4 }}
-  {{- end }}
+    {{- include "clusterpirate.labels" . | nindent 4 }}
 data:
   logLevel: {{ .Values.clusterPirate.logLevel | quote }}
   healthPort: {{ .Values.clusterPirate.healthPort | quote }}

--- a/charts/clusterpirate/templates/secret.yaml
+++ b/charts/clusterpirate/templates/secret.yaml
@@ -8,10 +8,8 @@ metadata:
   annotations:
 {{- include "clusterpirate.annotations" . | indent 4 }}
   {{- end }}
-  {{- if .Values.commonLabels }}
   labels:
-{{- include "clusterpirate.labels" . | indent 4 }}
-  {{- end }}
+    {{- include "clusterpirate.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   {{- if .Values.auth.accessToken }}

--- a/charts/clusterpirate/templates/serviceaccount.yaml
+++ b/charts/clusterpirate/templates/serviceaccount.yaml
@@ -11,8 +11,6 @@ metadata:
     {{- end }}
 {{- include "clusterpirate.annotations" . | indent 4 }}
   {{- end }}
-  {{- if .Values.commonLabels }}
   labels:
-{{- include "clusterpirate.labels" . | indent 4 }}
-  {{- end }}
+    {{- include "clusterpirate.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/clusterpirate/tests/common-labels_test.yaml
+++ b/charts/clusterpirate/tests/common-labels_test.yaml
@@ -1,0 +1,49 @@
+suite: test clusterpirate common labels
+templates:
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - secret.yaml
+  - serviceaccount.yaml
+set:
+  auth:
+    accessToken: test-token
+tests:
+  - it: should label every object by default
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: clusterpirate
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+
+  - it: should add commonLabels to every object
+    set:
+      commonLabels:
+        team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: clusterpirate
+
+  - it: should keep commonAnnotations separate from labels
+    set:
+      commonLabels:
+        team: platform
+      commonAnnotations:
+        owner: platform-team
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform-team
+      - isNull:
+          path: metadata.labels.owner
+      - isNull:
+          path: metadata.annotations.team


### PR DESCRIPTION
### Description of the change

Five templates (clusterrole, clusterrolebinding, configmap, secret, serviceaccount) render labels as `labels:` followed by `{{- include "clusterpirate.labels" . | indent 4 }}`. `cloudpirates.labels` returns no leading newline, so the `{{-` eats the newline after `labels:` and the first label ends up on the same line. Setting `commonLabels` therefore aborts the render. The identical annotations block works because `cloudpirates.annotations` does start with a newline, which is why this went unnoticed.

The same five blocks are wrapped in `{{- if .Values.commonLabels }}`, so with default values those objects get no labels at all, not even `app.kubernetes.io/name`. Both are fixed by rendering labels unconditionally with `nindent 4`, the way deployment.yaml already does.

### Benefits

`commonLabels` no longer breaks `helm install`, and the ConfigMap, Secret, ServiceAccount, ClusterRole and ClusterRoleBinding carry the standard labels like the Deployment does.

### Possible drawbacks

Those five objects gain labels they did not have before. Label selectors are unaffected, the selector labels come from a different helper.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))