### PR TITLE
charts/redis: allow setting runtimeclass

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.26
+version: 0.34.27
 appVersion: "8.10.1"
 keywords:
   - redis
@@ -41,8 +41,8 @@ annotations:
     - name: Maintainer CloudPirates
       url: https://www.cloudpirates.io
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: "Redis Cluster now recovers after all pods are deleted/recreated: the init Job waits for the cluster to re-form via gossip instead of running 'cluster create' on non-empty nodes (which failed with 'Node is not empty'), and cluster.announceHostnames now defaults to true so nodes.conf survives pod IP changes"
+    - kind: added
+      description: "Add optional runtimeClassName support for all Redis workloads (StatefulSet/Deployment, sentinel master-discovery Deployment, cluster init Job); field is omitted when empty so existing deployments are unaffected"
       links:
         - name: "Changelog"
           url: "https://github.com/CloudPirates-io/helm-charts/blob/main/charts/redis/CHANGELOG.md"

--- a/charts/redis/templates/job.yaml
+++ b/charts/redis/templates/job.yaml
@@ -236,4 +236,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with (.Values.clusterInitJob.runtimeClassName | default .Values.runtimeClassName) }}
+      runtimeClassName: {{ . }}
+      {{- end }}
 {{- end }}

--- a/charts/redis/templates/sentinel-master-deployment.yaml
+++ b/charts/redis/templates/sentinel-master-deployment.yaml
@@ -41,6 +41,9 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       securityContext: {{ include "cloudpirates.renderPodSecurityContext" . | nindent 8 }}
       containers:
       - name: master-discovery

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -1448,6 +1448,9 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      {{- with .Values.runtimeClassName }}
+      runtimeClassName: {{ . }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -565,6 +565,9 @@
         "priorityClassName": {
             "type": "string"
         },
+        "runtimeClassName": {
+            "type": "string"
+        },
         "readinessProbe": {
             "type": "object",
             "properties": {

--- a/charts/redis/values.schema.json
+++ b/charts/redis/values.schema.json
@@ -137,6 +137,9 @@
                 "resources": {
                     "type": "object"
                 },
+                "runtimeClassName": {
+                    "type": "string"
+                },
                 "tolerations": {
                     "type": "array"
                 }
@@ -565,9 +568,6 @@
         "priorityClassName": {
             "type": "string"
         },
-        "runtimeClassName": {
-            "type": "string"
-        },
         "readinessProbe": {
             "type": "object",
             "properties": {
@@ -599,6 +599,9 @@
         },
         "revisionHistoryLimit": {
             "type": "integer"
+        },
+        "runtimeClassName": {
+            "type": "string"
         },
         "sentinel": {
             "type": "object",

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -338,6 +338,9 @@ nodeSelector: {}
 ## @param priorityClassName for pod eviction
 priorityClassName: ""
 
+## @param runtimeClassName Runtime class for pods (leave empty to use cluster default)
+runtimeClassName: ""
+
 ## @param tolerations Tolerations for pod assignment
 tolerations: []
 
@@ -780,6 +783,8 @@ clusterInitJob:
   tolerations: []
   ## @param clusterInitJob.affinity Affinity rules for the clusterInit Job (defaults to .Values.affinity if not set)
   affinity: {}
+  ## @param clusterInitJob.runtimeClassName Runtime class for the clusterInit Job pod (defaults to .Values.runtimeClassName if not set)
+  runtimeClassName: ""
   ## @param clusterInitJob.recoveryTimeout Seconds the Job waits for an existing cluster to re-form via gossip before failing
   ## When the cluster already holds state (e.g. all pods were deleted and recreated), the Job waits for the nodes to
   ## re-form the cluster instead of running "cluster create" on non-empty nodes (which fails with "Node is not empty"


### PR DESCRIPTION

### Description of the change

Adds optional `runtimeClassName` support to the `charts/redis` chart. When set, the value is injected into the pod spec of all relevant workloads:

- **StatefulSet / Deployment** (`statefulset.yaml`) - the main Redis (and optional Sentinel) pods
- **Sentinel master-discovery Deployment** (`sentinel-master-deployment.yaml`)
- **Cluster init Job** (`job.yaml`) - supports an independent override via `clusterInitJob.runtimeClassName`, falling back to the top-level `runtimeClassName`

When `runtimeClassName` is left empty (the default), the field is omitted entirely from rendered manifests, so the cluster's default runtime class continues to be used with no behaviour change.

### Benefits

- Allows operators to run Redis pods under an alternative container runtime (e.g. `gvisor`, `kata-containers`) for stronger workload isolation, without having to patch the chart manually.
- Consistent with how other scheduling fields (`nodeSelector`, `tolerations`, `priorityClassName`) are handled - opt-in, empty by default.
- The cluster init Job supports its own override (`clusterInitJob.runtimeClassName`) for cases where the Job must run under a different runtime than the Redis pods themselves.

### Possible drawbacks

- None known. The field is fully optional and backward-compatible; existing deployments are unaffected.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes #

### Additional information

Usage example:

```yaml
# Use gVisor for all Redis pods
runtimeClassName: gvisor

# Override only for the cluster-init Job (e.g. if gVisor isn't needed there)
clusterInitJob:
  runtimeClassName: ""
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md`
- [X] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [X] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))
