### PR TITLE
[zookeeper] Honor the documented probe enable flags and startupProbe

### DIFF
--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.13.7
+version: 0.13.8
 appVersion: "3.9.5"
 keywords:
   - zookeeper

--- a/charts/zookeeper/templates/statefulset.yaml
+++ b/charts/zookeeper/templates/statefulset.yaml
@@ -89,6 +89,7 @@ spec:
               {{- else }}
               exec /docker-entrypoint.sh zkServer.sh start-foreground
               {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             {{- if .Values.livenessProbe.custom }}
             {{- toYaml .Values.livenessProbe.custom | nindent 12 }}
@@ -101,6 +102,8 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             {{- if .Values.readinessProbe.custom }}
             {{- toYaml .Values.readinessProbe.custom | nindent 12 }}
@@ -113,6 +116,17 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            tcpSocket:
+              port: client
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+          {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: data

--- a/charts/zookeeper/tests/probes_test.yaml
+++ b/charts/zookeeper/tests/probes_test.yaml
@@ -1,0 +1,62 @@
+suite: test zookeeper probes
+templates:
+  - statefulset.yaml
+tests:
+  - it: should render liveness and readiness probes by default
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should drop the liveness probe when disabled
+    set:
+      livenessProbe:
+        enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should drop the readiness probe when disabled
+    set:
+      readinessProbe:
+        enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+      - isNotNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should render the startup probe when enabled
+    set:
+      startupProbe:
+        enabled: true
+        failureThreshold: 42
+        periodSeconds: 7
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.tcpSocket.port
+          value: client
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 42
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 7
+
+  - it: should use a custom liveness handler when given
+    set:
+      livenessProbe:
+        custom:
+          exec:
+            command: ["/bin/sh", "-c", "zkServer.sh status"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          value: zkServer.sh status
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket


### PR DESCRIPTION
### Description of the change

`livenessProbe.enabled`, `readinessProbe.enabled` and the six `startupProbe` parameters are documented in values.yaml but no template reads them: both probes render unconditionally and startupProbe is never rendered at all. Wired all three up, following the kafka chart.

### Benefits

Disabling a probe disables it, and a slow forming ensemble can use a startupProbe instead of dying to the liveness probe on cold start.

### Possible drawbacks

None. Probes default to enabled and startupProbe to disabled, so the default render is unchanged.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified