### PR TITLE
[etcd] Set automountServiceAccountToken on the pod spec

### DIFF
--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.8.6
+version: 0.8.7
 appVersion: "3.7.1"
 keywords:
   - etcd

--- a/charts/etcd/templates/statefulset.yaml
+++ b/charts/etcd/templates/statefulset.yaml
@@ -41,6 +41,7 @@ spec:
 {{ . | nindent 6 }}
 {{- end }}
       serviceAccountName: {{ include "etcd.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/etcd/tests/automount-token_test.yaml
+++ b/charts/etcd/tests/automount-token_test.yaml
@@ -1,0 +1,45 @@
+suite: test etcd service account token mounting
+templates:
+  - statefulset.yaml
+  - serviceaccount.yaml
+tests:
+  - it: should set automountServiceAccountToken on the pod spec by default
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should set it on the pod spec when the chart does not create the ServiceAccount
+    template: statefulset.yaml
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: default
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should follow the value when token mounting is enabled
+    template: statefulset.yaml
+    set:
+      serviceAccount:
+        create: false
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  - it: should keep setting it on the created ServiceAccount
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true


### PR DESCRIPTION
### Description of the change

`serviceAccount.automountServiceAccountToken` is only written onto the ServiceAccount the chart creates, so with `serviceAccount.create: false` it vanishes and the pod mounts the API token anyway. Set it on the pod spec too, as keycloak, mariadb, postgres, rabbitmq, redis and memcached do.

### Benefits

The value is honored with a pre-existing or the default ServiceAccount.

### Possible drawbacks

None. The default is false, which the pod already got implicitly.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified