### PR TITLE
[timescaledb] Mount config.existingConfigmap instead of dropping it

### DIFF
--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.13.5
+version: 0.13.6
 appVersion: "2.29.2"
 keywords:
   - timescaledb

--- a/charts/timescaledb/templates/statefulset.yaml
+++ b/charts/timescaledb/templates/statefulset.yaml
@@ -117,10 +117,8 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ include "timescaledb.dataDir" . }}
-            {{- if not .Values.config.existingConfigmap }}
             - name: config
               mountPath: {{ include "timescaledb.configDir" . }}
-            {{- end }}
             - name: run
               mountPath: {{ include "timescaledb.runDir" . }}
             - name: tmp
@@ -134,12 +132,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim }}
         {{- end }}
-        {{- if not .Values.config.existingConfigmap }}
         - name: config
           configMap:
             name: {{ include "timescaledb.configmapName" . }}
             optional: true
-        {{- end }}
         - name: run
           emptyDir: {}
         - name: tmp

--- a/charts/timescaledb/tests/existing-configmap_test.yaml
+++ b/charts/timescaledb/tests/existing-configmap_test.yaml
@@ -1,0 +1,57 @@
+suite: test timescaledb config configmap
+templates:
+  - statefulset.yaml
+  - configmap.yaml
+tests:
+  - it: should mount the chart ConfigMap by default
+    template: statefulset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-timescaledb
+              optional: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/postgresql
+
+  - it: should mount an existing ConfigMap when one is named
+    template: statefulset.yaml
+    set:
+      config:
+        existingConfigmap: my-ts-config
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: my-ts-config
+              optional: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/postgresql
+
+  - it: should create the chart ConfigMap by default
+    template: configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-timescaledb
+
+  - it: should not create the chart ConfigMap when an existing one is named
+    template: configmap.yaml
+    set:
+      config:
+        existingConfigmap: my-ts-config
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
### Description of the change

The config volume and its mount are both guarded by `{{- if not .Values.config.existingConfigmap }}`, so naming an existing ConfigMap drops the mount instead of pointing at it and the pod gets no postgresql.conf. Dropped both guards; the volume already resolves its name through `timescaledb.configmapName`, and configmap.yaml stays gated.

### Benefits

`config.existingConfigmap` does what the README says.

### Possible drawbacks

None. Without it the render is unchanged.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified