### PR TITLE
[common, clusterpirate, etcd, ghost, kafka, keycloak, mariadb, memcached, minio, mongodb, nginx, postgres, rabbitmq, rabbitmq-cluster-operator, redis, rustfs, timescaledb, valkey, zookeeper] Render templated values in commonLabels and commonAnnotations

### DIFF
--- a/charts/clusterpirate/Chart.lock
+++ b/charts/clusterpirate/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
+  version: 2.2.1
 - name: valkey
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.25.7
-digest: sha256:28c54f50e9351ab107d7303427bb1593c17e546dedcb18afeb34a58dde8197d4
-generated: "2026-08-31T07:23:16.624165329Z"
+digest: sha256:cf37336aa40ac44a64b97f0ae1eb1f778933603e4e4f68c715f24bdd27b3b153
+generated: "2026-09-08T10:10:40.193651+02:00"

--- a/charts/clusterpirate/Chart.yaml
+++ b/charts/clusterpirate/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: clusterpirate
 description: Client agent for the CloudPirates Managed Observability Platform to connect your Kubernetes cluster to our infrastructure
 type: application
-version: 1.5.13
+version: 1.5.14
 appVersion: "1.0.1"
 keywords:
   - kubernetes
@@ -19,7 +19,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
   - name: valkey
     version: "0.25.7"

--- a/charts/etcd/Chart.lock
+++ b/charts/etcd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:48:46.584839+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:10:44.098142+02:00"

--- a/charts/etcd/Chart.yaml
+++ b/charts/etcd/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: etcd
 description: etcd is a distributed reliable key-value store for the most critical data of a distributed system
 type: application
-version: 0.8.7
+version: 0.8.8
 appVersion: "3.7.1"
 keywords:
   - etcd
@@ -20,7 +20,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/513x513/36b7a72378/etcd-logo.svg
 annotations:

--- a/charts/ghost/Chart.lock
+++ b/charts/ghost/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
+  version: 2.2.1
 - name: mariadb
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.4.0
-digest: sha256:f032f9794e05de151415267ffad9750235648005267d9f64df3614228df0fb4a
-generated: "2026-02-16T16:48:53.326298+01:00"
+digest: sha256:4282b0d84981f85d880d5e3e94dfc1cf0ba1bc581b432b3eabe0d1a599cb20a7
+generated: "2026-09-08T10:10:48.213346+02:00"

--- a/charts/ghost/Chart.yaml
+++ b/charts/ghost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ghost
 description: A simple, powerful publishing platform that allows you to share your stories with the world.
 type: application
-version: 0.20.18
+version: 0.20.19
 appVersion: "6.62.0"
 keywords:
   - ghost
@@ -21,7 +21,7 @@ maintainers:
     url: https://www.srf.ch
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
   - name: mariadb
     version: "0.4.x"

--- a/charts/kafka/Chart.lock
+++ b/charts/kafka/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-05-29T19:15:24.989123+03:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:10:51.723906+02:00"

--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kafka
 description: Apache Kafka is a distributed event streaming platform used for high-performance data pipelines, streaming analytics, and data integration. This chart deploys Kafka in KRaft mode (no ZooKeeper required).
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "4.3.1"
 keywords:
   - kafka
@@ -24,7 +24,7 @@ maintainers:
     url: https://github.com/vaggeliskls
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/a5d4be1ea1/kafka-logo.svg
 annotations:

--- a/charts/keycloak/Chart.lock
+++ b/charts/keycloak/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
+  version: 2.2.1
 - name: postgres
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.9.0
 - name: mariadb
   repository: oci://registry-1.docker.io/cloudpirates
   version: 0.4.0
-digest: sha256:05cd1f52e198c5abf39c5b0263fa5f47e9c80fcf69e154fa0e77356545e53afc
-generated: "2026-02-16T16:49:00.698096+01:00"
+digest: sha256:09931a40cd3043834e1cee3242f9a8131260e7b745720c6f6e607c9b9313e5c5
+generated: "2026-09-08T10:10:56.255205+02:00"

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak
 description: Open Source Identity and Access Management Solution
 type: application
