### PR TITLE
[kafka] Exec the command override so SIGTERM reaches the broker

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka is a distributed event streaming platform used for high-performance data pipelines, streaming analytics, and data integration. This chart deploys Kafka in KRaft mode (no ZooKeeper required).
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "4.3.1"
 keywords:
   - kafka

--- a/charts/kafka/templates/statefulset.yaml
+++ b/charts/kafka/templates/statefulset.yaml
@@ -134,7 +134,7 @@ spec:
               echo "Formatting KRaft storage (idempotent) for node ${NODE_ID}..."
               /opt/kafka/bin/kafka-storage.sh format -t "${KAFKA_CLUSTER_ID}" -c "$RUNTIME_CONFIG" --ignore-formatted
               {{ if .Values.command -}}
-              {{ range $i, $c := .Values.command }}{{ if $i }} {{ end }}{{ $c | quote }}{{- end }}
+              exec {{ range $i, $c := .Values.command }}{{ if $i }} {{ end }}{{ $c | quote }}{{- end }}
               {{- else -}}
               exec /opt/kafka/bin/kafka-server-start.sh "$RUNTIME_CONFIG"{{ range .Values.extraArgs }} {{ . | quote }}{{ end }}
               {{- end }}

--- a/charts/kafka/tests/unittest-defaults_test.yaml
+++ b/charts/kafka/tests/unittest-defaults_test.yaml
@@ -458,10 +458,25 @@ tests:
       # not be concatenated onto it (previously rendered `--ignore-formatted"sleep 3600"`).
       - matchRegex:
           path: spec.template.spec.containers[0].args[0]
-          pattern: '--ignore-formatted\s+"sleep 3600"'
+          pattern: '--ignore-formatted\s+exec "sleep 3600"'
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: '--ignore-formatted"'
+      # The override has to be exec'd so SIGTERM reaches the broker instead of the shell.
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?m)^exec "sleep 3600"$'
+
+  - it: should exec a multi word command override
+    template: statefulset.yaml
+    set:
+      command:
+        - /opt/kafka/bin/custom-start.sh
+        - --foo
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: '(?m)^exec "/opt/kafka/bin/custom-start\.sh" "--foo"$'
 
   - it: should append extraArgs to the kafka-server-start command
     template: statefulset.yaml


### PR DESCRIPTION
### Description of the change

The default branch execs kafka-server-start.sh, but the `command` override branch renders the command bare. The container command is `["/bin/sh", "-ec"]` with a multi command script, so the shell stays PID 1 and forks the override as a child. sh does not forward signals, so the SIGTERM sent on pod deletion never reaches the broker and it is killed at the end of the grace period without a clean shutdown.

Same fix as #1580 for zookeeper.

I also updated the existing `should place a command override on its own line` case in unittest-defaults_test.yaml: its pattern expected the override immediately after `--ignore-formatted`, and `exec ` now sits between. Its sibling assertion on the default branch already required `exec`, so the two are symmetric now.

### Benefits

A custom `command` gets a clean shutdown instead of SIGKILL.

### Possible drawbacks

None for the default path, which already execd.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))