### PR TITLE
[rabbitmq] Test containerSecurityContext instead of an unused value

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.21.17
+version: 0.21.18
 appVersion: "4.3.5"
 keywords:
   - rabbitmq

--- a/charts/rabbitmq/tests/rabbitmq-functionality_test.yaml
+++ b/charts/rabbitmq/tests/rabbitmq-functionality_test.yaml
@@ -218,19 +218,21 @@ tests:
   - it: should configure security contexts correctly
     set:
       podSecurityContext:
-        fsGroup: 999
-      securityContext:
-        runAsUser: 999
-        runAsNonRoot: true
-        allowPrivilegeEscalation: false
+        fsGroup: 2000
+      containerSecurityContext:
+        runAsUser: 1234
+        runAsGroup: 4321
     template: templates/statefulset.yaml
     asserts:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
-          value: 999
+          value: 2000
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
-          value: 999
+          value: 1234
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsGroup
+          value: 4321
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false


### PR DESCRIPTION
### Description of the change

The `should configure security contexts correctly` case sets `securityContext.*`, which this chart does not read - the container context comes from `containerSecurityContext`. The set block is dead and the asserted values are the defaults, so it passes without exercising an override. Renamed it and picked values that differ from the defaults; against a hardcoded context the old case stays green, the new one fails.

### Benefits

Regressions in `containerSecurityContext` or `podSecurityContext` handling get caught.

### Possible drawbacks

None, test only.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified