### PR TITLE
[timescaledb] Fix config_file wiring, listen_addresses, and postgresql.conf syntax errors

### DIFF
--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.13.6
+version: 0.13.7
 appVersion: "2.29.2"
 keywords:
   - timescaledb
@@ -41,10 +41,10 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
-    - kind: added
-      description: "Add namespaceOverride Value to all Charts that missing it"
+    - kind: fixed
+      description: "Wire up config_file so config.postgresql* values actually reach postgres, and fix listen_addresses/quoting bugs that wiring it exposed"
       links:
         - name: "Pull Request"
-          url: "https://github.com/CloudPirates-io/helm-charts/pull/1214"
+          url: "https://github.com/CloudPirates-io/helm-charts/pull/TODO"
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/timescaledb/CHANGELOG.md"

--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v2
+﻿apiVersion: v2
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
@@ -45,6 +45,6 @@ annotations:
       description: "Wire up config_file so config.postgresql* values actually reach postgres, and fix listen_addresses/quoting bugs that wiring it exposed"
       links:
         - name: "Pull Request"
-          url: "https://github.com/CloudPirates-io/helm-charts/pull/TODO"
+          url: "https://github.com/CloudPirates-io/helm-charts/pull/1692"
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/timescaledb/CHANGELOG.md"

--- a/charts/timescaledb/templates/configmap.yaml
+++ b/charts/timescaledb/templates/configmap.yaml
@@ -13,8 +13,15 @@ metadata:
 data:
   postgresql.conf: |
     # PostgreSQL configuration file
-    
+
     # Connection Settings
+    #
+    # listen_addresses defaults to 'localhost' in stock Postgres -- the standard
+    # postgres Docker entrypoint normally overrides this to '*' in the generated
+    # config specifically so the container is reachable from other pods. Since
+    # config_file now points here instead of that generated file, this must be
+    # set explicitly, or every other pod loses TCP access to this one.
+    listen_addresses = '*'
     {{- if .Values.config.postgresqlMaxConnections }}
     max_connections = {{ .Values.config.postgresqlMaxConnections }}
     {{- else }}
@@ -74,7 +81,7 @@ data:
     log_min_error_statement = error
     
     {{- if .Values.config.postgresqlLogStatement }}
-    log_statement = {{ .Values.config.postgresqlLogStatement | quote }}
+    log_statement = {{ .Values.config.postgresqlLogStatement | squote }}
     {{- else }}
     log_statement = 'none'
     {{- end }}
@@ -87,7 +94,7 @@ data:
     
     # Shared Libraries
     {{- if .Values.config.postgresqlSharedPreloadLibraries }}
-    shared_preload_libraries = {{ .Values.config.postgresqlSharedPreloadLibraries | quote }}
+    shared_preload_libraries = {{ .Values.config.postgresqlSharedPreloadLibraries | squote }}
     {{- end }}
     
     # Locale and Formatting
@@ -103,4 +110,12 @@ data:
     {{- range .Values.config.extraConfig }}
     {{ . }}
     {{- end }}
+
+    # Must stay last: postgres applies config sequentially, so anything set here wins
+    # over everything above, matching normal ALTER SYSTEM semantics. A relative path
+    # here would resolve against the directory containing *this* file
+    # (timescaledb.configDir), not PGDATA -- ALTER SYSTEM always writes to
+    # PGDATA/postgresql.auto.conf regardless of config_file, so this must be an
+    # absolute path to actually find it.
+    include_if_exists '{{ include "timescaledb.dataDir" . }}/pgdata/postgresql.auto.conf'
 {{- end }}

--- a/charts/timescaledb/templates/statefulset.yaml
+++ b/charts/timescaledb/templates/statefulset.yaml
@@ -41,6 +41,16 @@ spec:
           securityContext: {{ include "cloudpirates.renderContainerSecurityContext" . | nindent 12 }}
           image: {{ include "timescaledb.image" . }}
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          # Points postgres at the rendered postgresql.conf ConfigMap (mounted below at
+          # timescaledb.configDir). Without this, postgres falls back to the default
+          # $PGDATA/postgresql.conf written by initdb/timescaledb-tune, so every
+          # config.postgresql* value below is rendered into a ConfigMap that is mounted
+          # but never actually read. hba_file/ident_file/data_directory are unaffected --
+          # postgres resolves those from PGDATA regardless of config_file.
+          args:
+            - postgres
+            - -c
+            - {{ printf "config_file=%s/postgresql.conf" (include "timescaledb.configDir" .) | quote }}
           env:
             # Default PostgreSQL environment variables
             - name: PGDATA
@@ -50,19 +60,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "timescaledb.secretName" . }}
                   key: {{ include "timescaledb.adminPasswordKey" . }}
-            # PostgreSQL configuration
-            {{- if .Values.config.postgresqlMaxConnections }}
-            - name: POSTGRES_MAX_CONNECTIONS
-              value: {{ .Values.config.postgresqlMaxConnections | quote }}
-            {{- end }}
-            {{- if .Values.config.postgresqlSharedBuffers }}
-            - name: POSTGRES_SHARED_BUFFERS
-              value: {{ .Values.config.postgresqlSharedBuffers | quote }}
-            {{- end }}
-            {{- if .Values.config.postgresqlEffectiveCacheSize }}
-            - name: POSTGRES_EFFECTIVE_CACHE_SIZE
-              value: {{ .Values.config.postgresqlEffectiveCacheSize | quote }}
-            {{- end }}
             {{- with .Values.extraEnvVars }}
 {{ toYaml . | indent 12 }}
             {{- end }}

