### PR TITLE
[minio] Let renovate manage the image again

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.13.2
+version: 0.13.3
 appVersion: "2025.10.15"
 keywords:
   - minio

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -18,13 +18,13 @@ commonLabels: {}
 commonAnnotations: {}
 
 ## @section MinIO image configuration
+## IMPORTANT: We are using a, by default, hardened image provided by us, which patches cve´s but does not in any way modify the behavior of minio. You are free to switch over to vanilla versions if this concerns you.
 image:
   ## @param image.registry MinIO image registry
   registry: docker.io
   ## @param image.repository MinIO image repository
   repository: cloudpirates/image-minio
   ## @param image.tag MinIO image tag (immutable tags are recommended)
-  ## IMPORTANT: We are using a, by default, hardened image provided by us, which patches cve´s but does not in any way modify the behavior of minio. You are free to switch over to vanilla versions if this concerns you.
   tag: "RELEASE.2025-10-15T17-29-55Z-hardened@sha256:8dc02a7e509336c8bbb67962086d691bdcde20a2c9327ed68e5081a681f6dbfc"
   ## @param image.useCpuV1 Use the Minio image tags suitable for old cpus (see https://github.com/minio/minio/issues/18365)
   useCpuV1: false


### PR DESCRIPTION
### Description of the change

The custom manager in `renovate.json` matches `## @param X.repository` / `repository:` / `## @param X.tag` / `tag:` as one run. The hardened image note sits between `## @param image.tag` and `tag:`, breaking the run, so the image has not been getting updates. Moved the note above the `image:` block: the regex matches nothing before and `docker.io/cloudpirates/image-minio` after.

### Benefits

The minio image is under renovate again.

### Possible drawbacks

None, comment placement only. `helm template` output is byte identical.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified