### PR TITLE
[mongodb] Fix the annotation blocks on the metrics and mongos Services

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.18.10
+version: 0.18.11
 appVersion: "8.3.8"
 keywords:
   - mongodb

--- a/charts/mongodb/templates/metrics-service.yaml
+++ b/charts/mongodb/templates/metrics-service.yaml
@@ -13,7 +13,9 @@ metadata:
   {{- if or (include "mongodb.annotations" .) .Values.metrics.service.annotations }}
   annotations: 
 {{- (include "mongodb.annotations" .) | indent 4 }}
-{{- toYaml .Values.metrics.service.annotations | nindent 4 }}
+  {{- if .Values.metrics.service.annotations }}
+{{ toYaml .Values.metrics.service.annotations | indent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}

--- a/charts/mongodb/templates/metrics-servicemonitor.yaml
+++ b/charts/mongodb/templates/metrics-servicemonitor.yaml
@@ -6,10 +6,12 @@ metadata:
   namespace: {{ default (include "cloudpirates.namespace" .) .Values.metrics.serviceMonitor.namespace }}
   labels:
     {{- include "mongodb.metrics.serviceMonitor.labels" . | nindent 4 }}
-  {{- with .Values.metrics.serviceMonitor.annotations }}
+  {{- if or (include "mongodb.annotations" .) .Values.metrics.serviceMonitor.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-    {{- include "mongodb.annotations" . }}
+{{- (include "mongodb.annotations" .) | indent 4 }}
+  {{- if .Values.metrics.serviceMonitor.annotations }}
+{{ toYaml .Values.metrics.serviceMonitor.annotations | indent 4 }}
+  {{- end }}
   {{- end }}
 spec:
   {{- if .Values.metrics.serviceMonitor.jobLabel }}

--- a/charts/mongodb/templates/service-mongos.yaml
+++ b/charts/mongodb/templates/service-mongos.yaml
@@ -8,12 +8,12 @@ metadata:
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
     service-type: mongos
-  {{- with .Values.shardedCluster.mongos.service.annotations }}
+  {{- if or (include "mongodb.annotations" .) .Values.shardedCluster.mongos.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+{{- (include "mongodb.annotations" .) | indent 4 }}
+  {{- if .Values.shardedCluster.mongos.service.annotations }}
+{{ toYaml .Values.shardedCluster.mongos.service.annotations | indent 4 }}
   {{- end }}
-  {{- with (include "mongodb.annotations" .) }}
-{{- . | indent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.shardedCluster.mongos.service.type }}

--- a/charts/mongodb/tests/annotations_test.yaml
+++ b/charts/mongodb/tests/annotations_test.yaml
@@ -1,0 +1,87 @@
+suite: test mongodb annotation blocks
+templates:
+  - metrics-service.yaml
+  - metrics-servicemonitor.yaml
+  - service-mongos.yaml
+tests:
+  - it: should render the metrics Service with commonAnnotations and no service annotations
+    template: metrics-service.yaml
+    set:
+      metrics:
+        enabled: true
+      commonAnnotations:
+        owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform
+
+  - it: should merge commonAnnotations and metrics.service.annotations
+    template: metrics-service.yaml
+    set:
+      metrics:
+        enabled: true
+        service:
+          annotations:
+            prometheus.io/scrape: "true"
+      commonAnnotations:
+        owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: should render the ServiceMonitor when serviceMonitor.annotations is set
+    template: metrics-servicemonitor.yaml
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+          annotations:
+            argocd.argoproj.io/sync-wave: "1"
+      commonAnnotations:
+        owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "1"
+      - equal:
+          path: metadata.annotations.owner
+          value: platform
+
+  - it: should apply commonAnnotations to the ServiceMonitor with no serviceMonitor annotations
+    template: metrics-servicemonitor.yaml
+    set:
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      commonAnnotations:
+        owner: platform
+    asserts:
+      - equal:
+          path: metadata.annotations.owner
+          value: platform
+
+  - it: should put commonAnnotations on the mongos Service as annotations, not labels
+    template: service-mongos.yaml
+    documentIndex: 0
+    set:
+      shardedCluster:
+        enabled: true
+        keyFile: abcdefghij
+      commonAnnotations:
+        owner: platform
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-mongodb-mongos
+      - equal:
+          path: metadata.annotations.owner
+          value: platform
+      - isNull:
+          path: metadata.labels.owner


### PR DESCRIPTION
### Description of the change

Three annotation blocks do not follow the shape used in service.yaml:

- metrics-service.yaml renders `toYaml .Values.metrics.service.annotations` with no emptiness guard, so the default `{}` emits a bare `{}` line inside the annotations map and `commonAnnotations` produces invalid YAML
- metrics-servicemonitor.yaml calls `include "mongodb.annotations" .` from inside a `with` block, so `.` is the annotations map and the helper hits a nil pointer on `.Values`. Setting the documented `metrics.serviceMonitor.annotations` aborts the render, and `commonAnnotations` never reach the ServiceMonitor otherwise
- service-mongos.yaml emits the common annotations with no `annotations:` key of its own, so on a sharded cluster they are appended to the preceding `labels:` block and silently become labels

All three now use the same `if or` + `annotations:` shape as service.yaml.

### Benefits

`commonAnnotations` and `metrics.serviceMonitor.annotations` work on all three objects. On the mongos Service an annotation value that is not a legal label value no longer gets the Service rejected by the API server.

### Possible drawbacks

None.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))