--- a/charts/timescaledb/tests/config-file_test.yaml
+++ b/charts/timescaledb/tests/config-file_test.yaml
@@ -1,0 +1,78 @@
+suite: test timescaledb config_file wiring
+templates:
+  - statefulset.yaml
+  - configmap.yaml
+tests:
+  - it: should point postgres at the rendered config ConfigMap
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - postgres
+            - -c
+            - config_file=/etc/postgresql/postgresql.conf
+
+  - it: should not set the removed PostgreSQL tuning environment variables
+    template: statefulset.yaml
+    set:
+      config:
+        postgresqlMaxConnections: 100
+        postgresqlSharedBuffers: 128MB
+        postgresqlEffectiveCacheSize: 4GB
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_MAX_CONNECTIONS
+            value: "100"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_SHARED_BUFFERS
+            value: 128MB
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_EFFECTIVE_CACHE_SIZE
+            value: 4GB
+
+  - it: should set listen_addresses to allow connections from other pods
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["postgresql.conf"]
+          pattern: "listen_addresses = '\\*'"
+
+  - it: should single-quote shared_preload_libraries, not double-quote
+    template: configmap.yaml
+    set:
+      config:
+        postgresqlSharedPreloadLibraries: timescaledb
+    asserts:
+      - matchRegex:
+          path: data["postgresql.conf"]
+          pattern: "shared_preload_libraries = 'timescaledb'"
+      - notMatchRegex:
+          path: data["postgresql.conf"]
+          pattern: 'shared_preload_libraries = "timescaledb"'
+
+  - it: should single-quote log_statement, not double-quote
+    template: configmap.yaml
+    set:
+      config:
+        postgresqlLogStatement: all
+    asserts:
+      - matchRegex:
+          path: data["postgresql.conf"]
+          pattern: "log_statement = 'all'"
+      - notMatchRegex:
+          path: data["postgresql.conf"]
+          pattern: 'log_statement = "all"'
+
+  - it: should include postgresql.auto.conf from PGDATA so ALTER SYSTEM keeps working
+    template: configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["postgresql.conf"]
+          pattern: "include_if_exists '/var/lib/postgresql/data/pgdata/postgresql\\.auto\\.conf'"


### PR DESCRIPTION
### Description of the change

`config.postgresql*` values are rendered into a `postgresql.conf` ConfigMap, mounted at `/etc/postgresql`, but postgres never actually reads it: `config_file` defaults to `$PGDATA/postgresql.conf` (written by `initdb`/`timescaledb-tune`), and nothing tells postgres to look anywhere else. This PR wires `config_file` so that ConfigMap is genuinely loaded, and fixes three bugs that were dormant only because the file was never read:

1. Add `-c config_file=.../postgresql.conf` to the postgres args; drop the now-fully-dead `POSTGRES_MAX_CONNECTIONS`/`POSTGRES_SHARED_BUFFERS`/`POSTGRES_EFFECTIVE_CACHE_SIZE` env vars (nothing in the image reads them; they duplicate what `config_file` now covers).
2. Add `listen_addresses = '*'` -- stock Postgres defaults to `localhost`; the standard postgres Docker entrypoint normally overrides this to `*` in the *generated* config specifically so the container is reachable from other pods. Once `config_file` points elsewhere, that override is lost.
3. Fix `shared_preload_libraries`/`log_statement` from `quote` (double quotes) to `squote` (single quotes) -- double quotes are invalid Postgres value syntax, crashes the server on start.
4. Add `include_if_exists '.../pgdata/postgresql.auto.conf'` (absolute path) at the end of the file, so `ALTER SYSTEM` keeps working -- must be absolute, since a relative path resolves against this file's own directory, not `PGDATA`.

### Benefits

`config.postgresql*` (max_connections, shared_buffers, effective_cache_size, work_mem, maintenance_work_mem, etc.) actually take effect, instead of being silently ignored in favor of whatever `timescaledb-tune` computed against the node's memory at `initdb` time.

### Possible drawbacks

- **Behavior change on upgrade for existing users of `config.postgresql*`**: anyone who already set these values believing they worked will see them genuinely take effect for the first time after upgrading -- worth a mention in release notes.
- `config_file` and `listen_addresses` are postmaster-context settings; upgrading requires (and Helm/StatefulSet upgrades naturally cause) a pod restart to pick them up.
- All four changes were found and fixed in this exact order against a real deployment -- each one, on its own, reproduces a live outage, so they should land together rather than be split.

### Applicable issues

_None filed -- happy to open one first if preferred._

### Additional information

Verified end-to-end against a real deployment (not just `helm template`/`lint`): each of the four bugs above was hit and fixed in sequence before the chart was healthy and network-reachable again. Added `tests/config-file_test.yaml` covering all four; `helm lint` and `helm unittest charts/timescaledb` pass (32/32, including all pre-existing suites -- no regressions).

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` -- N/A, no new values.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026)