### PR TITLE
[memcached] Point the exporter at the memcached container port

### DIFF
--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.14.6
+version: 0.14.7
 appVersion: "1.6.45"
 keywords:
   - memcached

--- a/charts/memcached/templates/deployment.yaml
+++ b/charts/memcached/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           image: {{ include "memcached.metrics.image" . | quote }}
           imagePullPolicy: {{ include "cloudpirates.imagePullPolicy" (dict "image" .Values.metrics.image) }}
           args:
-            - "--memcached.address=localhost:{{ .Values.service.port }}"
+            - "--memcached.address=localhost:11211"
             - "--web.listen-address=:{{ .Values.metrics.service.port }}"
             {{- range .Values.metrics.extraArgs }}
             - {{ . }}

--- a/charts/memcached/tests/metrics-address_test.yaml
+++ b/charts/memcached/tests/metrics-address_test.yaml
@@ -1,0 +1,43 @@
+suite: test memcached exporter address
+templates:
+  - deployment.yaml
+set:
+  metrics:
+    enabled: true
+tests:
+  - it: should point the exporter at the memcached container port
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--memcached.address=localhost:11211"
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: memcached
+            containerPort: 11211
+            protocol: TCP
+
+  - it: should keep the exporter on the container port when service.port differs
+    set:
+      service:
+        port: 11212
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--memcached.address=localhost:11211"
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: memcached
+            containerPort: 11211
+            protocol: TCP
+
+  - it: should still bind the exporter web listener to the metrics service port
+    set:
+      metrics:
+        service:
+          port: 9151
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--web.listen-address=:9151"


### PR DESCRIPTION
### Description of the change

The exporter gets `--memcached.address=localhost:{{ .Values.service.port }}`, but the container port is hardcoded to 11211 and nothing passes `-p` to memcached, so changing `service.port` points the exporter at a dead port and metrics stop silently. Pointed it at the container port.

### Benefits

Metrics survive a changed `service.port`.

### Possible drawbacks

If `service.port` is meant to drive the listener instead, the alternative is passing `-p` to memcached and using it for containerPort, as redis does.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified