### PR TITLE
[rustfs] Add support for versioning on Bucket creation

### DIFF
--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: rustfs
-description: (ALPHA) High-performance distributed object storage with S3-compatible API
+description: High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.10.6
+version: 0.11.0
 appVersion: "1.0.0"
 keywords:
   - rustfs

--- a/charts/rustfs/README.md
+++ b/charts/rustfs/README.md
@@ -159,6 +159,7 @@ The following table lists the configurable parameters of the RustFS chart and th
 **Buckets**
 ```yaml
 - name: my-bucket
+  versioning: true
 ```
 
 **Users**

--- a/charts/rustfs/templates/deployment.yaml
+++ b/charts/rustfs/templates/deployment.yaml
@@ -11,9 +11,7 @@ metadata:
     {{- include "rustfs.annotations" . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount | default 1 }}
-  strategy:
-    type: Recreate
+  replicas: {{ .Values.replicaCount | default 1 }}″
   selector:
     matchLabels:
       {{- include "rustfs.selectorLabels" . | nindent 6 }}

--- a/charts/rustfs/templates/deployment.yaml
+++ b/charts/rustfs/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "rustfs.annotations" . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount | default 1 }}″
+  replicas: {{ .Values.replicaCount | default 1 }}
   selector:
     matchLabels:
       {{- include "rustfs.selectorLabels" . | nindent 6 }}

--- a/charts/rustfs/templates/setup-job.yaml
+++ b/charts/rustfs/templates/setup-job.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- . | nindent 4 }}
     {{- end }}
 spec:
-  backoffLimit: 3
+  backoffLimit: {{ .Values.setup.job.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.setup.job.ttlSecondsAfterFinished }}
   template:
     metadata:
@@ -98,12 +98,9 @@ spec:
                 name=$(echo "${policy}" | jq -r '.name')
                 echo "${policy}" | jq -r '.spec' > /tmp/policy.json
 
-                rc admin policy create local "${name}" /tmp/policy.json
-
-                ret=$?
-                if [ ${ret} -ne 0 ]; then
-                  exit ${ret}
-                fi
+                rc admin policy create local "${name}" /tmp/policy.json || {
+                  exit $?
+                }
               done
 
               # Read, add users and assign policies
@@ -111,36 +108,30 @@ spec:
                 name=$(echo "${user}" | jq -r '.name')
                 password=$(echo "${user}" | jq -r '.password')
 
-                rc admin user add local "${name}" "${password}"
-
-                ret=$?
-                if [ ${ret} -ne 0 ]; then
-                  exit ${ret}
-                fi
+                rc admin user add local "${name}" "${password}" || {
+                  exit $?
+                }
 
                 echo "${user}" | jq -r '.policies[]' | while read -r policy; do
-                  rc admin policy attach local "${policy}" --user "${name}"
-
-                  ret=$?
-                  if [ ${ret} -ne 0 ]; then
-                    exit ${ret}
-                  fi
+                  rc admin policy attach local "${policy}" --user "${name}" || {
+                    exit $?
+                  }
                 done
               done
 
-              # Create buckets
+              # Create or update buckets
               jq -c '.[]' /setup/buckets | while read -r bucket; do
                 name=$(echo "${bucket}" | jq -r '.name')
 
-                rc mb "local/${name}"
+                rc bucket create --ignore-existing "local/${name}" || {
+                  exit $?
+                }
 
-                ret=$?
-                if [ ${ret} -ne 0 ]; then
-                  if [ ${ret} -eq 3 ]; then
-                    echo "Bucket '${name}' seems to exist already"
-                  else
-                    exit ${ret}
-                  fi
+                versioning=$(echo "${bucket}" | jq -r '.versioning')
+                if [ "${versioning}" == "true" ]; then
+                  rc bucket version enable "local/${name}"
+                else
+                  rc bucket version suspend "local/${name}"
                 fi
               done
           volumeMounts:

--- a/charts/rustfs/templates/setup-job.yaml
+++ b/charts/rustfs/templates/setup-job.yaml
@@ -14,12 +14,13 @@ metadata:
     # Run as a post-install/post-upgrade hook so a successfully completed setup
     # task does not block `helm --wait` (a Completed Pod never becomes Ready).
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     {{- with (include "rustfs.annotations" .) }}
     {{- . | nindent 4 }}
     {{- end }}
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: {{ .Values.setup.job.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/charts/rustfs/values.schema.json
+++ b/charts/rustfs/values.schema.json
@@ -526,6 +526,17 @@
                         }
                     }
                 },
+                "job": {
+                    "type": "object",
+                    "properties": {
+                        "backoffLimit": {
+                            "type": "integer"
+                        },
+                        "ttlSecondsAfterFinished": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "policies": {
                     "type": "array"
                 },

--- a/charts/rustfs/values.yaml
+++ b/charts/rustfs/values.yaml
@@ -70,6 +70,9 @@ config:
 
 # -- Setups RustFS via CLI
 setup:
+  job:
+    ## @param setup.job.ttlSecondsAfterFinished TTL for completed setup job
+    ttlSecondsAfterFinished: 300
   image:
     ## @param image.registry RustFS CLI image registry
     registry: docker.io

--- a/charts/rustfs/values.yaml
+++ b/charts/rustfs/values.yaml
@@ -73,6 +73,8 @@ setup:
   job:
     ## @param setup.job.ttlSecondsAfterFinished TTL for completed setup job
     ttlSecondsAfterFinished: 300
+    ## @param setup.job.backoffLimit Backoff limit for setup job
+    backoffLimit: 3
   image:
     ## @param image.registry RustFS CLI image registry
     registry: docker.io
@@ -103,6 +105,7 @@ setup:
   # -- Bucket definitions
   buckets: []
 #    - name: test
+#      versioning: true
 
 ## @section Deployment configuration
 replicaCount: 1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 - Labels are automatically applied when they are inside the square brackets of your PR title on opening. Examples:
   - [redis]: adds `redis` label
   - [redis, valkey] Adds `redis` and `valkey` labels

 Thank you for contributing! We will try to test and integrate the change as soon as we can.
 -->

### Description of the change

Adds support for versioning on Bucket setup

### Benefits

More automated setup feature.

### Additional information

- I removed the automated Job deletion and added the Vanilla Kubernetes TTL feature
- I also removed `Recreate` strategy for deployments. I don't know if this is really useful. If yes, it should be configurable. Feedback appricated.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md`
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