-version: 0.21.35
+version: 0.21.36
 appVersion: "26.7.3"
 keywords:
   - keycloak
@@ -23,7 +23,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
   - name: postgres
     version: "0.9.x"

--- a/charts/keycloak/templates/_helpers.tpl
+++ b/charts/keycloak/templates/_helpers.tpl
@@ -32,9 +32,7 @@ Common labels
 Common annotations
 */}}
 {{- define "keycloak.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{- toYaml . }}
-{{- end }}
+{{- include "cloudpirates.annotations" . -}}
 {{- end }}
 
 {{/*

--- a/charts/keycloak/tests/common-parameters_test.yaml
+++ b/charts/keycloak/tests/common-parameters_test.yaml
@@ -58,6 +58,27 @@ tests:
           value: custom-value
         template: templates/statefulset.yaml
 
+  - it: should tpl-render templated values in commonLabels and commonAnnotations
+    set:
+      commonLabels:
+        tags.datadoghq.com/version: "{{ .Values.image.tag }}"
+      commonAnnotations:
+        release-revision: "{{ .Release.Revision }}"
+    asserts:
+      - equal:
+          path: metadata.labels['tags.datadoghq.com/version']
+          value: "26.4.5@sha256:653852bfdea2be6e958b9e90a976eff1c6de34edd55f2f679bdc48ef16bc528e"
+        template: templates/statefulset.yaml
+      - equal:
+          path: spec.template.metadata.labels['tags.datadoghq.com/version']
+          value: "26.4.5@sha256:653852bfdea2be6e958b9e90a976eff1c6de34edd55f2f679bdc48ef16bc528e"
+        template: templates/statefulset.yaml
+      - equal:
+          # helm-unittest doesn't perform a real install, so .Release.Revision defaults to 0
+          path: metadata.annotations['release-revision']
+          value: "0"
+        template: templates/statefulset.yaml
+
   - it: should render custom image registry
     set:
       global:

--- a/charts/mariadb/Chart.lock
+++ b/charts/mariadb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:06.711551+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:00.656249+02:00"

--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mariadb
 description: MariaDB is a high-performance, open-source relational database server that is a drop-in replacement for MySQL. Supports both single-node and Galera Cluster deployments.
 type: application
-version: 0.16.12
+version: 0.16.13
 appVersion: "12.3.3"
 keywords:
   - mariadb
@@ -27,7 +27,7 @@ maintainers:
     url: https://www.srf.ch
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/6512dd22ee/mariadb-logo.svg
 annotations:

--- a/charts/memcached/Chart.lock
+++ b/charts/memcached/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:12.023558+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:04.152589+02:00"

--- a/charts/memcached/Chart.yaml
+++ b/charts/memcached/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: memcached
 description: Memcached is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 type: application
-version: 0.14.8
+version: 0.14.9
 appVersion: "1.6.45"
 keywords:
   - memcached
@@ -20,7 +20,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/0faa83eb34/memcached-logo.svg
 annotations:

--- a/charts/minio/Chart.lock
+++ b/charts/minio/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:17.386113+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:08.079463+02:00"

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: minio
 description: High Performance Object Storage compatible with Amazon S3 APIs
 type: application
-version: 0.13.3
+version: 0.13.4
 appVersion: "2025.10.15"
 keywords:
   - minio
@@ -20,7 +20,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/5d3310f00d/minio-logo.svg
 annotations:

--- a/charts/minio/templates/_helpers.tpl
+++ b/charts/minio/templates/_helpers.tpl
@@ -32,9 +32,7 @@ Common labels
 Common annotations
 */}}
 {{- define "minio.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{- toYaml . }}
-{{- end }}
+{{- include "cloudpirates.annotations" . -}}
 {{- end }}
 
 {{/*

--- a/charts/mongodb/Chart.lock
+++ b/charts/mongodb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:22.702888+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:11.789135+02:00"

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb
 description: MongoDB a flexible NoSQL database for scalable, real-time data management
 type: application
-version: 0.18.11
+version: 0.18.12
 appVersion: "8.3.8"
 keywords:
   - mongodb
@@ -18,7 +18,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/5d228988dc/mongodb-logo.svg
 annotations:

--- a/charts/nginx/Chart.lock
+++ b/charts/nginx/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:28.146297+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:15.58452+02:00"

--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nginx
 description: Nginx is a high-performance HTTP server and reverse proxy.
 type: application
-version: 0.16.7
+version: 0.16.8
 appVersion: "1.31.5"
 keywords:
   - nginx
@@ -21,7 +21,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/9fcd98c061/nginx-logo.svg
 annotations:

--- a/charts/postgres/Chart.lock
+++ b/charts/postgres/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:33.431576+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:19.36004+02:00"

--- a/charts/postgres/Chart.yaml
+++ b/charts/postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: postgres
 description: The World's Most Advanced Open Source Relational Database
 type: application
-version: 0.20.4
+version: 0.20.5
 appVersion: "18.6.0"
 keywords:
   - postgres
@@ -20,7 +20,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/95e7f13e62/postgres-logo.svg
 annotations:

--- a/charts/postgres/templates/_helpers.tpl
+++ b/charts/postgres/templates/_helpers.tpl
@@ -32,9 +32,7 @@ Common labels
 Common annotations
 */}}
 {{- define "postgres.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{- toYaml . }}
-{{- end }}
+{{- include "cloudpirates.annotations" . -}}
 {{- end }}
 
 {{/*

--- a/charts/rabbitmq-cluster-operator/Chart.lock
+++ b/charts/rabbitmq-cluster-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:38.912908+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:27.734428+02:00"

--- a/charts/rabbitmq-cluster-operator/Chart.yaml
+++ b/charts/rabbitmq-cluster-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq-cluster-operator
 description: Kubernetes operator to deploy and manage RabbitMQ clusters.
 type: application
-version: 0.6.11
+version: 0.6.12
 appVersion: "2.22.5"
 keywords:
   - rabbitmq-cluster-operator
@@ -24,7 +24,7 @@ maintainers:
     url: https://about.bl4ko.com
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/aa1bd68288/rabbitmq-logo.svg
 annotations:

--- a/charts/rabbitmq/Chart.lock
+++ b/charts/rabbitmq/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:44.222204+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:23.243779+02:00"

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rabbitmq
 description: A messaging broker that implements the Advanced Message Queuing Protocol (AMQP)
 type: application
-version: 0.21.23
+version: 0.21.24
 appVersion: "4.3.5"
 keywords:
   - rabbitmq
@@ -20,7 +20,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/aa1bd68288/rabbitmq-logo.svg
 annotations:

--- a/charts/redis/Chart.lock
+++ b/charts/redis/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:49.665914+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:31.984971+02:00"

--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: redis
 description: An open source, in-memory data structure store used as a database, cache, and message broker.
 type: application
-version: 0.34.29
+version: 0.34.30
 appVersion: "8.10.1"
 keywords:
   - redis
@@ -21,7 +21,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/32c74816d1/redis-logo.svg
 annotations:

--- a/charts/rustfs/Chart.lock
+++ b/charts/rustfs/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:49:55.078487+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:35.440816+02:00"

--- a/charts/rustfs/Chart.yaml
+++ b/charts/rustfs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rustfs
 description: High-performance distributed object storage with S3-compatible API
 type: application
-version: 0.11.1
+version: 0.11.2
 appVersion: "1.0.0"
 keywords:
   - rustfs
@@ -24,7 +24,7 @@ maintainers:
     url: https://www.srf.ch
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/513x513/246ebb8da4/rustfs-logo.svg
 annotations:

--- a/charts/rustfs/templates/_helpers.tpl
+++ b/charts/rustfs/templates/_helpers.tpl
@@ -32,9 +32,7 @@ Common labels
 Common annotations
 */}}
 {{- define "rustfs.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{- toYaml . }}
-{{- end }}
+{{- include "cloudpirates.annotations" . -}}
 {{- end }}
 
 {{/*

--- a/charts/timescaledb/Chart.lock
+++ b/charts/timescaledb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:50:00.367154+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:38.876755+02:00"

--- a/charts/timescaledb/Chart.yaml
+++ b/charts/timescaledb/Chart.yaml
@@ -2,7 +2,7 @@
 name: timescaledb
 description: TimescaleDB - The Open Source Time-Series Database for PostgreSQL
 type: application
-version: 0.13.7
+version: 0.13.8
 appVersion: "2.29.2"
 keywords:
   - timescaledb
@@ -21,7 +21,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/b2e01452ce/timescaledb-logo.svg
 annotations:

--- a/charts/timescaledb/templates/_helpers.tpl
+++ b/charts/timescaledb/templates/_helpers.tpl
@@ -32,9 +32,7 @@ Common labels
 Common annotations
 */}}
 {{- define "timescaledb.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{ toYaml . }}
-{{- end }}
+{{- include "cloudpirates.annotations" . -}}
 {{- end }}
 
 {{/*

--- a/charts/valkey/Chart.lock
+++ b/charts/valkey/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:50:05.720624+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:42.341025+02:00"

--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: valkey
 description: High performance in-memory data structure store, fork of Redis. Valkey is an open-source, high-performance key/value datastore that supports a variety of workloads such as caching, message queues, and can act as a primary database.
 type: application
-version: 0.25.9
+version: 0.25.10
 appVersion: "9.1.0"
 home: https://www.valkey.io
 sources:
@@ -22,7 +22,7 @@ maintainers:
     url: https://www.cloudpirates.io
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/5242c0e31a/valkey-logo.svg
 annotations:

--- a/charts/valkey/templates/_helpers.tpl
+++ b/charts/valkey/templates/_helpers.tpl
@@ -32,9 +32,7 @@ Common labels
 Common annotations
 */}}
 {{- define "valkey.annotations" -}}
-{{- with .Values.commonAnnotations }}
-{{ toYaml . }}
-{{- end }}
+{{- include "cloudpirates.annotations" . -}}
 {{- end }}
 
 {{/*

--- a/charts/zookeeper/Chart.lock
+++ b/charts/zookeeper/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/cloudpirates
-  version: 2.2.0
-digest: sha256:a38dfdc974869f987d4e07c1a33c03db67fe20a37aba7d0f06c81f3adc220531
-generated: "2026-02-16T16:50:15.762743+01:00"
+  version: 2.2.1
+digest: sha256:2a1007fa72a0c991cbbd71e9fa5c2053b3c521feb2bde60af204ce9d75086e1b
+generated: "2026-09-08T10:11:45.692171+02:00"

--- a/charts/zookeeper/Chart.yaml
+++ b/charts/zookeeper/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: zookeeper
 description: Apache ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
 type: application
-version: 0.13.9
+version: 0.13.10
 appVersion: "3.9.5"
 keywords:
   - zookeeper
@@ -22,7 +22,7 @@ maintainers:
     url: https://www.srf.ch
 dependencies:
   - name: common
-    version: "2.2.0"
+    version: "2.2.1"
     repository: oci://registry-1.docker.io/cloudpirates
 icon: https://a.storyblok.com/f/143071/512x512/07b0f90b58/apache-zookeeper-logo.svg
 annotations:


### PR DESCRIPTION
### Description of the change

`commonLabels` and `commonAnnotations` are documented and widely used as "Helm value maps merged into every resource", but the `common` library chart's `cloudpirates.labels` / `cloudpirates.annotations` helpers only ever did a raw `toYaml` on them. Any value containing a Go template expression (e.g. `"{{ .Values.image.tag }}"` or `"{{ .Release.Revision }}"`) was passed through **literally** instead of being rendered, ending up as dead text in the final manifest.

This PR:

- Fixes `cloudpirates.labels` and `cloudpirates.annotations` in `charts/common` to render `commonLabels` / `commonAnnotations` through the `cloudpirates.tplvalues.render` helper (already present in the library, already used elsewhere in the repo for single string values, just never wired into these two helpers).
- Bumps `common` to `2.2.1` (patch, backwards compatible).
- Fixes `keycloak`, `minio`, `postgres`, `rustfs`, `timescaledb`, and `valkey`, whose `<chart>.annotations` helper duplicated the old raw-`toYaml` logic locally instead of delegating to `cloudpirates.annotations` (same bug, just bypassing the shared helper). They now delegate like every other chart already does.
- Bumps the `common` dependency to `2.2.1` and the chart version (patch) in all 18 charts that depend on `common`, so the fix is available everywhere: `clusterpirate`, `etcd`, `ghost`, `kafka`, `keycloak`, `mariadb`, `memcached`, `minio`, `mongodb`, `nginx`, `postgres`, `rabbitmq`, `rabbitmq-cluster-operator`, `redis`, `rustfs`, `timescaledb`, `valkey`, `zookeeper`.
- One commit per chart, so each change is independently reviewable/revertable.

### Context

Found while wiring Datadog Unified Service Tagging on a Keycloak StatefulSet deployed with this chart. Setting:

```yaml
commonLabels:
  tags.datadoghq.com/env: "production"
  tags.datadoghq.com/service: "keycloak"
  tags.datadoghq.com/version: "{{ .Values.image.tag }}"
```

rendered the pod label as the literal string `tags.datadoghq.com/version: '{{ .Values.image.tag }}'` instead of the resolved image tag, because `cloudpirates.labels` never passed `commonLabels` through `tpl`. This silently breaks any `commonLabels`/`commonAnnotations` value that relies on templating (image tag, `.Release.Revision`, `.Chart.AppVersion`, etc.) across every chart in the repo, not just keycloak.

### Benefits

- `commonLabels` and `commonAnnotations` now behave consistently with the rest of the chart's `extraEnvVars`/templated fields, and with Bitnami's `common.tplvalues.render` equivalent that most Helm users expect.
- No behavior change for the common case (static string values); purely additive support for templated values.
- Removes duplicated, drifted copies of the same annotations logic in 6 charts, reducing future maintenance surface.

### Possible drawbacks

- `mariadb` applies `.Values.commonAnnotations` inline in ~14 individual templates instead of through a centralized `mariadb.annotations` helper, so its `commonAnnotations` still isn't tpl-rendered after this PR. Fixing it would mean touching every one of those templates (or introducing a helper and refactoring them), which felt like a bigger, separate change. Happy to follow up in a dedicated PR if maintainers agree that's the right scope. `mariadb.labels` (and therefore `commonLabels`) *is* fixed by this PR.
- Since `common` is a library chart resolved from the OCI registry, the dependent charts' `version: "2.2.1"` pin for `common` won't actually resolve (`helm dependency update`) until `common:2.2.1` is published. I validated every chart locally by packaging the patched `common` chart and vendoring it manually into each dependent chart's `charts/` folder (not committed, `*.tgz` is gitignored).

### Additional information

Tested locally (network-published `common:2.2.1` obviously isn't available yet, so `common` was packaged locally and vendored into each dependent chart's `charts/` folder for validation, then removed):

- `helm lint` passes on all 19 touched charts.
- `helm unittest` passes on all charts that have a `tests/` suite (no regressions), including a new test in `keycloak/tests/common-parameters_test.yaml` asserting that a templated `commonLabels`/`commonAnnotations` value renders correctly on both the `StatefulSet` and its pod template.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is _not necessary_ when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [<name_of_the_chart>] Descriptive title
- [x] All commits are signed and verified (required as of January 22, 2026 - see [CONTRIBUTING.md](../CONTRIBUTING.md#setting-up-your-development-environment))